### PR TITLE
feat: enhance SuggestionPills component with showAllButtonOn prop

### DIFF
--- a/docs/demos/suggestion/pills-popper-config.vue
+++ b/docs/demos/suggestion/pills-popper-config.vue
@@ -1,11 +1,16 @@
 <template>
-  <TrSuggestionPills :items="items" v-model:showAll="showAll" @item-click="handleItemClick"></TrSuggestionPills>
+  <TrSuggestionPills
+    :items="items"
+    v-model:showAll="showAll"
+    @item-click="handleItemClick"
+    @click-outside="handleClickOutside"
+  ></TrSuggestionPills>
   <hr />
   <span>点击第一个图标会打开Popover弹出框</span>
   <hr />
   <div>
     <label>手动控制显示更多：</label>
-    <tiny-switch v-model="showAll"></tiny-switch>
+    <tiny-switch v-model="showAll" ref="showAllRef"></tiny-switch>
   </div>
 </template>
 
@@ -16,6 +21,7 @@ import { TinySwitch } from '@opentiny/vue'
 import { h, markRaw, ref } from 'vue'
 
 const showAll = ref(false)
+const showAllRef = ref<InstanceType<typeof TinySwitch>>()
 
 const dropdownMenuItems = ref([
   { id: '1', text: '去续费' },
@@ -96,6 +102,13 @@ const handleItemClick = (item: SuggestionPillItem) => {
   if (item.id === items.value[0].id) {
     delaySetData()
   }
+}
+
+const handleClickOutside = (event: MouseEvent) => {
+  if (showAllRef.value?.$el.contains(event.target as Node)) {
+    return
+  }
+  showAll.value = false
 }
 </script>
 

--- a/docs/src/components/suggestion-pills.md
+++ b/docs/src/components/suggestion-pills.md
@@ -51,10 +51,11 @@ outline: deep
 
 药丸组件属性配置。
 
-| 属性      | 类型                   | 说明                       |
-| --------- | ---------------------- | -------------------------- |
-| `items`   | `SuggestionPillItem[]` | 建议药丸项数据数组         |
-| `showAll` | `boolean`              | 是否展开全部元素 (v-model) |
+| 属性              | 类型                   | 默认值    | 说明                                                        |
+| ----------------- | ---------------------- | --------- | ----------------------------------------------------------- |
+| `items`           | `SuggestionPillItem[]` | -         | 建议药丸项数据数组                                          |
+| `showAll`         | `boolean`              | -         | 是否展开全部元素 (v-model)                                  |
+| `showAllButtonOn` | `'hover' \| 'always'`  | `'hover'` | 显示“更多按钮”的时机，`hover`为悬停显示，`always`为总是显示 |
 
 ### SuggestionPillsSlots
 
@@ -68,10 +69,10 @@ outline: deep
 
 药丸组件事件定义。
 
-| 事件名          | 参数                       | 说明                                           |
-| --------------- | -------------------------- | ---------------------------------------------- |
-| `item-click`    | `item: SuggestionPillItem` | 点击药丸项时触发                               |
-| `click-outside` |                            | 点击组件外部区域时触发，用于关闭展开的药丸列表 |
+| 事件名          | 参数                       | 说明                   |
+| --------------- | -------------------------- | ---------------------- |
+| `item-click`    | `item: SuggestionPillItem` | 点击药丸项时触发       |
+| `click-outside` | `event: MouseEvent`        | 点击组件外部区域时触发 |
 
 ### SuggestionPillButtonProps
 

--- a/packages/components/src/suggestion-pills/index.type.ts
+++ b/packages/components/src/suggestion-pills/index.type.ts
@@ -29,6 +29,13 @@ export interface SuggestionPillsProps {
    * model:showAll
    */
   showAll?: boolean
+  /**
+   * 显示更多按钮的时机
+   * - hover: 鼠标悬停时显示
+   * - always: 总是显示
+   * @default 'hover'
+   */
+  showAllButtonOn?: 'hover' | 'always'
 }
 
 /**
@@ -40,7 +47,7 @@ export interface SuggestionPillsSlots {
 
 export interface SuggestionPillsEmits {
   (e: 'item-click', item: SuggestionPillItem): void
-  (e: 'click-outside'): void
+  (e: 'click-outside', event: MouseEvent): void
 }
 
 export interface SuggestionPillButtonProps {

--- a/packages/components/src/suggestion-pills/index.vue
+++ b/packages/components/src/suggestion-pills/index.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { IconArrowDown, IconArrowUp } from '@opentiny/tiny-robot-svgs'
+import { IconArrowUp } from '@opentiny/tiny-robot-svgs'
 import { onClickOutside, useElementSize, watchDebounced } from '@vueuse/core'
 import { computed, nextTick, ref, watch } from 'vue'
 import { PillButtonWrapper } from './components'
 import { SuggestionPillItem, SuggestionPillsEmits, SuggestionPillsProps, SuggestionPillsSlots } from './index.type'
 
-const props = defineProps<SuggestionPillsProps>()
+const props = withDefaults(defineProps<SuggestionPillsProps>(), {
+  showAllButtonOn: 'hover',
+})
 
 const emit = defineEmits<SuggestionPillsEmits>()
 
@@ -71,9 +73,8 @@ const toggleIsShowingMore = () => {
   showAll.value = !showAll.value
 }
 
-onClickOutside(containerWrapperRef, () => {
-  showAll.value = false
-  emit('click-outside')
+onClickOutside(containerWrapperRef, (event) => {
+  emit('click-outside', event)
 })
 </script>
 
@@ -102,9 +103,13 @@ onClickOutside(containerWrapperRef, () => {
         </div>
       </Transition>
     </div>
-    <button v-if="hasShowMoreBtn" class="tr-suggestion-pills__expand" @click="toggleIsShowingMore">
-      <IconArrowUp v-if="!showAll" />
-      <IconArrowDown v-else />
+    <button
+      v-if="hasShowMoreBtn"
+      class="tr-suggestion-pills__expand"
+      :class="{ 'show-on-hover': props.showAllButtonOn === 'hover' }"
+      @click="toggleIsShowingMore"
+    >
+      <IconArrowUp class="tr-suggestion-pills__expand-icon" :class="{ rotate: showAll }" />
     </button>
   </div>
 </template>
@@ -112,6 +117,12 @@ onClickOutside(containerWrapperRef, () => {
 <style lang="less" scoped>
 .tr-suggestion-pills__wrapper {
   position: relative;
+}
+
+.tr-suggestion-pills__wrapper:hover {
+  .tr-suggestion-pills__expand.show-on-hover {
+    opacity: 1;
+  }
 }
 
 .tr-suggestion-pills__container {
@@ -172,6 +183,16 @@ onClickOutside(containerWrapperRef, () => {
 
   &:hover {
     background-color: rgb(235, 235, 235);
+  }
+
+  &.show-on-hover {
+    opacity: 0;
+  }
+
+  .tr-suggestion-pills__expand-icon {
+    &.rotate {
+      transform: rotate(180deg);
+    }
   }
 }
 </style>


### PR DESCRIPTION

- Added `@click-outside` event to handle closing the pills list when clicking outside.
- Introduced `showAllButtonOn` prop to control the visibility of the "show more" button based on hover or always.
- Updated documentation to reflect new prop and event details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new option to control when the "show more" button appears on suggestion pills, allowing it to display on hover or always.
- **Improvements**
	- The "show more" button now uses a single icon with rotation for expanded/collapsed states, providing a smoother visual experience.
	- Clicking outside the suggestion pills now more accurately controls their visibility, preventing accidental closure when interacting with the toggle switch.
- **Documentation**
	- Updated documentation to reflect the new "show more" button display option and revised event details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->