### PR TITLE
fix: update sender component styles

### DIFF
--- a/docs/src/components/sender.md
+++ b/docs/src/components/sender.md
@@ -230,6 +230,7 @@ Sender 组件支持多种键盘快捷键操作，提高用户输入效率：
 | submitType           | 提交方式                 | `'enter' \| 'ctrl+enter' \| 'shift+enter'`              | `'enter'`         |
 | theme                | 主题样式                 | `'light' \| 'dark'`                                     | `'light'`         |
 | suggestions          | 输入建议列表             | `string[]`                                              | `[]`              |
+| suggestionPopupWidth | 输入建议弹窗宽度         | `'number' \| 'string'`                                                 | `400px`             |
 
 
 ### Events

--- a/packages/components/src/sender/index.less
+++ b/packages/components/src/sender/index.less
@@ -450,15 +450,12 @@
 
   // 加载状态
   &.is-loading {
-    cursor: wait;
 
     .tiny-input__inner {
-      cursor: wait;
       background-color: var(--tr-sender-bg-color);
     }
 
     .tiny-textarea__inner {
-      cursor: wait;
       background-color: var(--tr-sender-bg-color);
     }
   }

--- a/packages/components/src/sender/index.type.ts
+++ b/packages/components/src/sender/index.type.ts
@@ -40,6 +40,7 @@ export interface SenderProps {
   placeholder?: string // 占位文本
   showWordLimit?: boolean // 显示字数统计
   suggestions?: string[] // 输入建议
+  suggestionPopupWidth?: string | number // 联想建议弹窗宽度，如 '300px' 或 300
   theme?: ThemeType // 主题
   template?: string // 模板字符串，格式如 "你好 [称呼]，感谢您的 [事项]"
   hasContent?: boolean // 手动指定是否有内容，用于模板模式

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -30,6 +30,7 @@ const props = withDefaults(defineProps<SenderProps>(), {
   template: '',
   templateInitialValues: () => ({}),
   suggestions: () => [],
+  suggestionPopupWidth: 400,
 })
 
 const emit = defineEmits<SenderEmits>()
@@ -56,7 +57,6 @@ const {
   suggestionsListRef,
   filteredSuggestions,
   activeSuggestion,
-  updateCompletionPlaceholder,
   updateSuggestionsState,
   selectSuggestion,
   acceptCurrentSuggestion,
@@ -299,11 +299,10 @@ const { handleKeyPress, triggerSubmit }: KeyboardHandler = useKeyboardHandler(
 // 处理焦点事件
 const handleFocus = (event: FocusEvent) => {
   emit('focus', event)
+  // 当有输入内容且有匹配的联想项时，显示联想弹窗但不自动选中任何项
   if (inputValue.value && filteredSuggestions.value.length > 0 && !props.template) {
     showSuggestionsPopup.value = true
     showTabHint.value = true
-    if (highlightedIndex.value === -1) highlightedIndex.value = 0
-    updateCompletionPlaceholder(activeSuggestion.value || filteredSuggestions.value[0])
   }
 }
 
@@ -352,6 +351,15 @@ const senderClasses = computed(() => ({
   'has-error': !!errorMessage.value,
   'is-auto-switching': isAutoSwitching.value,
 }))
+
+// 联想建议弹窗宽度样式
+const suggestionPopupWidthStyle = computed(() => {
+  const width = props.suggestionPopupWidth
+  if (typeof width === 'number') {
+    return `${width}px`
+  }
+  return width
+})
 
 // 错误处理
 const errorMessage = ref<string>('')
@@ -571,6 +579,7 @@ defineExpose({
         v-if="showSuggestionsPopup && filteredSuggestions.length"
         ref="suggestionsListRef"
         class="tiny-sender__suggestions"
+        :style="{ width: suggestionPopupWidthStyle }"
       >
         <div
           v-for="(item, index) in filteredSuggestions"

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -9,6 +9,7 @@ import { useSuggestionHandler } from './composables/useSuggestionHandler'
 import ActionButtons from './components/ActionButtons.vue'
 import TemplateEditor from './components/TemplateEditor.vue'
 import { IconAssociate } from '@opentiny/tiny-robot-svgs'
+import { toCssUnit } from '../shared/utils'
 import './index.less'
 
 const props = withDefaults(defineProps<SenderProps>(), {
@@ -354,11 +355,11 @@ const senderClasses = computed(() => ({
 
 // 联想建议弹窗宽度样式
 const suggestionPopupWidthStyle = computed(() => {
-  const width = props.suggestionPopupWidth
-  if (typeof width === 'number') {
-    return `${width}px`
+  const width = toCssUnit(props.suggestionPopupWidth)
+  return {
+    width: width,
+    maxWidth: '100%', // 确保不超出父容器宽度
   }
-  return width
 })
 
 // 错误处理
@@ -579,7 +580,7 @@ defineExpose({
         v-if="showSuggestionsPopup && filteredSuggestions.length"
         ref="suggestionsListRef"
         class="tiny-sender__suggestions"
-        :style="{ width: suggestionPopupWidthStyle }"
+        :style="suggestionPopupWidthStyle"
       >
         <div
           v-for="(item, index) in filteredSuggestions"


### PR DESCRIPTION
1. 恢复输入框加载状态的鼠标指示器样式

2. 增加 `suggestionPopupWidth` 属性配置问题联想弹窗的宽度
 
3. 修改 问题联想弹窗 默认选中逻辑

默认不选中 问题联想弹窗 中的输入框匹配项，输入框内不显示  placeholder + tab hint

输入框展示用户输入的内容，上下键选择后 问题联想弹窗 显示选中效果、输入框内呈现 placeholder + tab hint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new option to customize the width of the input suggestion popup in the Sender component.

- **Improvements**
  - The suggestion popup now appears without automatically highlighting or selecting the first suggestion, requiring explicit user action to highlight items.
  - The width of the suggestion popup can be set using either a number or a string value.

- **Style**
  - The loading state of the Sender component no longer changes the cursor to "wait".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->