### PR TITLE
chore: fix publish action error

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -104,7 +104,7 @@ jobs:
 
       # 步骤10: 发布文档到GitHub Pages
       - name: Build VitePress
-        run: pnpm -F docs build --base=/tiny-robot/latest/
+        run: pnpm -F docs build --base=/tiny-robot/${{steps.parse_tag.outputs.dist_tag}}/
 
       - name: Verify build output
         run: ls -la ./docs/dist


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build process so the base URL now reflects the current distribution tag (e.g., alpha, beta, rc, latest) instead of always using "latest". This ensures documentation URLs match the published version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->