### PR TITLE
refactor: simplify slot handling in base-popper component

### DIFF
--- a/packages/components/src/base-popper/index.vue
+++ b/packages/components/src/base-popper/index.vue
@@ -1,18 +1,8 @@
 <!-- eslint-disable @typescript-eslint/no-explicit-any -->
 <script setup lang="ts">
-import { MaybeElement, useElementBounding, useElementSize } from '@vueuse/core'
-import {
-  ComponentPublicInstance,
-  computed,
-  CSSProperties,
-  Fragment,
-  nextTick,
-  ref,
-  TransitionProps,
-  VNode,
-  watch,
-} from 'vue'
-import { useTeleportTarget } from '../shared/composables'
+import { useElementBounding, useElementSize } from '@vueuse/core'
+import { computed, CSSProperties, isVNode, ref, TransitionProps, VNode, watch } from 'vue'
+import { useSlotRefs, useTeleportTarget } from '../shared/composables'
 import { toCssUnit } from '../shared/utils'
 
 defineOptions({
@@ -37,50 +27,16 @@ const props = withDefaults(
 )
 
 const slots = defineSlots<{
-  trigger?: () => VNode | VNode[]
-  content?: () => VNode | VNode[]
+  trigger?: () => VNode[]
+  content?: () => VNode[]
 }>()
 
-const triggerVNodes = computed(() => {
-  const triggerSlot = slots.trigger?.()
-  const vnodes = triggerSlot ? (Array.isArray(triggerSlot) ? triggerSlot : [triggerSlot]) : []
-
-  // 如果第一个 vnode 是 Fragment 类型，并且 children 是数组，则返回 children（只渲染第一个 v-for Fragment）
-  if (vnodes[0].type === Fragment && Array.isArray(vnodes[0].children)) {
-    return vnodes[0].children
-  }
-
-  return vnodes
-})
-const triggerLength = computed(() => (props.renderAllTriggers ? triggerVNodes.value.length : 1))
-const renderedTriggerVNodes = computed(() => triggerVNodes.value.slice(0, triggerLength.value))
-
-const triggerRefs = ref<MaybeElement[]>([])
-const triggerRef = computed(() => triggerRefs.value.at(0))
-
-const getRef = (el: unknown) => {
-  if ((el as ComponentPublicInstance)?.$el) {
-    // Vue 组件实例
-    return el as ComponentPublicInstance
-  } else if (el instanceof HTMLElement || el instanceof SVGElement) {
-    // 原生 HTMLElement 或者 SVGElement
-    return el
-  }
-  console.warn('trigger must be an HTMLElement or SVGElement or Vue component instance')
-  return null
-}
-
-const setRefs = (el: unknown, index: number) => {
-  triggerRefs.value[index] = getRef(el)
-}
-
-watch(
-  triggerLength,
-  (len) => {
-    triggerRefs.value.length = len
-  },
-  { flush: 'post' },
-)
+const {
+  vnodes: triggerVNodes,
+  refs: triggerRefs,
+  ref: triggerRef,
+  setRefs,
+} = useSlotRefs(slots.trigger, props.renderAllTriggers)
 
 function createIndexedEventHandlers(events: TriggerEvents = {}, index: number) {
   const wrapped: TriggerEvents = {}
@@ -95,7 +51,7 @@ function createIndexedEventHandlers(events: TriggerEvents = {}, index: number) {
 }
 
 const indexedEventHandlers = computed(() =>
-  renderedTriggerVNodes.value.map((_, index) => createIndexedEventHandlers(props.triggerEvents, index)),
+  triggerVNodes.value.map((_, index) => createIndexedEventHandlers(props.triggerEvents, index)),
 )
 
 const popperRef = ref<HTMLDivElement | null>(null)
@@ -154,11 +110,10 @@ watch(
   () => props.show,
   (value) => {
     if (value) {
-      nextTick(() => {
-        update()
-      })
+      update()
     }
   },
+  { flush: 'post' },
 )
 
 const teleportTarget = useTeleportTarget(triggerRef)
@@ -172,8 +127,8 @@ defineExpose({
 
 <template>
   <component
-    v-for="(vnode, index) in renderedTriggerVNodes"
-    :key="(vnode as VNode).key ?? index"
+    v-for="(vnode, index) in triggerVNodes"
+    :key="isVNode(vnode) ? vnode.key : index"
     :is="vnode"
     :ref="(el: unknown) => setRefs(el, index)"
     v-bind="indexedEventHandlers[index]"

--- a/packages/components/src/shared/composables/index.ts
+++ b/packages/components/src/shared/composables/index.ts
@@ -1,1 +1,2 @@
+export * from './useSlotRefs'
 export * from './useTeleportTarget'

--- a/packages/components/src/shared/composables/useSlotRefs.ts
+++ b/packages/components/src/shared/composables/useSlotRefs.ts
@@ -6,11 +6,10 @@ export function useSlotRefs(slot?: (...args: any[]) => VNode[], renderAll?: bool
   const vnodes = computed(() => {
     const nodes = slot?.() || []
 
-    // TODO 支持多个 Fragment 的情况
-    // 如果第一个 vnode 是 Fragment 类型，并且 children 是数组，则返回 children（只渲染第一个 v-for Fragment）
-    const firstNode = nodes.at(0)
-    if (firstNode?.type === Fragment && Array.isArray(firstNode.children)) {
-      return firstNode.children
+    // 如果 vnodes 中存在 Fragment 类型，并且 children 是数组，则返回 children。只渲染第一个是 Fragment 的节点
+    const fragmentNode = nodes.find((node) => node.type === Fragment)
+    if (fragmentNode && Array.isArray(fragmentNode.children)) {
+      return fragmentNode.children
     }
 
     return nodes
@@ -22,14 +21,14 @@ export function useSlotRefs(slot?: (...args: any[]) => VNode[], renderAll?: bool
   const refs = ref<MaybeElement[]>([])
 
   const resolveRef = (el: unknown) => {
-    if ((el as ComponentPublicInstance)?.$el) {
+    if (el && typeof el === 'object' && '$el' in el) {
       // Vue 组件实例
       return el as ComponentPublicInstance
     } else if (el instanceof HTMLElement || el instanceof SVGElement) {
       // 原生 HTMLElement 或者 SVGElement
       return el
     }
-    console.warn('trigger must be an HTMLElement or SVGElement or Vue component instance')
+    console.warn('el must be an HTMLElement or SVGElement or Vue component instance. el:', el)
     return null
   }
 

--- a/packages/components/src/shared/composables/useSlotRefs.ts
+++ b/packages/components/src/shared/composables/useSlotRefs.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { MaybeElement } from '@vueuse/core'
+import { ComponentPublicInstance, computed, Fragment, ref, VNode, watch } from 'vue'
+
+export function useSlotRefs(slot?: (...args: any[]) => VNode[], renderAll?: boolean) {
+  const vnodes = computed(() => {
+    const nodes = slot?.() || []
+
+    // TODO 支持多个 Fragment 的情况
+    // 如果第一个 vnode 是 Fragment 类型，并且 children 是数组，则返回 children（只渲染第一个 v-for Fragment）
+    const firstNode = nodes.at(0)
+    if (firstNode?.type === Fragment && Array.isArray(firstNode.children)) {
+      return firstNode.children
+    }
+
+    return nodes
+  })
+
+  const length = computed(() => (renderAll ? vnodes.value.length : 1))
+  const renderedVNodes = computed(() => vnodes.value.slice(0, length.value))
+
+  const refs = ref<MaybeElement[]>([])
+
+  const resolveRef = (el: unknown) => {
+    if ((el as ComponentPublicInstance)?.$el) {
+      // Vue 组件实例
+      return el as ComponentPublicInstance
+    } else if (el instanceof HTMLElement || el instanceof SVGElement) {
+      // 原生 HTMLElement 或者 SVGElement
+      return el
+    }
+    console.warn('trigger must be an HTMLElement or SVGElement or Vue component instance')
+    return null
+  }
+
+  const setRef = (el: unknown) => {
+    refs.value[0] = resolveRef(el)
+  }
+
+  const setRefs = (el: unknown, index: number) => {
+    refs.value[index] = resolveRef(el)
+  }
+
+  watch(
+    length,
+    (len) => {
+      refs.value.length = len
+    },
+    { flush: 'post' },
+  )
+
+  return {
+    vnodes: renderedVNodes,
+    ref: computed(() => refs.value.at(0)),
+    refs,
+    setRef,
+    setRefs,
+  }
+}


### PR DESCRIPTION
- Removed unnecessary complexity in trigger VNode management by introducing a new `useSlotRefs` composable.
- Updated the base-popper component to utilize the new composable for better readability and maintainability.
- Enhanced the handling of trigger VNodes and their references, improving overall performance and clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new utility to manage references for slot content, improving how slot elements are handled within components.

* **Refactor**
  * Simplified internal logic for managing trigger elements and their references, resulting in cleaner and more maintainable components.

* **Chores**
  * Updated shared composables to export new utilities for broader use across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->