### PR TITLE
fix: blur close pop-up modal and style issues

### DIFF
--- a/packages/components/src/sender/index.less
+++ b/packages/components/src/sender/index.less
@@ -759,47 +759,46 @@
 }
 
 /* 模式切换过渡动画 */
-.tiny-sender-slide-up-enter-active,
-.tiny-sender-slide-up-leave-active,
-.tiny-sender-slide-down-enter-active,
-.tiny-sender-slide-down-leave-active {
-  overflow: hidden;
-  max-height: var(--tr-sender-transition-max-height);
+.tiny-sender-slide-up {
+
+  &-enter-active,
+  &-leave-active {
+    transition:
+      opacity var(--tr-sender-suggestion-transition-duration) var(--tr-sender-suggestion-transition-style),
+      transform var(--tr-sender-suggestion-transition-duration) var(--tr-sender-suggestion-transition-style);
+  }
+
+  &-enter-from,
+  &-leave-to {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  &-enter-to,
+  &-leave-from {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-.tiny-sender-slide-up-enter-from,
-.tiny-sender-slide-up-leave-to {
-  opacity: 0;
-  transform: translateY(10px);
-  max-height: 0;
-}
+.tiny-sender-slide-down {
 
-.tiny-sender-slide-down-enter-from,
-.tiny-sender-slide-down-leave-to {
-  opacity: 0;
-  transform: translateY(-10px);
-  max-height: 0;
-}
+  &-enter-active,
+  &-leave-active {
+    transition:
+      opacity var(--tr-sender-suggestion-transition-duration) var(--tr-sender-suggestion-transition-style),
+      transform var(--tr-sender-suggestion-transition-duration) var(--tr-sender-suggestion-transition-style);
+  }
 
-/* 模式切换过渡动画 */
-.tiny-sender-slide-up-enter-active,
-.tiny-sender-slide-up-leave-active,
-.tiny-sender-slide-down-enter-active,
-.tiny-sender-slide-down-leave-active {
-  overflow: hidden;
-  max-height: var(--tr-sender-transition-max-height);
-}
+  &-enter-from,
+  &-leave-to {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
 
-.tiny-sender-slide-up-enter-from,
-.tiny-sender-slide-up-leave-to {
-  opacity: 0;
-  transform: translateY(10px);
-  max-height: 0;
-}
-
-.tiny-sender-slide-down-enter-from,
-.tiny-sender-slide-down-leave-to {
-  opacity: 0;
-  transform: translateY(-10px);
-  max-height: 0;
+  &-enter-to,
+  &-leave-from {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/packages/components/src/sender/index.less
+++ b/packages/components/src/sender/index.less
@@ -338,6 +338,7 @@
       padding: var(--tr-sender-suggestion-item-padding);
       cursor: pointer;
       font-size: var(--tr-sender-suggestion-item-font-size);
+      gap: var(--tr-sender-suggestion-item-gap);
 
       &.highlighted {
         background-color: var(--tr-sender-suggestion-hover-color);
@@ -345,7 +346,7 @@
       }
 
       .suggestion-item__icon {
-        margin-right: var(--tr-sender-suggestion-item-icon-margin-right);
+        height: var(--tr-sender-suggestion-item-icon-size);
         font-size: var(--tr-sender-suggestion-item-icon-size);
         text-align: center;
       }

--- a/packages/components/src/sender/index.less
+++ b/packages/components/src/sender/index.less
@@ -346,7 +346,6 @@
       }
 
       .suggestion-item__icon {
-        height: var(--tr-sender-suggestion-item-icon-size);
         font-size: var(--tr-sender-suggestion-item-icon-size);
         text-align: center;
       }

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -580,7 +580,7 @@ defineExpose({
           @mouseenter="handleSuggestionItemHover(index)"
           @mousedown.prevent="selectSuggestion(item)"
         >
-          <span class="suggestion-item__icon"><IconAssociate /></span>
+          <IconAssociate class="suggestion-item__icon" />
           <span class="suggestion-item__text">
             <span
               v-for="(part, partIndex) in highlightSuggestionText(item, inputValue)"

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -309,6 +309,8 @@ const handleFocus = (event: FocusEvent) => {
 
 const handleBlur = (event: FocusEvent) => {
   emit('blur', event)
+  // 失焦时关闭联想弹窗
+  closeSuggestionsPopup()
 }
 
 const currentType = computed(() => (currentMode.value === 'multiple' ? 'textarea' : 'text'))

--- a/packages/components/src/sender/vars.less
+++ b/packages/components/src/sender/vars.less
@@ -144,7 +144,6 @@
   --tr-sender-suggestion-item-padding: 4px 8px;
   --tr-sender-suggestion-item-font-size: 14px;
   --tr-sender-suggestion-item-icon-size: 16px;
-  --tr-sender-suggestion-item-icon-margin-right: 8px;
   --tr-sender-suggestion-max-height: 200px;
   --tr-sender-suggestion-scrollbar-width: 6px;
   --tr-sender-suggestion-scrollbar-border-radius: 6px;

--- a/packages/components/src/sender/vars.less
+++ b/packages/components/src/sender/vars.less
@@ -128,7 +128,7 @@
 
   // 建议相关变量
   --tr-sender-suggestion-width: 400px;
-  --tr-sender-suggestion-padding: 4px;
+  --tr-sender-suggestion-padding: 8px;
   --tr-sender-suggestion-padding-bottom: 4px;
   --tr-sender-suggestion-box-shadow-color: rgba(0, 0, 0, 0.1);
   --tr-sender-suggestion-placeholder-color: #999;
@@ -150,6 +150,7 @@
   --tr-sender-suggestion-scrollbar-border-radius: 6px;
   --tr-sender-suggestion-transition-duration: 0.2s;
   --tr-sender-suggestion-transition-style: ease;
+  --tr-sender-suggestion-item-gap: 8px;
 
   // 自动完成占位符
   --tr-sender-completion-placeholder-font-size: 14px;


### PR DESCRIPTION
1. 实现输入框失焦后联想弹窗关闭
2. 修复联想弹窗图标未居中，对齐设计稿修改边距

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved spacing and sizing for suggestion items and their icons in the sender component.
  - Increased padding and introduced a new gap variable for more consistent layout in suggestions.
  - Enhanced slide-up and slide-down animations for smoother suggestion popup transitions.

- **Bug Fixes**
  - Ensured the suggestion popup reliably closes when the input loses focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->