### PR TITLE
chore: mark Question and Suggestion components for deprecation

### DIFF
--- a/docs/src/components/question.md
+++ b/docs/src/components/question.md
@@ -4,6 +4,9 @@ outline: deep
 
 # Question 快捷问题组件
 
+> [!CAUTION]
+> 本组件准备弃用，请使用 [SuggestionPopover 建议弹出框](./suggestion-popover.html)和 [SuggestionPills 建议按钮组](./suggestion-pills.html) 组件
+
 Question 是一个用于展示问题列表的通用组件，包含两个主要部分：热门问题弹窗和一般问题悬浮胶囊。
 
 组件支持分类展示、问题列表的部分/全部显示切换以及暗色主题适配。

--- a/docs/src/components/suggestion-pills.md
+++ b/docs/src/components/suggestion-pills.md
@@ -20,7 +20,7 @@ outline: deep
 
 ## API
 
-### SuggestionPillProps
+### SuggestionPillsProps
 
 药丸组件属性配置。
 
@@ -28,7 +28,7 @@ outline: deep
 | ------- | ---------------------- | ------------------ |
 | `items` | `SuggestionPillItem[]` | 建议药丸项数据数组 |
 
-### SuggestionPillSlots
+### SuggestionPillsSlots
 
 药丸组件插槽定义。
 
@@ -36,7 +36,7 @@ outline: deep
 | --------- | ------------------------ | -------------- |
 | `default` | `() => VNode \| VNode[]` | 自定义内容插槽 |
 
-### SuggestionPillEmits
+### SuggestionPillsEmits
 
 药丸组件事件定义。
 

--- a/docs/src/components/suggestion.md
+++ b/docs/src/components/suggestion.md
@@ -4,6 +4,9 @@ outline: deep
 
 # Suggestion 快捷指令
 
+> [!CAUTION]
+> 本组件准备弃用，请使用 [SuggestionPopover 建议弹出框](./suggestion-popover.html)和 [SuggestionPills 建议按钮组](./suggestion-pills.html) 组件
+
 快捷指令组件是一个用于显示快捷指令/提示的复合组件，支持胶囊式快捷指令和弹窗的快捷指令两种形式。
 
 ## 代码示例

--- a/packages/components/src/suggestion-pills/index.type.ts
+++ b/packages/components/src/suggestion-pills/index.type.ts
@@ -23,15 +23,15 @@ export type SuggestionPillBaseItem<T> = {
 export type SuggestionPillItem<T = Record<string, unknown>> = SuggestionPillBaseItem<T> &
   ({ text: string; icon?: VNode | Component } | { text?: string; icon: VNode | Component })
 
-export interface SuggestionPillProps {
+export interface SuggestionPillsProps {
   items?: SuggestionPillItem[]
 }
 
-export interface SuggestionPillSlots {
+export interface SuggestionPillsSlots {
   default?: () => VNode | VNode[]
 }
 
-export interface SuggestionPillEmits {
+export interface SuggestionPillsEmits {
   (e: 'item-click', item: SuggestionPillItem): void
 }
 

--- a/packages/components/src/suggestion-pills/index.vue
+++ b/packages/components/src/suggestion-pills/index.vue
@@ -4,11 +4,11 @@ import { computed, useTemplateRef } from 'vue'
 import DropdownMenu from '../dropdown-menu'
 import SuggestionPopover from '../suggestion-popover'
 import { PillButton } from './components'
-import { SuggestionPillEmits, SuggestionPillProps } from './index.type'
+import { SuggestionPillsEmits, SuggestionPillsProps } from './index.type'
 
-const props = defineProps<SuggestionPillProps>()
+const props = defineProps<SuggestionPillsProps>()
 
-const emit = defineEmits<SuggestionPillEmits>()
+const emit = defineEmits<SuggestionPillsEmits>()
 
 const containerRef = useTemplateRef('container')
 


### PR DESCRIPTION
update SuggestionPill to SuggestionPills in documentation and types

<img width="756" alt="image" src="https://github.com/user-attachments/assets/463d31c8-217a-492f-94b0-6d05fcd09ab3" />
<img width="726" alt="image" src="https://github.com/user-attachments/assets/c62f5da2-ce18-440f-99e3-f473f7918e7a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added deprecation notices to the documentation for the "Question" and "Suggestion" components, advising users to switch to "SuggestionPopover" and "SuggestionPills".
  - Updated section headers in the "SuggestionPills" documentation for consistency with the component name.

- **Refactor**
  - Renamed internal type and interface names related to "SuggestionPills" for naming consistency. No changes to public APIs or component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->