### PR TITLE
feat: template filling support shortcut submission

### DIFF
--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -46,7 +46,6 @@ const templateHandler = useTemplateHandler(contentEditableRef, {
     emit('input', newValue)
   },
   onContentStatusChange: (hasContent: boolean) => emit('content-status', hasContent),
-  onSubmit: (submitValue: string) => emit('submit', submitValue),
 })
 
 // 使用键盘事件处理 Hook
@@ -55,7 +54,8 @@ const keyboardHandler = useTemplateKeyboardHandler({
   isComposing,
   getValueFromDOM: templateHandler.getValueFromDOM,
   handleInput: templateHandler.handleInput,
-  onSubmit: (submitValue: string) => emit('submit', submitValue),
+  onSubmit: () => emit('submit'),
+  submitType: props.submitType,
 })
 
 // 生成模板内容的辅助函数

--- a/packages/components/src/sender/composables/useKeyboardHandler.ts
+++ b/packages/components/src/sender/composables/useKeyboardHandler.ts
@@ -4,6 +4,33 @@ import { type CursorPosition } from './useTemplateHandler'
 import { isOnlyZeroWidthSpace, cleanZeroWidthSpaces } from '../utils/zeroWidthUtils'
 
 /**
+ * 检查是否为指定的提交快捷键
+ * @param event 键盘事件
+ * @param submitType 提交类型
+ * @returns 是否触发提交
+ *
+ * 提交行为说明：
+ * - 当 submitType 为 enter 时：按 Enter 键提交
+ * - 当 submitType 为 ctrlEnter 时：按 Ctrl+Enter 提交，单独按 Enter 换行
+ * - 当 submitType 为 shiftEnter 时：按 Shift+Enter 提交，单独按 Enter 换行
+ */
+export const checkSubmitShortcut = (event: KeyboardEvent, submitType: SubmitTrigger): boolean => {
+  const isEnter = event.key === 'Enter'
+  if (!isEnter) return false
+
+  switch (submitType) {
+    case 'enter':
+      return !event.shiftKey && !event.ctrlKey && !event.metaKey
+    case 'ctrlEnter':
+      return (event.ctrlKey || event.metaKey) && !event.shiftKey
+    case 'shiftEnter':
+      return event.shiftKey && !event.ctrlKey && !event.metaKey
+    default:
+      return false
+  }
+}
+
+/**
  * 键盘处理Hook
  * 集中管理组件的键盘相关操作
  *
@@ -49,33 +76,6 @@ export function useKeyboardHandler(
   const triggerSubmit = () => {
     if (!validateSubmission(inputValue.value)) return
     emit('submit', inputValue.value.trim())
-  }
-
-  /**
-   * 检查是否为指定的提交快捷键
-   * @param event 键盘事件
-   * @param submitType 提交类型
-   * @returns 是否触发提交
-   *
-   * 提交行为说明：
-   * - 当 submitType 为 enter 时：按 Enter 键提交
-   * - 当 submitType 为 ctrlEnter 时：按 Ctrl+Enter 提交，单独按 Enter 换行
-   * - 当 submitType 为 shiftEnter 时：按 Shift+Enter 提交，单独按 Enter 换行
-   */
-  const checkSubmitShortcut = (event: KeyboardEvent, submitType: SubmitTrigger): boolean => {
-    const isEnter = event.key === 'Enter'
-    if (!isEnter) return false
-
-    switch (submitType) {
-      case 'enter':
-        return !event.shiftKey && !event.ctrlKey && !event.metaKey
-      case 'ctrlEnter':
-        return (event.ctrlKey || event.metaKey) && !event.shiftKey
-      case 'shiftEnter':
-        return event.shiftKey && !event.ctrlKey && !event.metaKey
-      default:
-        return false
-    }
   }
 
   /**
@@ -177,7 +177,9 @@ export interface TemplateKeyboardOptions {
   /** 输入处理方法 */
   handleInput: () => void
   /** 提交事件回调 */
-  onSubmit: (value: string) => void
+  onSubmit: () => void
+  /** 提交触发方式 */
+  submitType?: SubmitTrigger
 }
 
 /**
@@ -594,11 +596,15 @@ export function useTemplateKeyboardHandler(options: TemplateKeyboardOptions) {
 
     const range = selection.getRangeAt(0)
 
-    // 处理Enter键
-    if (event.key === 'Enter') {
-      event.preventDefault()
-      options.onSubmit(options.getValueFromDOM())
-      return
+    // 处理提交快捷键
+    const submitType = options.submitType || 'enter'
+    if (checkSubmitShortcut(event, submitType)) {
+      const currentValue = options.getValueFromDOM()
+      if (currentValue.trim().length > 0) {
+        event.preventDefault()
+        options.onSubmit()
+        return
+      }
     }
 
     // 处理左右箭头键导航

--- a/packages/components/src/sender/composables/useTemplateHandler.ts
+++ b/packages/components/src/sender/composables/useTemplateHandler.ts
@@ -39,7 +39,6 @@ export interface TemplateHandlerOptions {
   onValueChange: (value: string) => void
   onInput: (value: string) => void
   onContentStatusChange: (hasContent: boolean) => void
-  onSubmit: (value: string) => void
 }
 
 /**

--- a/packages/components/src/sender/index.type.ts
+++ b/packages/components/src/sender/index.type.ts
@@ -137,6 +137,8 @@ export interface TemplateEditorProps {
   value?: string
   /** 是否自动聚焦 */
   autofocus?: boolean
+  /** 提交触发方式 */
+  submitType?: SubmitTrigger
 }
 
 /**
@@ -158,7 +160,7 @@ export interface TemplateEditorEmits {
   /** 内容变更状态 - 通知父组件是否有内容 */
   (e: 'content-status', hasContent: boolean): void
   /** 提交事件 */
-  (e: 'submit', value: string): void
+  (e: 'submit'): void
   /** 聚焦事件 */
   (e: 'focus', event: FocusEvent): void
   /** 失焦事件 */

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -448,7 +448,9 @@ defineExpose({
               <TemplateEditor
                 ref="templateEditorRef"
                 v-model:value="inputValue"
+                :submit-type="submitType"
                 @input="handleTemplateInput"
+                @submit="triggerSubmit"
                 @empty-content="exitTemplateMode"
               />
             </template>


### PR DESCRIPTION
**支持快捷键提交模板编辑内容**

注：模板编辑内容 提交快捷键 与 输入框 提交快捷键保持一致（默认为 Enter）

快捷键提交流程梳理：
```mermaid
graph TD
    A[用户按下快捷键] --> B{检查输入法状态}
    B -->|isComposing=true| C[阻止处理]
    B -->|isComposing=false| D[DOM事件监听器]
    
    D --> E[TemplateEditor.vue @keydown]
    E --> F[keyboardHandler.handleTemplateKeyDown]
    
    F --> G{checkSubmitShortcut}
    G -->|非提交键| H[处理其他键盘事件]
    G -->|是提交快捷键| I[options.getValueFromDOM]
    
    I --> J{内容验证}
    J -->|内容为空| K[阻止提交]
    J -->|有内容| L[event.preventDefault]
    
    L --> M[options.onSubmit]
    M --> N["emit('submit')"]
    N --> O[父组件 @submit 监听]
    O --> P[triggerSubmit函数]
    P --> Q["emit('submit', value)"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the keyboard shortcut used to submit templates in the editor.

- **Bug Fixes**
  - Submission events from the template editor no longer include the template content as an argument.

- **Refactor**
  - Improved event handling for template submission, making keyboard shortcut detection more consistent and configurable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->