### PR TITLE
refactor: replace useTemplateRef with ref for Vue 3.4 compatibility

### DIFF
--- a/packages/components/src/action-group/ActionGroup.vue
+++ b/packages/components/src/action-group/ActionGroup.vue
@@ -2,7 +2,7 @@
 import { IconMenu } from '@opentiny/tiny-robot-svgs'
 import TinyTooltip from '@opentiny/vue-tooltip'
 import { onClickOutside, useWindowSize } from '@vueuse/core'
-import { computed, nextTick, ref, useTemplateRef, VNode, watch } from 'vue'
+import { computed, nextTick, ref, VNode, watch } from 'vue'
 import IconButton from '../icon-button'
 import { ActionGroupEvents, ActionGroupProps, ActionGroupSlots } from './index.type'
 
@@ -56,16 +56,16 @@ const moreList = computed(() => {
   return []
 })
 
-const moreBtn = useTemplateRef('moreBtnRef')
-const dropDown = useTemplateRef('dropDownRef')
+const moreBtnRef = ref<HTMLSpanElement | null>(null)
+const dropDownRef = ref<HTMLUListElement | null>(null)
 const showDropdown = ref(false)
 
 const handleMoreClick = () => {
   showDropdown.value = !showDropdown.value
 }
 
-onClickOutside(dropDown, (ev) => {
-  if (moreBtn.value?.contains(ev.target as Node)) {
+onClickOutside(dropDownRef, (ev) => {
+  if (moreBtnRef.value?.contains(ev.target as Node)) {
     return
   }
 
@@ -81,12 +81,12 @@ const dropDownPlacement = ref('placement-bottom')
 const { height: windowHeight } = useWindowSize()
 
 const updateDropDownPlacement = () => {
-  if (!dropDown.value || !moreBtn.value) {
+  if (!dropDownRef.value || !moreBtnRef.value) {
     return 'placement-bottom'
   }
 
-  const dropDownRect = dropDown.value.getBoundingClientRect()
-  const moreBtnRect = moreBtn.value.getBoundingClientRect()
+  const dropDownRect = dropDownRef.value.getBoundingClientRect()
+  const moreBtnRect = moreBtnRef.value.getBoundingClientRect()
 
   dropDownPlacement.value =
     moreBtnRect.bottom + dropDownRect.height + 16 > windowHeight.value ? 'placement-top' : 'placement-bottom'

--- a/packages/components/src/bubble/BubbleList.vue
+++ b/packages/components/src/bubble/BubbleList.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { useScroll } from '@vueuse/core'
-import { computed, useTemplateRef, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import Bubble from './Bubble.vue'
 import { BubbleListProps, BubbleProps, BubbleSlots } from './index.type'
 
 const props = withDefaults(defineProps<BubbleListProps>(), {})
 
-const scrollContainerRef = useTemplateRef<HTMLDivElement>('scrollContainer')
+const scrollContainerRef = ref<HTMLDivElement | null>(null)
 const { y } = useScroll(scrollContainerRef, {
   behavior: 'smooth',
   throttle: 100,
@@ -35,7 +35,7 @@ const getItemSlots = (item: BubbleProps & { slots?: BubbleSlots }): BubbleSlots 
 </script>
 
 <template>
-  <div class="tr-bubble-list" ref="scrollContainer">
+  <div class="tr-bubble-list" ref="scrollContainerRef">
     <Bubble v-for="(item, index) in props.items" :key="item.id || index" v-bind="getItemProps(item)">
       <template v-for="(_, slotName) in getItemSlots(item)" #[slotName]="slotProps" :key="slotName">
         <component :is="getItemSlots(item)[slotName]" v-bind="slotProps" />

--- a/packages/components/src/dropdown-menu/index.vue
+++ b/packages/components/src/dropdown-menu/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onClickOutside, useElementBounding } from '@vueuse/core'
-import { computed, CSSProperties, ref, useTemplateRef, watch } from 'vue'
+import { computed, CSSProperties, ref, watch } from 'vue'
 import { toCssUnit } from '../shared/utils'
 import { DropdownMenuEmits, DropdownMenuItem, DropdownMenuProps, DropdownMenuSlots } from './index.type'
 
@@ -15,8 +15,8 @@ defineSlots<DropdownMenuSlots>()
 
 const emit = defineEmits<DropdownMenuEmits>()
 
-const dropDownTriggerRef = useTemplateRef('dropdown-menu-trigger')
-const dropdownMenuRef = useTemplateRef('dropdown-menu')
+const dropDownTriggerRef = ref<HTMLDivElement | null>(null)
+const dropdownMenuRef = ref<HTMLDivElement | null>(null)
 
 const { x, y, update } = useElementBounding(dropDownTriggerRef)
 const { width: menuWidth, height: menuHeight } = useElementBounding(dropdownMenuRef)
@@ -50,12 +50,12 @@ const handleItemClick = (item: DropdownMenuItem) => {
 </script>
 
 <template>
-  <div class="tr-dropdown-menu__wrapper" ref="dropdown-menu-trigger" @click="handleToggleShow">
+  <div class="tr-dropdown-menu__wrapper" ref="dropDownTriggerRef" @click="handleToggleShow">
     <slot />
 
     <Transition name="tr-dropdown-menu">
       <Teleport v-if="show" to="body">
-        <div class="tr-dropdown-menu" :style="dropdownStyles" ref="dropdown-menu">
+        <div class="tr-dropdown-menu" :style="dropdownStyles" ref="dropdownMenuRef">
           <ul class="tr-dropdown-menu__list">
             <li
               class="tr-dropdown-menu__list-item"

--- a/packages/components/src/flow-layout-buttons/index.vue
+++ b/packages/components/src/flow-layout-buttons/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { IconArrowDown } from '@opentiny/tiny-robot-svgs'
 import { onClickOutside, useElementSize } from '@vueuse/core'
-import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { FlowLayoutEmits, FlowLayoutProps } from './index.type'
 
 const props = withDefaults(defineProps<FlowLayoutProps>(), {
@@ -24,9 +24,9 @@ watch(
 
 const emit = defineEmits<FlowLayoutEmits>()
 
-const containerRef = useTemplateRef('container')
-const moreButtonRef = useTemplateRef('more-button')
-const dropDownRef = useTemplateRef('dropDown')
+const containerRef = ref<HTMLDivElement | null>(null)
+const moreButtonRef = ref<HTMLButtonElement | null>(null)
+const dropDownRef = ref<HTMLDivElement | null>(null)
 
 const itemRefs = ref<(HTMLElement | null)[]>([])
 const moreButtonIndex = ref<number | null>(null)
@@ -127,7 +127,7 @@ onClickOutside(dropDownRef, (ev) => {
 </script>
 
 <template>
-  <div class="tr-flow-layout" ref="container">
+  <div class="tr-flow-layout" ref="containerRef">
     <template v-for="(item, index) in props.items" :key="item.id">
       <button
         :class="['tr-flow-layout__item', { 'icon-only': !item.label }, { selected: item.id === selected }]"
@@ -143,7 +143,7 @@ onClickOutside(dropDownRef, (ev) => {
       <button
         :class="['tr-flow-layout__item', 'icon-only', { selected: moreButtonSelected }]"
         v-if="!hideMoreButton"
-        ref="more-button"
+        ref="moreButtonRef"
         @click="handleClickMore"
         @mouseenter="handleHoverMore(true)"
         @mouseleave="handleHoverMore(false)"
@@ -155,7 +155,7 @@ onClickOutside(dropDownRef, (ev) => {
         @mouseenter="handleHoverMore(true)"
         @mouseleave="handleHoverMore(false)"
       >
-        <div class="tr-flow-layout__dropdown" v-if="showMore" ref="dropDown">
+        <div class="tr-flow-layout__dropdown" v-if="showMore" ref="dropDownRef">
           <button
             :class="['tr-flow-layout__dropdown_item', { selected: item.id === selected }]"
             v-for="item in leftItems"

--- a/packages/components/src/suggestion-pills/index.vue
+++ b/packages/components/src/suggestion-pills/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useScroll } from '@vueuse/core'
-import { computed, useTemplateRef } from 'vue'
+import { computed, ref } from 'vue'
 import DropdownMenu from '../dropdown-menu'
 import SuggestionPopover from '../suggestion-popover'
 import { PillButton } from './components'
@@ -10,7 +10,7 @@ const props = defineProps<SuggestionPillsProps>()
 
 const emit = defineEmits<SuggestionPillsEmits>()
 
-const containerRef = useTemplateRef('container')
+const containerRef = ref<HTMLDivElement | null>(null)
 
 const { arrivedState } = useScroll(containerRef)
 
@@ -28,7 +28,7 @@ const maskImage = computed(() => {
 </script>
 
 <template>
-  <div class="tr-suggestion-pills__container" ref="container">
+  <div class="tr-suggestion-pills__container" ref="containerRef">
     <slot>
       <template v-for="item in props.items" :key="item.id">
         <SuggestionPopover

--- a/packages/components/src/suggestion-popover/index.vue
+++ b/packages/components/src/suggestion-popover/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { IconClose, IconSparkles } from '@opentiny/tiny-robot-svgs'
 import { onClickOutside, useElementBounding, useMediaQuery } from '@vueuse/core'
-import { computed, CSSProperties, ref, useTemplateRef, watch } from 'vue'
+import { computed, CSSProperties, ref, watch } from 'vue'
 import FlowLayoutButtons from '../flow-layout-buttons'
 import IconButton from '../icon-button'
 import { toCssUnit } from '../shared/utils'
@@ -73,8 +73,8 @@ const flowLayoutGroups = computed(() => {
   }))
 })
 
-const popoverTriggerRef = useTemplateRef('popover-trigger')
-const popoverRef = useTemplateRef('popover')
+const popoverTriggerRef = ref<HTMLDivElement | null>(null)
+const popoverRef = ref<HTMLDivElement | null>(null)
 
 const { x, y, update } = useElementBounding(popoverTriggerRef)
 
@@ -135,7 +135,7 @@ const handleGroupClick = (id: string) => {
 </script>
 
 <template>
-  <div class="tr-question-popover__wrapper" ref="popover-trigger" @click="handleToggleShow">
+  <div class="tr-question-popover__wrapper" ref="popoverTriggerRef" @click="handleToggleShow">
     <slot />
 
     <Teleport v-if="show && isMobile" to="body">
@@ -143,7 +143,7 @@ const handleGroupClick = (id: string) => {
     </Teleport>
     <Transition name="tr-question-popover">
       <Teleport v-if="show" to="body">
-        <div class="tr-question-popover" :style="popoverStyles" ref="popover">
+        <div class="tr-question-popover" :style="popoverStyles" ref="popoverRef">
           <div class="tr-question__header">
             <component v-if="props.icon" :is="props.icon" />
             <span v-else class="tr-question__header-icon">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated several components to use standard Vue refs for DOM element references instead of a custom template ref helper. This change does not impact component behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->