### PR TITLE
chore: support publish alpha/beta/rc/latest tag version

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -56,9 +56,39 @@ jobs:
       - name: Run Build Components
         run: pnpm build
 
+      - name: Parse Publish tag
+        id: parse_tag
+        run: |
+          tag_name="${GITHUB_REF#refs/tags/}"
+          if [[ "$tag_name" == *alpha* ]]; then
+            echo "dist_tag=alpha" >> "$GITHUB_OUTPUT"
+          elif [[ "$tag_name" == *beta* ]]; then
+            echo "dist_tag=beta" >> "$GITHUB_OUTPUT"
+          elif [[ "$tag_name" == *rc* ]]; then
+            echo "dist_tag=rc" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify clean working directory
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "Working directory is not clean"
+            exit 1
+          fi
+
+      - name: Verify package version match tag
+        run: |
+          tag_name="${GITHUB_REF#refs/tags/}"
+          package_version=$(pnpm lerna list --scope=@opentiny/tiny-robot --json | jq -r '.[0].version')
+          if [[ "$tag_name" != "v$package_version" ]]; then
+            echo "Tag name $tag_name does not match package version $package_version"
+            exit 1
+          fi
+
       # 步骤8: 发布组件到NPM
       - name: Publish components
-        run: pnpm lerna publish from-package --pre-dist-tag latest --yes
+        run: pnpm lerna publish from-package --pre-dist-tag ${{steps.parse_tag.outputs.dist_tag}} --yes
         env:
           # 使用NPM令牌进行身份验证
           NODE_AUTH_TOKEN: ${{ secrets.NPM_OPENTINY_ROBOT_TOKEN }}
@@ -84,7 +114,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/dist
-          destination_dir: ./latest/
+          destination_dir: ./${{steps.parse_tag.outputs.dist_tag}}/
           keep_files: true
           force_orphan: false
           user_name: 'github-actions[bot]'

--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -15,6 +15,7 @@ on:
         options:
           - alpha
           - beta
+          - rc
           - latest
 
 concurrency:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved publishing workflow to automatically determine and use the correct distribution tag (e.g., alpha, beta, rc, or latest) based on the Git tag.
  * Added validation to ensure the Git working directory is clean and the tag version matches the package version before publishing.
  * Documentation deployment now targets a directory named after the distribution tag.
  * Expanded manual publish workflow options to include "rc" as a selectable release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->