### PR TITLE
refactor: Remove Teleport to="body" for Shadow DOM compatibility

### DIFF
--- a/packages/components/src/dropdown-menu/index.vue
+++ b/packages/components/src/dropdown-menu/index.vue
@@ -55,24 +55,22 @@ const handleItemClick = (item: DropdownMenuItem) => {
 <template>
   <div class="tr-dropdown-menu__wrapper" ref="dropDownTriggerRef" @click="handleToggleShow">
     <slot />
-
-    <Transition name="tr-dropdown-menu">
-      <Teleport v-if="show" to="body">
-        <div class="tr-dropdown-menu" :style="dropdownStyles" ref="dropdownMenuRef">
-          <ul class="tr-dropdown-menu__list">
-            <li
-              class="tr-dropdown-menu__list-item"
-              v-for="item in props.items"
-              :key="item.id"
-              @click="handleItemClick(item)"
-            >
-              {{ item.text }}
-            </li>
-          </ul>
-        </div>
-      </Teleport>
-    </Transition>
   </div>
+
+  <Transition name="tr-dropdown-menu">
+    <div v-if="show" class="tr-dropdown-menu" :style="dropdownStyles" ref="dropdownMenuRef">
+      <ul class="tr-dropdown-menu__list">
+        <li
+          class="tr-dropdown-menu__list-item"
+          v-for="item in props.items"
+          :key="item.id"
+          @click="handleItemClick(item)"
+        >
+          {{ item.text }}
+        </li>
+      </ul>
+    </div>
+  </Transition>
 </template>
 
 <style lang="less" scoped>

--- a/packages/components/src/suggestion-popover/index.vue
+++ b/packages/components/src/suggestion-popover/index.vue
@@ -140,66 +140,55 @@ const handleGroupClick = (id: string) => {
 <template>
   <div class="tr-question-popover__wrapper" ref="popoverTriggerRef" @click="handleToggleShow">
     <slot />
-
-    <Teleport v-if="show && isMobile" to="body">
-      <div class="tr-question-popover__backdrop"></div>
-    </Teleport>
-    <Transition name="tr-question-popover">
-      <Teleport v-if="show" to="body">
-        <div class="tr-question-popover" :style="popoverStyles" ref="popoverRef">
-          <div class="tr-question__header">
-            <component v-if="props.icon" :is="props.icon" />
-            <span v-else class="tr-question__header-icon">
-              <IconSparkles style="color: #1476ff" />
-            </span>
-            <h3 class="tr-question__header-title">{{ props.title }}</h3>
-            <IconButton
-              class="tr-question-popover__close"
-              :icon="IconClose"
-              size="24"
-              svg-size="20"
-              @click="handleClose"
-            />
-          </div>
-          <div v-if="props.loading" class="tr-question__loading-wrapper">
-            <slot name="loading">
-              <img class="tr-question__loading" src="../assets/loading.webp" />
-              <span class="tr-question__loading-text">正在加载</span>
-            </slot>
-          </div>
-          <div v-else-if="props.data.length === 0" class="tr-question__no-data-wrapper">
-            <slot name="empty">
-              <img class="tr-question__no-data" src="../assets/svgs/no-data.svg" />
-              <span class="tr-question__no-data-text">暂时没有内容</span>
-            </slot>
-          </div>
-          <template v-else>
-            <FlowLayoutButtons
-              class="tr-question__group"
-              v-if="flowLayoutGroups.length > 0"
-              :items="flowLayoutGroups"
-              v-model:selected="selectedGroup"
-              :lines-limit="2"
-              :show-more-trigger="props.groupShowMoreTrigger"
-              @item-click="handleGroupClick"
-            ></FlowLayoutButtons>
-            <ul class="tr-question__list">
-              <li
-                class="tr-question__list-item"
-                v-for="(item, index) in dataItems"
-                :key="item.id"
-                @click="handleItemClick(item)"
-              >
-                <span class="tr-question__list-item-text">
-                  <span>{{ index + 1 }}. </span>{{ item.text }}
-                </span>
-              </li>
-            </ul>
-          </template>
-        </div>
-      </Teleport>
-    </Transition>
   </div>
+  <div v-if="show && isMobile" class="tr-question-popover__backdrop"></div>
+  <Transition name="tr-question-popover">
+    <div v-if="show" class="tr-question-popover" :style="popoverStyles" ref="popoverRef">
+      <div class="tr-question__header">
+        <component v-if="props.icon" :is="props.icon" />
+        <span v-else class="tr-question__header-icon">
+          <IconSparkles style="color: #1476ff" />
+        </span>
+        <h3 class="tr-question__header-title">{{ props.title }}</h3>
+        <IconButton class="tr-question-popover__close" :icon="IconClose" size="24" svg-size="20" @click="handleClose" />
+      </div>
+      <div v-if="props.loading" class="tr-question__loading-wrapper">
+        <slot name="loading">
+          <img class="tr-question__loading" src="../assets/loading.webp" />
+          <span class="tr-question__loading-text">正在加载</span>
+        </slot>
+      </div>
+      <div v-else-if="props.data.length === 0" class="tr-question__no-data-wrapper">
+        <slot name="empty">
+          <img class="tr-question__no-data" src="../assets/svgs/no-data.svg" />
+          <span class="tr-question__no-data-text">暂时没有内容</span>
+        </slot>
+      </div>
+      <template v-else>
+        <FlowLayoutButtons
+          class="tr-question__group"
+          v-if="flowLayoutGroups.length > 0"
+          :items="flowLayoutGroups"
+          v-model:selected="selectedGroup"
+          :lines-limit="2"
+          :show-more-trigger="props.groupShowMoreTrigger"
+          @item-click="handleGroupClick"
+        ></FlowLayoutButtons>
+        <ul class="tr-question__list">
+          <li
+            class="tr-question__list-item"
+            v-for="(item, index) in dataItems"
+            :key="item.id"
+            @click="handleItemClick(item)"
+          >
+            <span class="tr-question__list-item-text">
+              <span>{{ index + 1 }}. </span>{{ item.text }}
+            </span>
+          </li>
+        </ul>
+      </template>
+    </div>
+  </Transition>
 </template>
 
 <style lang="less" scoped>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the dropdown menu and suggestion popover components by removing teleportation of elements to the document body. All content now renders directly within the component hierarchy, maintaining existing UI and animation behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->