### PR TITLE
fix: submit shortcut triggers newline

### DIFF
--- a/docs/demos/suggestion/All.vue
+++ b/docs/demos/suggestion/All.vue
@@ -27,7 +27,6 @@
             :placeholder="placeholder"
             :clearable="true"
             mode="multiple"
-            :has-content="hasContent"
             @submit="handleSubmit"
             @keydown="(e) => handleKeyDown(e, onTrigger, onKeyDown)"
             @update:modelValue="updateInputValue"
@@ -53,7 +52,7 @@
 
 <script setup lang="ts">
 import { TrSender, TrSuggestion } from '@opentiny/tiny-robot'
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { nextTick, onMounted, ref, watch } from 'vue'
 import { templateCategories, templateSuggestions } from './templateData'
 
 // 状态管理
@@ -66,15 +65,6 @@ const senderRef = ref<any>(null)
 const loading = ref(false)
 const placeholder = ref('输入 / 打开指令菜单...')
 const messages = ref<string[]>([])
-
-// 计算属性：判断是否有内容
-const hasContent = computed(() => {
-  // 当处于指令编辑模式且输入内容不为空时，视为有内容
-  if (currentTemplate.value) {
-    return inputText.value.trim().length > 0
-  }
-  return inputText.value.trim().length > 0
-})
 
 // 更新输入值
 const updateInputValue = (value) => {

--- a/packages/components/src/sender/composables/useKeyboardHandler.ts
+++ b/packages/components/src/sender/composables/useKeyboardHandler.ts
@@ -178,10 +178,14 @@ export function useKeyboardHandler(
     // 检查是否匹配当前的提交快捷键
     const shouldSubmit = checkSubmitShortcut(event, props.submitType as SubmitTrigger)
 
-    // 只有当满足提交条件且输入框有内容时才提交
-    if (shouldSubmit && validateSubmission(inputValue.value)) {
+    if (shouldSubmit) {
+      // 只要是提交快捷键，就阻止默认行为（比如换行）
       event.preventDefault()
-      triggerSubmit()
+
+      // 如果验证通过，则执行提交
+      if (validateSubmission(inputValue.value)) {
+        triggerSubmit()
+      }
     }
   }
 

--- a/packages/components/src/sender/composables/useKeyboardHandler.ts
+++ b/packages/components/src/sender/composables/useKeyboardHandler.ts
@@ -16,7 +16,7 @@ import type { SenderProps, SenderEmits, SpeechState, SubmitTrigger } from '../in
  * @param closeSuggestionsPopup - 关闭建议弹窗的函数
  * @param navigateSuggestions - 导航建议列表的函数
  * @param toggleSpeech - 切换语音识别函数
- * @param isOverLimit - 是否超出字数限制
+ * @param canSubmit - 是否可以提交
  * @param currentMode - 当前输入模式
  * @param setMultipleMode - 设置为多行模式的回调函数
  * @param isTemplateMode - 是否处于模板编辑模式
@@ -34,42 +34,17 @@ export function useKeyboardHandler(
   closeSuggestionsPopup: (keepFocus?: boolean) => void,
   navigateSuggestions: (direction: 'up' | 'down') => void,
   toggleSpeech: () => void,
-  isOverLimit: Ref<boolean>,
+  canSubmit: ComputedRef<boolean>,
   currentMode?: Ref<'single' | 'multiple'>,
   setMultipleMode?: () => void,
   isTemplateMode?: ComputedRef<boolean>,
   exitTemplateMode?: () => void,
 ) {
   /**
-   * 验证提交条件
-   * @param value 输入值
-   * @returns 是否可以提交
-   */
-  const validateSubmission = (value: string): boolean => {
-    // 基础状态检查：禁用或加载中时不能提交
-    if (props.disabled || props.loading) {
-      return false
-    }
-
-    // 内容检查：空内容不能提交
-    const trimmedValue = value.trim()
-    if (trimmedValue.length === 0) {
-      return false
-    }
-
-    // 字数限制检查：超出限制时不能提交
-    if (isOverLimit.value) {
-      return false
-    }
-
-    return true
-  }
-
-  /**
    * 触发提交
    */
   const triggerSubmit = () => {
-    if (!validateSubmission(inputValue.value)) return
+    if (!canSubmit.value) return
 
     if (isTemplateMode?.value) {
       exitTemplateMode?.()
@@ -183,7 +158,7 @@ export function useKeyboardHandler(
       event.preventDefault()
 
       // 如果验证通过，则执行提交
-      if (validateSubmission(inputValue.value)) {
+      if (canSubmit.value) {
         triggerSubmit()
       }
     }

--- a/packages/components/src/sender/composables/useSuggestionHandler.ts
+++ b/packages/components/src/sender/composables/useSuggestionHandler.ts
@@ -1,4 +1,4 @@
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick, ComputedRef } from 'vue'
 import type { SenderProps, SenderEmits } from '../index.type'
 
 /**
@@ -92,12 +92,14 @@ const highlightSuggestionText = (suggestionText: string, inputText: string) => {
  * @param emit - 组件方法
  * @param inputValue - 输入值
  * @param isComposing - 是否处于输入法组合状态
+ * @param showTemplateEditor - 是否显示模板编辑器
  */
 export function useSuggestionHandler(
   props: SenderProps,
   emit: SenderEmits,
   inputValue: ReturnType<typeof ref<string>>,
   isComposing: ReturnType<typeof ref<boolean>>,
+  showTemplateEditor: ComputedRef<boolean>,
 ) {
   // 状态变量
   /**
@@ -145,7 +147,7 @@ export function useSuggestionHandler(
    * 基于当前输入过滤出匹配的建议项
    */
   const filteredSuggestions = computed(() => {
-    if (!props.suggestions || !inputValue.value || props.template) return []
+    if (!props.suggestions || !inputValue.value || showTemplateEditor.value) return []
     const lowerInputValue = inputValue.value.toLowerCase()
     return props.suggestions.filter((item) => item.toLowerCase().includes(lowerInputValue))
   })
@@ -235,7 +237,7 @@ export function useSuggestionHandler(
         inputValue.value &&
         props.suggestions &&
         props.suggestions.length > 0 &&
-        !props.template &&
+        !showTemplateEditor.value &&
         filteredSuggestions.value.length > 0
 
       if (shouldShowSuggestions) {

--- a/packages/components/src/sender/index.type.ts
+++ b/packages/components/src/sender/index.type.ts
@@ -44,7 +44,6 @@ export interface SenderProps {
   suggestions?: string[] // 输入建议
   suggestionPopupWidth?: string | number // 联想建议弹窗宽度，如 '300px' 或 300
   theme?: ThemeType // 主题
-  template?: string // 模板字符串，格式如 "你好 [称呼]，感谢您的 [事项]"
   templateData?: UserItem[] // 模板数据
   stopText?: string // 停止按钮文字，不传则只显示图标
 }

--- a/packages/components/src/sender/index.type.ts
+++ b/packages/components/src/sender/index.type.ts
@@ -45,7 +45,6 @@ export interface SenderProps {
   suggestionPopupWidth?: string | number // 联想建议弹窗宽度，如 '300px' 或 300
   theme?: ThemeType // 主题
   template?: string // 模板字符串，格式如 "你好 [称呼]，感谢您的 [事项]"
-  hasContent?: boolean // 手动指定是否有内容，用于模板模式
   templateData?: UserItem[] // 模板数据
   stopText?: string // 停止按钮文字，不传则只显示图标
 }

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -27,7 +27,6 @@ const props = withDefaults(defineProps<SenderProps>(), {
   showWordLimit: false,
   submitType: 'enter',
   theme: 'light',
-  hasContent: undefined,
   template: '',
   templateData: () => [],
   suggestions: () => [],
@@ -382,7 +381,7 @@ const hasDecorativeContent = computed(() => !!slots.decorativeContent)
 // 状态计算
 const isDisabled = computed((): boolean => props.disabled || hasDecorativeContent.value)
 const isLoading = computed(() => props.loading)
-const hasContent = computed(() => (props.hasContent !== undefined ? props.hasContent : !!inputValue.value))
+const hasContent = computed(() => !!inputValue.value.trim())
 
 // 样式类
 const senderClasses = computed(() => ({

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -338,7 +338,7 @@ const { handleKeyPress, triggerSubmit }: KeyboardHandler = useKeyboardHandler(
 const handleFocus = (event: FocusEvent) => {
   emit('focus', event)
   // 当有输入内容且有匹配的联想项时，显示联想弹窗但不自动选中任何项
-  if (inputValue.value && filteredSuggestions.value.length > 0) {
+  if (inputValue.value && filteredSuggestions.value.length > 0 && !showTemplateEditor.value) {
     showSuggestionsPopup.value = true
     showTabHint.value = true
   }

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -48,6 +48,28 @@ const showTemplateEditor = computed(() => props.templateData && props.templateDa
 // 输入控制
 const { inputValue, isComposing, clearInput: originalClearInput }: InputHandler = useInputHandler(props, emit)
 
+const hasContent = computed(() => !!inputValue.value.trim())
+
+// 统一的提交条件验证
+const canSubmit = computed(() => {
+  // 基础状态检查：禁用或加载中时不能提交
+  if (props.disabled || props.loading) {
+    return false
+  }
+
+  // 内容检查：空内容不能提交
+  if (!hasContent.value) {
+    return false
+  }
+
+  // 字数限制检查：超出限制时不能提交
+  if (isOverLimit.value) {
+    return false
+  }
+
+  return true
+})
+
 // 建议处理
 const {
   showSuggestionsPopup,
@@ -327,7 +349,7 @@ const { handleKeyPress, triggerSubmit }: KeyboardHandler = useKeyboardHandler(
   closeSuggestionsPopup,
   navigateSuggestions,
   toggleSpeech,
-  isOverLimit,
+  canSubmit,
   currentMode,
   setMultipleMode,
   showTemplateEditor,
@@ -380,7 +402,6 @@ const hasDecorativeContent = computed(() => !!slots.decorativeContent)
 // 状态计算
 const isDisabled = computed((): boolean => props.disabled || hasDecorativeContent.value)
 const isLoading = computed(() => props.loading)
-const hasContent = computed(() => !!inputValue.value.trim())
 
 // 样式类
 const senderClasses = computed(() => ({

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -27,7 +27,6 @@ const props = withDefaults(defineProps<SenderProps>(), {
   showWordLimit: false,
   submitType: 'enter',
   theme: 'light',
-  template: '',
   templateData: () => [],
   suggestions: () => [],
   suggestionPopupWidth: 400,
@@ -66,7 +65,7 @@ const {
   handleSuggestionItemHover,
   handleSuggestionItemLeave,
   highlightSuggestionText,
-} = useSuggestionHandler(props, emit, inputValue, isComposing)
+} = useSuggestionHandler(props, emit, inputValue, isComposing, showTemplateEditor)
 
 // 自动模式切换
 const currentMode = ref(props.mode)
@@ -339,7 +338,7 @@ const { handleKeyPress, triggerSubmit }: KeyboardHandler = useKeyboardHandler(
 const handleFocus = (event: FocusEvent) => {
   emit('focus', event)
   // 当有输入内容且有匹配的联想项时，显示联想弹窗但不自动选中任何项
-  if (inputValue.value && filteredSuggestions.value.length > 0 && !props.template) {
+  if (inputValue.value && filteredSuggestions.value.length > 0) {
     showSuggestionsPopup.value = true
     showTabHint.value = true
   }


### PR DESCRIPTION
一、 输入框无有效内容时禁止发送

**当前问题**

多行模式下，当不满足提交条件时，使用快捷键 `enter` 会触发编辑器的默认换行行为

**预期行为**

多行模式下，当不满足提交条件时， 避免触发快捷键 enter 的换行行为

二、移除无效的 `template` prop,  更新相关用法

三、场景截图

1. 无内容（未输入内容时）

![image](https://github.com/user-attachments/assets/1f5df6c6-b787-42a2-9ee0-d9ff2586df66)

2. 有效内容（输入文本时）

![image](https://github.com/user-attachments/assets/2857ec69-0bf0-4ec6-b559-f7914e54d0a1)


3. 无效内容（只输入空格，不显示发送按钮 且 无法通过快捷键发送）
![image](https://github.com/user-attachments/assets/b1747411-c719-4fdd-ab88-e18d9a7da415)


4. 字数超出限制（发送按钮禁用、发送内容不截断 且 无法点击发送按钮或通过快捷键发送）

![image](https://github.com/user-attachments/assets/377c6595-7a2f-41c8-a694-5f7144d98d0f)

