### PR TITLE
style: update template editor color

### DIFF
--- a/packages/components/src/sender/index.less
+++ b/packages/components/src/sender/index.less
@@ -595,6 +595,8 @@
 
   .template-field {
     display: inline;
+    caret-color: var(--tr-sender-text-color);
+    color: var(--tr-sender-template-field-color);
     min-width: var(--tr-sender-template-field-min-width);
     max-width: none;
     background: var(--tr-sender-template-field-bg);

--- a/packages/components/src/sender/vars.less
+++ b/packages/components/src/sender/vars.less
@@ -42,8 +42,8 @@
   --tr-sender-template-editor-min-height: 26px;
   --tr-sender-template-editor-line-height: 26px;
   --tr-sender-template-editor-border-radius: 4px;
-  --tr-sender-template-field-bg: rgba(0, 0, 0, 0.05);
-  --tr-sender-template-field-bg-hover: rgba(0, 0, 0, 0.08);
+  --tr-sender-template-field-bg: rgba(20, 118, 255, 0.1);
+  --tr-sender-template-field-bg-hover: rgba(20, 118, 255, 0.15);
   --tr-sender-template-field-padding: 3px 8px;
   --tr-sender-template-field-margin: 0 2px;
   --tr-sender-template-field-border-radius: 4px;
@@ -51,7 +51,8 @@
   --tr-sender-template-field-min-width-empty: 3em;
   --tr-sender-template-field-min-height-empty: 24px;
   --tr-sender-template-field-line-height: 16px;
-  --tr-sender-template-field-placeholder-color: #a8abb2;
+  --tr-sender-template-field-color: #1476FF;
+  --tr-sender-template-field-placeholder-color: #A6CAFD;
   --tr-sender-template-field-placeholder-left: 8px;
 
   // 插槽变量


### PR DESCRIPTION
参考设计稿对齐模板编辑的相关色值
修改前
![before](https://github.com/user-attachments/assets/56249fd1-5d16-498b-915a-7e71d2946b80)

修改后
![after](https://github.com/user-attachments/assets/5516ac4b-7364-41c9-b037-3a7bcb7c6ba6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated sender template field with new background, text, and placeholder colors for improved visual clarity.
  - Adjusted caret (text cursor) color to match the updated text color in template fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->