### PR TITLE
fix: popover opened after click twice

### DIFF
--- a/docs/demos/dropdown-menu/basic.vue
+++ b/docs/demos/dropdown-menu/basic.vue
@@ -2,6 +2,16 @@
   <TrDropdownMenu :items="dropdownMenuItems" @item-click="(item) => console.log(item)">
     <TrSuggestionPillButton> 点我打开Dropdown Menu </TrSuggestionPillButton>
   </TrDropdownMenu>
+  <hr />
+  <TrDropdownMenu
+    :items="dropdownMenuItems"
+    :show="show"
+    trigger="manual"
+    @item-click="(item) => console.log(item)"
+    @click-outside="handleClickOutside"
+  >
+    <TrSuggestionPillButton @click="show = !show"> Trigger 为 manual </TrSuggestionPillButton>
+  </TrDropdownMenu>
 </template>
 
 <script setup lang="ts">
@@ -15,4 +25,10 @@ const dropdownMenuItems = ref([
   { id: '4', text: '导账单' },
   { id: '5', text: '对帐单' },
 ])
+
+const show = ref(false)
+
+const handleClickOutside = (ev: MouseEvent) => {
+  console.log('click-outside', ev)
+}
 </script>

--- a/docs/demos/suggestion/popover-trigger.vue
+++ b/docs/demos/suggestion/popover-trigger.vue
@@ -3,7 +3,13 @@
     <SuggestionPopover :data="data" trigger="click">
       <button>click触发</button>
     </SuggestionPopover>
-    <SuggestionPopover :data="data" :show="show" trigger="manual" @close="handleClose">
+    <SuggestionPopover
+      :data="data"
+      :show="show"
+      trigger="manual"
+      @close="handleClose"
+      @click-outside="handleClickOutside"
+    >
       <button @click="show = !show">manual触发</button>
     </SuggestionPopover>
   </div>
@@ -17,6 +23,10 @@ const show = ref(false)
 
 const handleClose = () => {
   show.value = false
+}
+
+const handleClickOutside = (ev: MouseEvent) => {
+  console.log('click-outside', ev)
 }
 
 const data = [

--- a/docs/src/components/dropdown-menu.md
+++ b/docs/src/components/dropdown-menu.md
@@ -18,11 +18,13 @@ outline: deep
 
 下拉菜单属性配置。
 
-| 属性        | 类型                 | 说明                     |
-| ----------- | -------------------- | ------------------------ |
-| `items`     | `DropdownMenuItem[]` | **必填**，菜单项数据数组 |
-| `minWidth`  | `string \| number`   | 下拉菜单最小宽度         |
-| `topOffset` | `string \| number`   | 下拉菜单顶部偏移量       |
+| 属性        | 类型                  | 默认值    | 说明                                            |
+| ----------- | --------------------- | --------- | ----------------------------------------------- |
+| `items`     | `DropdownMenuItem[]`  | -         | **必填**，菜单项数据数组                        |
+| `show`      | `boolean`             | -         | 是否显示菜单（仅在 trigger 为 'manual' 时有效） |
+| `trigger`   | `'click' \| 'manual'` | `'click'` | 触发方式                                        |
+| `minWidth`  | `string \| number`    | -         | 下拉菜单最小宽度                                |
+| `topOffset` | `string \| number`    | -         | 下拉菜单顶部偏移量                              |
 
 ### Slots
 
@@ -36,9 +38,10 @@ outline: deep
 
 下拉菜单事件定义。
 
-| 事件名       | 参数                     | 说明             |
-| ------------ | ------------------------ | ---------------- |
-| `item-click` | `item: DropdownMenuItem` | 点击菜单项时触发 |
+| 事件名          | 参数                     | 说明                   |
+| --------------- | ------------------------ | ---------------------- |
+| `item-click`    | `item: DropdownMenuItem` | 点击菜单项时触发       |
+| `click-outside` | `event: MouseEvent`      | 点击菜单外部区域时触发 |
 
 ### Types
 

--- a/docs/src/components/suggestion-popover.md
+++ b/docs/src/components/suggestion-popover.md
@@ -40,19 +40,19 @@ outline: deep
 
 弹出框属性配置。
 
-| 属性                   | 类型                             | 默认值    | 说明                                                           |
-| ---------------------- | -------------------------------- | --------- | -------------------------------------------------------------- |
-| `data`                 | `SuggestionData`                 | -         | **必填**，建议数据                                             |
-| `title`                | `string`                         | -         | 弹出框标题                                                     |
-| `icon`                 | `VNode \| Component`             | -         | 标题图标                                                       |
-| `show`                 | `boolean`                        | -         | 控制弹出框显示/隐藏，仅在 trigger 为 'manual' 时有效 |
-| `trigger`              | `'click' \| 'manual'` | `'click'` | 触发方式：点击或手动控制                                 |
-| `selectedGroup`        | `string`                         | -         | 当前选中分组 (v-model)                                         |
-| `groupShowMoreTrigger` | `'click' \| 'hover'`             | -         | 分组"显示更多"的触发方式                                       |
-| `loading`              | `boolean`                        | `false`   | 是否显示加载状态                                               |
-| `popoverWidth`         | `string \| number`               | -         | 弹出框宽度                                                     |
-| `popoverHeight`        | `string \| number`               | -         | 弹出框高度                                                     |
-| `topOffset`            | `string \| number`               | -         | 顶部偏移量                                                     |
+| 属性                   | 类型                  | 默认值    | 说明                                                 |
+| ---------------------- | --------------------- | --------- | ---------------------------------------------------- |
+| `data`                 | `SuggestionData`      | -         | **必填**，建议数据                                   |
+| `title`                | `string`              | -         | 弹出框标题                                           |
+| `icon`                 | `VNode \| Component`  | -         | 标题图标                                             |
+| `show`                 | `boolean`             | -         | 控制弹出框显示/隐藏，仅在 trigger 为 'manual' 时有效 |
+| `trigger`              | `'click' \| 'manual'` | `'click'` | 触发方式：点击或手动控制                             |
+| `selectedGroup`        | `string`              | -         | 当前选中分组 (v-model)                               |
+| `groupShowMoreTrigger` | `'click' \| 'hover'`  | -         | 分组"显示更多"的触发方式                             |
+| `loading`              | `boolean`             | `false`   | 是否显示加载状态                                     |
+| `popoverWidth`         | `string \| number`    | -         | 弹出框宽度                                           |
+| `popoverHeight`        | `string \| number`    | -         | 弹出框高度                                           |
+| `topOffset`            | `string \| number`    | -         | 顶部偏移量                                           |
 
 ### Slots
 
@@ -68,12 +68,13 @@ outline: deep
 
 弹出框事件定义。
 
-| 事件名        | 参数                     | 说明             |
-| ------------- | ------------------------ | ---------------- |
-| `item-click`  | `item: SuggestionItem`   | 点击建议项时触发 |
-| `group-click` | `group: SuggestionGroup` | 点击分组时触发   |
-| `open`       | -                        | 弹窗打开时触发   |
-| `close`       | -                        | 弹窗关闭时触发   |
+| 事件名          | 参数                     | 说明                   |
+| --------------- | ------------------------ | ---------------------- |
+| `item-click`    | `item: SuggestionItem`   | 点击建议项时触发       |
+| `group-click`   | `group: SuggestionGroup` | 点击分组时触发         |
+| `open`          | -                        | 弹窗打开时触发         |
+| `close`         | -                        | 弹窗关闭时触发         |
+| `click-outside` | `event: MouseEvent`      | 点击弹窗外部区域时触发 |
 
 ### Types
 

--- a/packages/components/src/dropdown-menu/index.type.ts
+++ b/packages/components/src/dropdown-menu/index.type.ts
@@ -5,6 +5,14 @@ export interface DropdownMenuItem {
 
 export interface DropdownMenuProps {
   items: DropdownMenuItem[]
+  /**
+   * 是否显示菜单，仅在 trigger 为 'manual' 时有效
+   */
+  show?: boolean
+  /**
+   * 触发方式。默认值为 'click'
+   */
+  trigger?: 'click' | 'manual'
   // 下面是样式相关的属性
   minWidth?: string | number
   topOffset?: string | number
@@ -16,8 +24,10 @@ export interface DropdownMenuSlots {
 
 export interface DropdownMenuEmits {
   (e: 'item-click', item: DropdownMenuItem): void
+  (e: 'click-outside', event: MouseEvent): void
 }
 
 export interface DropdownMenuEvents {
   itemClick?: (item: DropdownMenuItem) => void
+  clickOutside?: (event: MouseEvent) => void
 }

--- a/packages/components/src/dropdown-menu/index.vue
+++ b/packages/components/src/dropdown-menu/index.vue
@@ -5,6 +5,7 @@ import { toCssUnit } from '../shared/utils'
 import { DropdownMenuEmits, DropdownMenuItem, DropdownMenuProps, DropdownMenuSlots } from './index.type'
 
 const props = withDefaults(defineProps<DropdownMenuProps>(), {
+  trigger: 'click',
   topOffset: 0,
   minWidth: 160,
 })
@@ -12,7 +13,23 @@ const props = withDefaults(defineProps<DropdownMenuProps>(), {
 const attrs = useAttrs()
 const attrsStyle = computed(() => attrs.style as StyleValue)
 
-const show = ref(false)
+const showRef = ref(false)
+
+// 如果 trigger 是 manual，则 show 由外部控制，此时组件内部无法修改 show 的值
+const show = computed({
+  get: () => {
+    if (props.trigger === 'manual') {
+      return props.show
+    }
+    return showRef.value
+  },
+  set: (newValue) => {
+    if (props.trigger === 'manual') {
+      return
+    }
+    showRef.value = newValue
+  },
+})
 
 defineSlots<DropdownMenuSlots>()
 
@@ -32,11 +49,15 @@ const dropdownStyles = computed<CSSProperties>(() => {
 })
 
 onClickOutside(dropdownMenuRef, (ev) => {
-  // 如果在外部点到了 trigger，则停止冒泡，防止 triger 被点击然后触发菜单再次开启
-  if (dropDownTriggerRef.value?.contains(ev.target as Node)) {
-    ev.stopPropagation()
+  emit('click-outside', ev)
+
+  if (props.trigger === 'click') {
+    // 如果在外部点到了 trigger，则停止冒泡，防止 triger 被点击然后触发菜单再次开启
+    if (dropDownTriggerRef.value?.contains(ev.target as Node)) {
+      ev.stopPropagation()
+    }
+    show.value = false
   }
-  show.value = false
 })
 
 watch(show, (value) => {

--- a/packages/components/src/dropdown-menu/index.vue
+++ b/packages/components/src/dropdown-menu/index.vue
@@ -61,7 +61,7 @@ const handleItemClick = (item: DropdownMenuItem) => {
     :class="attrs.class"
     :style="attrsStyle"
     ref="dropDownTriggerRef"
-    @click="handleToggleShow"
+    @pointerup="handleToggleShow"
   >
     <slot />
   </div>

--- a/packages/components/src/suggestion-pills/components/PillButtonWrapper.vue
+++ b/packages/components/src/suggestion-pills/components/PillButtonWrapper.vue
@@ -20,7 +20,7 @@ const emit = defineEmits<{
     @group-click="item.action.events?.groupClick"
     @close="item.action.events?.close"
   >
-    <PillButton :item="item" @click="emit('click', $event, item)"></PillButton>
+    <PillButton :item="item" @pointerup="emit('click', $event, item)"></PillButton>
     <template v-for="(slotVNode, slotName) in item.action.slots" :key="slotName" #[slotName]>
       <component :is="slotVNode" />
     </template>
@@ -31,7 +31,7 @@ const emit = defineEmits<{
     v-bind="item.action.props"
     @item-click="item.action.events?.itemClick"
   >
-    <PillButton :item="item" @click="emit('click', $event, item)"></PillButton>
+    <PillButton :item="item" @pointerup="emit('click', $event, item)"></PillButton>
   </DropdownMenu>
-  <PillButton v-else :item="item" :style="style" @click="emit('click', $event, item)"></PillButton>
+  <PillButton v-else :item="item" :style="style" @pointerup="emit('click', $event, item)"></PillButton>
 </template>

--- a/packages/components/src/suggestion-popover/index.type.ts
+++ b/packages/components/src/suggestion-popover/index.type.ts
@@ -51,10 +51,13 @@ export interface SuggestionPopoverEmits {
   (e: 'group-click', group: SuggestionGroup): void
   (e: 'open'): void
   (e: 'close'): void
+  (e: 'click-outside', event: MouseEvent): void
 }
 
 export interface SuggestionPopoverEvents {
   itemClick?: (item: SuggestionItem) => void
   groupClick?: (group: SuggestionGroup) => void
+  open?: () => void
   close?: () => void
+  clickOutside?: (event: MouseEvent) => void
 }

--- a/packages/components/src/suggestion-popover/index.vue
+++ b/packages/components/src/suggestion-popover/index.vue
@@ -212,7 +212,7 @@ const handleItemMouseleave = (event: MouseEvent) => {
     :class="attrs.class"
     :style="attrsStyle"
     ref="popoverTriggerRef"
-    @click="handleToggleShow"
+    @pointerup="handleToggleShow"
   >
     <slot />
   </div>
@@ -280,6 +280,7 @@ const handleItemMouseleave = (event: MouseEvent) => {
   position: fixed;
   z-index: var(--tr-z-index-popover);
   height: v-bind('toCssUnit(props.popoverHeight)');
+  max-height: 100dvh;
   padding: 20px;
   padding-bottom: 16px;
   border-radius: 24px;

--- a/packages/components/src/suggestion-popover/index.vue
+++ b/packages/components/src/suggestion-popover/index.vue
@@ -147,16 +147,18 @@ const popoverStyles = computed<CSSProperties>(() => {
   }
 })
 
-if (props.trigger === 'click') {
-  onClickOutside(popoverRef, (ev) => {
+onClickOutside(popoverRef, (ev) => {
+  emit('click-outside', ev)
+
+  if (props.trigger === 'click') {
     // 如果在外部点到了 trigger，则停止冒泡，防止 triger 被点击然后触发菜单再次开启
     if (popoverTriggerRef.value?.contains(ev.target as Node)) {
       ev.stopPropagation()
     }
     show.value = false
     emit('close')
-  })
-}
+  }
+})
 
 watch(show, (value) => {
   if (value) {


### PR DESCRIPTION
TODO 后面移动端要移除当hover才显示的可交互元素
临时方案：
- Changed event listeners from `@click` to `@pointerup` in DropdownMenu and PillButtonWrapper components for improved responsiveness.
- Added `max-height` style to suggestion popover for better layout control.

在 iOS 移动端，:hover 的确会干扰首次点击事件，导致用户需要点击两次才能触发 click —— 第一次触发 :hover，第二次才触发事件。这是因为：

iOS Safari 模拟了 :hover 行为，即使是在触屏设备上。


事件类型 | 支持的输入方式 | 特点
-- | -- | --
click | 鼠标、部分触摸 | 有延迟（移动端通常有 300ms 延迟）
touchend | 触摸 | 仅适用于触摸设备
pointerup | 鼠标、触摸、笔输入 | ✅ 推荐，统一事件模型，无需区分设备类型

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Popover containers now have a maximum height limited to the viewport for improved display on various devices.

- **Style**
  - Updated popover styling to enhance usability with dynamic viewport units.

- **Refactor**
  - Changed dropdown menu, suggestion pill, and popover triggers to respond to pointer release actions instead of clicks for more consistent user interaction across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->