### PR TITLE
chore: only latest publish release note

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -95,6 +95,7 @@ jobs:
 
       # 步骤9: 发布组件到GitHub Release
       - name: Release
+        if: ${{ steps.parse_tag.outputs.dist_tag == 'latest' }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to only publish a GitHub Release when the tag is marked as "latest". Releases will be skipped for "alpha", "beta", or "rc" tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->