### PR TITLE
fix: update sender component docs and style issues

### DIFF
--- a/docs/demos/examples/Assistant.vue
+++ b/docs/demos/examples/Assistant.vue
@@ -26,10 +26,13 @@
     <template #footer>
       <tr-sender
         class="chat-input"
+        mode="multiple"
         v-model="inputMessage"
-        :placeholder="messageState.status === STATUS.PROCESSING ? '正在思考中...' : '请输入您的问题'"
+        :placeholder="GeneratingStatus.includes(messageState.status) ? '正在思考中...' : '请输入您的问题'"
         :clearable="true"
         :loading="GeneratingStatus.includes(messageState.status)"
+        :showWordLimit="true"
+        :maxLength="1000"
         @submit="sendMessage"
         @cancel="abortRequest"
       ></tr-sender>
@@ -50,7 +53,7 @@
 <script setup lang="ts">
 // import { TrContainer, TrWelcome, TrPrompts, TrBubbleList, TrSender } from '@opentiny/tiny-robot'
 import { type BubbleRoleConfig, type PromptProps } from '@opentiny/tiny-robot'
-import { AIClient, GeneratingStatus, STATUS, useMessage } from '@opentiny/tiny-robot-kit'
+import { AIClient, GeneratingStatus, useMessage } from '@opentiny/tiny-robot-kit'
 import { IconAi, IconNewSession, IconUser } from '@opentiny/tiny-robot-svgs'
 import { h, nextTick, ref, watch, type CSSProperties } from 'vue'
 

--- a/docs/demos/sender/All.vue
+++ b/docs/demos/sender/All.vue
@@ -1,6 +1,5 @@
 <template>
   <tr-sender
-    class="chat-input"
     v-model="inputMessage"
     mode="multiple"
     submitType="ctrlEnter"

--- a/docs/demos/sender/Mode.vue
+++ b/docs/demos/sender/Mode.vue
@@ -1,9 +1,9 @@
 <template>
   <div style="display: flex; flex-direction: column; gap: 20px">
     <h4>单行模式</h4>
-    <tr-sender class="chat-input" />
+    <tr-sender />
     <h4>多行模式</h4>
-    <tr-sender mode="multiple" class="chat-input" />
+    <tr-sender mode="multiple" />
   </div>
 </template>
 

--- a/docs/demos/tools/client/Basic.vue
+++ b/docs/demos/tools/client/Basic.vue
@@ -32,5 +32,5 @@ async function chat(content) {
 
 <template>
   <tr-bubble v-if="message" :content="message"></tr-bubble>
-  <tr-sender v-model="content" @submit="chat(content)" class="chat-input"></tr-sender>
+  <tr-sender v-model="content" @submit="chat(content)"></tr-sender>
 </template>

--- a/docs/demos/tools/client/Stream.vue
+++ b/docs/demos/tools/client/Stream.vue
@@ -58,5 +58,5 @@ function abortRequest() {
 
 <template>
   <tr-bubble v-if="message" :content="message"></tr-bubble>
-  <tr-sender class="chat-input" v-model="content" @submit="chat(content)" @cancel="abortRequest"></tr-sender>
+  <tr-sender v-model="content" @submit="chat(content)" @cancel="abortRequest"></tr-sender>
 </template>

--- a/docs/demos/tools/message/Basic.vue
+++ b/docs/demos/tools/message/Basic.vue
@@ -1,7 +1,6 @@
 <template>
   <tr-bubble-list :items="messages" :roles="roles"></tr-bubble-list>
   <tr-sender
-    class="chat-input"
     v-model="inputMessage"
     :placeholder="messageState.status === STATUS.PROCESSING ? '正在思考中...' : '请输入您的问题'"
     :clearable="true"
@@ -53,9 +52,3 @@ const roles: Record<string, BubbleRoleConfig> = {
   },
 }
 </script>
-
-<style scoped lang="less">
-.chat-input {
-  background-color: transparent;
-}
-</style>

--- a/docs/src/components/sender.md
+++ b/docs/src/components/sender.md
@@ -8,12 +8,6 @@ Sender 是一个灵活的输入组件，支持单行和多行模式，具有丰�
 
 ## 代码示例
 
-<style>
-.chat-input {
-  background-color: transparent;
-}
-</style>
-
 ### 基础用法
 
 > 单行模式(`mode="single"`), 适用于简单的输入场景，如搜索框、简短消息输入等。
@@ -55,16 +49,6 @@ Sender 是一个灵活的输入组件，支持单行和多行模式，具有丰�
 
 ```vue
 <tr-sender mode="multiple" :showWordLimit="true" :maxLength="1000" />
-```
-
-#### 自动调整高度
-
-设置`autoSize`属性使输入框高度自动适应内容。
-
-<tr-sender mode="multiple" :autoSize="true" />
-
-```vue
-<tr-sender mode="multiple" :autoSize="true" />
 ```
 
 #### 可清空输入
@@ -175,21 +159,21 @@ Sender 组件支持多种键盘快捷键操作，提高用户输入效率：
 
 ### Events
 
-| 事件名            | 说明                      | 回调参数               |
-| ----------------- | ------------------------- | ---------------------- |
-| update:modelValue | 输入值变化时触发(v-model) | `(value: string)`      |
-| blur              | 输入框失去焦点时触发      | `(event: FocusEvent)`  |
-| change            | 输入值改变且失焦时触发    | `(value: string)`      |
-| focus             | 输入框获得焦点时触发      | `(event: FocusEvent)`  |
-| input             | 输入值改变时触发          | `(value: string)`      |
-| submit            | 提交内容时触发            | `(value: string)`      |
-| clear             | 清空内容时触发            | `()`                   |
+| 事件名            | 说明                       | 回调参数               |
+| ----------------- | -------------------------- | ---------------------- |
+| update:modelValue | 输入值变化时触发(v-model)  | `(value: string)`      |
+| blur              | 输入框失去焦点时触发       | `(event: FocusEvent)`  |
+| change            | 输入值改变且失焦时触发     | `(value: string)`      |
+| focus             | 输入框获得焦点时触发       | `(event: FocusEvent)`  |
+| input             | 输入值改变时触发           | `(value: string)`      |
+| submit            | 提交内容时触发             | `(value: string)`      |
+| clear             | 清空内容时触发             | `()`                   |
 | cancel            | 取消发送（加载状态）时触发 | `()`                   |
-| speech-start      | 语音识别开始时触发        | `()`                   |
-| speech-end        | 语音识别结束时触发        | `(transcript: string)` |
-| speech-interim    | 语音识别中间结果时触发    | `(transcript: string)` |
-| speech-error      | 语音识别错误时触发        | `(error: Error)`       |
-| suggestion-select | 选择输入建议时触发        | `(value: string)`      |
+| speech-start      | 语音识别开始时触发         | `()`                   |
+| speech-end        | 语音识别结束时触发         | `(transcript: string)` |
+| speech-interim    | 语音识别中间结果时触发     | `(transcript: string)` |
+| speech-error      | 语音识别错误时触发         | `(error: Error)`       |
+| suggestion-select | 选择输入建议时触发         | `(value: string)`      |
 
 ### Methods
 
@@ -223,83 +207,3 @@ Sender 组件支持多种键盘快捷键操作，提高用户输入效率：
 | `prefix`  | 前缀插槽，位于输入框左侧 | `.tiny-sender__prefix-slot`  | 无                     |
 | `actions` | 后缀插槽，位于输入框右侧 | `.tiny-sender__actions-slot` | 单行模式下的操作按钮   |
 | `footer`  | 底部插槽，位于输入框下方 | `.tiny-sender__footer-slot`  | 字数限制和多行模式按钮 |
-
-### 样式定制
-
-可以通过CSS变量自定义组件样式：
-
-#### 容器样式变量
-
-- `--tr-sender-border-radius`: 组件边框圆角，默认 8px
-- `--tr-sender-border-color`: 边框颜色，默认 #e4e7ed
-- `--tr-sender-focus-border-color`: 聚焦时边框颜色，默认 #409eff
-- `--tr-sender-bg-color`: 背景色，默认 #fff
-- `--tr-sender-padding`: 内边距，默认 10px
-
-#### 输入区域变量
-
-- `--tr-sender-content-padding`: 内容区域内边距，默认 10px
-- `--tr-sender-content-padding-with-prefix`: 有前缀时内容区域内边距，默认 10px 10px 10px 0
-- `--tr-sender-input-font-size`: 输入字体大小，默认 14px
-- `--tr-sender-input-line-height`: 输入行高，默认 1.5
-- `--tr-sender-input-color`: 输入文本颜色，默认 #303133
-
-#### 插槽样式变量
-
-##### 头部插槽（Header）
-
-- `--tr-sender-header-max-height`: 最大高度，默认 120px
-- `--tr-sender-header-min-height`: 最小高度，默认 40px
-- `--tr-sender-header-shadow`: 阴影效果，默认 0 2px 8px rgba(0,0,0,0.1)
-- `--tr-sender-header-padding`: 内边距
-
-##### 前缀插槽（Prefix）
-
-- `--tr-sender-prefix-width`: 宽度，默认 60px
-- `--tr-sender-prefix-min-width`: 最小宽度，默认 44px
-- `--tr-sender-prefix-hover-bg`: 悬停背景色，默认 #f5f5f5
-- `--tr-sender-prefix-padding-left`: 左内边距，默认 16px
-
-##### 操作区域（Actions）
-
-- `--tr-sender-actions-width`: 宽度，默认 auto
-- `--tr-sender-actions-min-width`: 最小宽度，默认 32px
-- `--tr-sender-actions-gap`: 按钮间距，默认 8px
-- `--tr-sender-actions-icon-size`: 图标大小，默认 20px
-- `--tr-sender-actions-padding-right`: 右侧内边距，默认 10px
-
-##### 底部插槽（Footer）
-
-- `--tr-sender-footer-max-height`: 最大高度，默认 200px
-- `--tr-sender-footer-min-height`: 最小高度，默认 0
-- `--tr-sender-footer-bg`: 背景色，默认 #fff
-- `--tr-sender-footer-hover`: 悬停背景色，默认 #f9f9f9
-
-### 主题适配
-
-Sender 支持亮色和暗色两种主题模式，通过`theme`属性控制：
-
-<tr-sender theme="dark" />
-
-```vue
-<tr-sender theme="dark" />
-```
-
-也可以通过CSS变量实现更细致的主题定制：
-
-```css
-/* 亮色主题 */
-.theme-light {
-  --tr-sender-bg-color: #fff;
-  --tr-sender-border-color: #e4e7ed;
-  --tr-sender-input-color: #303133;
-}
-
-/* 暗色主题 */
-.theme-dark {
-  --tr-sender-bg-color: #1e1e1e;
-  --tr-sender-border-color: #4c4c4c;
-  --tr-sender-input-color: #e0e0e0;
-  --tr-sender-actions-icon-color: #b0b0b0;
-}
-```

--- a/packages/components/src/sender/index.less
+++ b/packages/components/src/sender/index.less
@@ -2,7 +2,6 @@
 
 // 主要组件样式
 .tiny-sender {
-  background: var(--tr-sender-bg-color);
   position: relative;
   color: var(--tr-sender-text-color);
 
@@ -31,6 +30,12 @@
     color: var(--tr-sender-text-color-secondary);
   }
 
+  .tiny-textarea.is-disabled .tiny-textarea__inner {
+    border: none;
+    background: var(--tr-sender-bg-color);
+    color: var(--tr-sender-text-color-secondary);
+  }
+
   .tiny-input__suffix {
     right: 0;
     display: flex;
@@ -39,9 +44,10 @@
 
   .tiny-textarea__inner {
     border: none;
-    height: var(--tr-sender-input-height);
-    padding-left: 0;
-    padding-right: 0;
+    height: 26px;
+
+    padding: 0;
+    align-content: center; // 使内容垂直居中
     background-color: var(--tr-sender-bg-color);
     color: var(--tr-sender-text-color);
 
@@ -88,7 +94,6 @@
     width: 100%;
     border-radius: 0 0 var(--tr-sender-border-radius) var(--tr-sender-border-radius);
     background: var(--tr-sender-footer-bg);
-    margin-top: var(--tr-sender-gap);
     z-index: 1;
 
     &.tiny-sender__bottom-row {
@@ -248,6 +253,11 @@
       cursor: wait;
       background-color: var(--tr-sender-bg-color);
     }
+
+    .tiny-textarea__inner {
+      cursor: wait;
+      background-color: var(--tr-sender-bg-color);
+    }
   }
 
   // 错误状态
@@ -283,8 +293,8 @@
 .action-buttons {
   display: flex;
   gap: var(--tr-sender-gap);
-  padding: var(--tr-sender-padding-top) var(--tr-sender-padding-right) var(--tr-sender-padding-bottom)
-    var(--tr-sender-padding-left);
+  padding-left: var(--tr-sender-padding-left);
+  padding-right: var(--tr-sender-padding-right);
   background: var(--tr-sender-bg-color);
   border-radius: var(--tr-sender-border-radius);
   align-items: center;

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -93,8 +93,8 @@ const handleBlur = (event: FocusEvent) => {
   emit('blur', event)
 }
 
-// 输入框类型计算
-const inputType = computed(() => (props.mode === 'multiple' ? 'textarea' : 'text'))
+// 初始化自适应对象
+const autoSize = computed(() => (props.mode === 'multiple' ? { minRows: 2, maxRows: 5 } : { maxRows: 1 }))
 
 const justifyContent = computed(
   (): {
@@ -190,9 +190,9 @@ defineExpose({
             <tiny-input
               ref="inputRef"
               :autosize="autoSize"
-              :type="inputType"
+              type="textarea"
               :readonly="isLoading"
-              :resize="mode === 'multiple' ? 'none' : undefined"
+              resize="none"
               v-model="inputValue"
               :disabled="isDisabled"
               :placeholder="placeholder"

--- a/packages/components/src/sender/vars.less
+++ b/packages/components/src/sender/vars.less
@@ -17,7 +17,7 @@
   --tr-sender-padding-bottom: 10px;
   --tr-sender-padding-left: 24px;
   --tr-sender-gap: 8px;
-  --tr-sender-input-height: 100px;
+  --tr-sender-input-height: 26px;
   --tr-sender-input-min-height: 60px;
   --tr-sender-icon-size: 22px;
   --tr-sender-icon-size-small: 18px;
@@ -48,7 +48,7 @@
 
   // 内容区域 (Content)
   --tr-sender-content-min-width: 180px;
-  --tr-sender-content-padding: 15px 10px 10px 24px;
+  --tr-sender-content-padding: 15px 10px 12px 24px;
   --tr-sender-content-padding-with-prefix: 15px 10px 10px 8px;
   --tr-sender-content-flex-grow: 1;
 
@@ -68,7 +68,7 @@
 
 /* 暗色主题 */
 .theme-dark,
-[data-theme="dark"] {
+[data-theme='dark'] {
   --tr-sender-border-color: #4c4d4f;
   --tr-sender-bg-color: #1c1c1c;
   --tr-sender-text-color: #ffffff;


### PR DESCRIPTION
【示例页面】
1.  输入框改为多行输入模式，支持换行与自适应
（5行数据之内自适应高度，之后出现滚动条）

2.  增加限制字数相关配置
3.  修复 placeholder 信息切换

【sender 组件】
1. 删除组件背景色
2. 调整输入框单行组件为文本域
（支持换行和数据滚动）
3. 调整部分样式

【sender 文档】
1. 删除 自适应示例 (现在组件多选模式下默认支持指定行数自适应）
2. 删除 样式与主题相关说明

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated input component styles: reduced default input height, adjusted padding, and improved disabled state appearance.
  - Removed custom background and style customization examples from documentation and demos.
  - Standardized the input to always use a textarea with fixed height and disabled resizing.
  - Removed the `.chat-input` class and related styles from all relevant demo files.
  - Improved dark theme selector syntax for consistency.

- **Documentation**
  - Removed sections on CSS variable customization, auto-resize property, and related style examples from the documentation.
  - Updated event tables and formatting for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->