### PR TITLE
fix: docs site navbar style issue

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -5,3 +5,8 @@
 .vitepress-demo-plugin__container li + li {
   margin: 0;
 }
+
+.VPNav .container {
+  width: unset;
+  padding: unset;
+}


### PR DESCRIPTION
修复文档页面顶部菜单栏样式问题

原因：
被TinyVue container类样式污染

修改前：
<img width="2318" height="432" alt="image" src="https://github.com/user-attachments/assets/9b97998a-372c-4e7a-b285-4d7fb984fe57" />

修改效果：
<img width="2246" height="542" alt="image" src="https://github.com/user-attachments/assets/718decdd-e58b-4ec1-a46d-886b2aa9a951" />
