### PR TITLE
refactor: improve popper component responsiveness and update demos

### DIFF
--- a/docs/demos/suggestion/pills-popper.vue
+++ b/docs/demos/suggestion/pills-popper.vue
@@ -21,7 +21,7 @@
         :items="dropdownMenuItems"
         @item-click="handleDropdownMenuItemClick"
         :key="index"
-        v-model:show="hoverShowModels[index]"
+        v-model:show="dropdownShowModels[index]"
         trigger="click"
       >
         <template #trigger>
@@ -97,13 +97,21 @@ const dropdownMenuItems = ref([
 ])
 
 const handleClickOutside = (event: MouseEvent) => {
-  if (event.composedPath().includes(showAllRef.value?.$el)) {
+  dropdownShowModels.value.forEach((_, index) => {
+    dropdownShowModels.value[index] = false
+  })
+
+  const composedPath = event.composedPath()
+  if (composedPath.some((el) => el instanceof HTMLElement && el.matches('ul.tr-dropdown-menu__list'))) {
     return
   }
-  if (addButtonRef.value && event.composedPath().includes(addButtonRef.value)) {
+  if (composedPath.includes(showAllRef.value?.$el)) {
     return
   }
-  if (removeButtonRef.value && event.composedPath().includes(removeButtonRef.value)) {
+  if (addButtonRef.value && composedPath.includes(addButtonRef.value)) {
+    return
+  }
+  if (removeButtonRef.value && composedPath.includes(removeButtonRef.value)) {
     return
   }
   showAll.value = false
@@ -139,12 +147,12 @@ const originalButtons = [
 
 const buttons = ref(structuredClone(originalButtons))
 
-const hoverShowModels = ref<boolean[]>([])
+const dropdownShowModels = ref<boolean[]>([])
 
 watch(
   () => buttons.value.length,
   (len) => {
-    hoverShowModels.value = Array.from({ length: len }, () => false)
+    dropdownShowModels.value = Array.from({ length: len }, () => false)
   },
   { immediate: true },
 )
@@ -178,7 +186,7 @@ watch(
           if (!entry.isIntersecting) {
             const index = Number((entry.target as HTMLElement).dataset.index)
             if (typeof index === 'number' && !isNaN(index)) {
-              hoverShowModels.value[index] = false
+              dropdownShowModels.value[index] = false
             }
           }
         })

--- a/packages/components/src/base-popper/components/Popper.vue
+++ b/packages/components/src/base-popper/components/Popper.vue
@@ -1,15 +1,25 @@
 <script setup lang="ts">
-import { TransitionProps } from 'vue'
+import { ref, TransitionProps } from 'vue'
 
 defineProps<{
   show: boolean
   transitionProps?: TransitionProps
 }>()
+
+const popperRef = ref<HTMLDivElement | null>(null)
+
+// 这里需要主动暴露 popperRef 给父组件，原因：
+// 由于 Popper 组件被 Transition 包裹，如果父组件直接使用 ref 绑定，拿到的是一个 VueInstance 实例，然后再 unrefElement 获取 DOM，
+// 可能因为过渡动画而无法同步获取到实际的 DOM 元素。即使获取到了，也可能会是一个 v-if 注释节点。
+// 而暴露的 popperRef 是实际的 DOM 元素，并且是响应式的
+defineExpose({
+  popperRef,
+})
 </script>
 
 <template>
   <Transition v-bind="transitionProps">
-    <div v-if="show" class="tr-base-popper">
+    <div v-if="show" class="tr-base-popper" ref="popperRef">
       <slot />
     </div>
   </Transition>

--- a/packages/components/src/base-popper/index.vue
+++ b/packages/components/src/base-popper/index.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable @typescript-eslint/no-explicit-any -->
 <script setup lang="tsx">
-import { MaybeElement, unrefElement, useElementBounding, useElementSize, VueInstance } from '@vueuse/core'
-import { computed, CSSProperties, nextTick, reactive, ref, TransitionProps, useAttrs, VNode, watch } from 'vue'
+import { useElementBounding, useElementSize } from '@vueuse/core'
+import { computed, CSSProperties, reactive, ref, TransitionProps, useAttrs, VNode, watch } from 'vue'
 import { createTeleport, useSlotRefs, useTeleportTarget } from '../shared/composables'
 import { toCssUnit } from '../shared/utils'
 import Popper from './components/Popper.vue'
@@ -46,16 +46,8 @@ const resolveEventHandlers = (events: TriggerEvents = {}) => {
   return result
 }
 
-const popperRef = ref<Exclude<MaybeElement, VueInstance>>(null)
-const setPopperRef = async (el: unknown) => {
-  await nextTick()
-  const resolvedEl = unrefElement(el as MaybeElement)
-  if (resolvedEl instanceof Element) {
-    popperRef.value = resolvedEl
-  } else {
-    popperRef.value = null
-  }
-}
+const popperInstance = ref<InstanceType<typeof Popper> | null>(null)
+const popperRef = computed(() => popperInstance.value?.popperRef || null)
 
 const resolvedOffset = computed(() => {
   if (typeof props.offset === 'number') {
@@ -124,7 +116,7 @@ const attrs = useAttrs()
 const teleportProps = reactive({ to: props.appendTo || teleportTarget.value })
 createTeleport(teleportProps, () => (
   <Popper
-    ref={setPopperRef}
+    ref={popperInstance}
     show={props.show}
     transitionProps={props.transitionProps}
     style={popperStyles.value}


### PR DESCRIPTION
这个pr是针对获取popper的DOM方式进行优化

### 修改前

popper组件 template 如下

```vue
<template>
  <Transition v-bind="transitionProps">
    <div v-if="show" class="tr-base-popper">
      <slot />
    </div>
  </Transition>
</template>
```

要在父组件获取 DOM，父组件使用 ref 绑定，拿到的是一个 `VueInstance` 实例，然后再 `unrefElement` 获取 DOM。如果此时 `show` 为 `false`，那么会获取到一个注释节点，这是因为 vue 会把 v-if 条件为假的节点变成注释节点，为了更好地定位dom，便于切换状态 。这个注释节点并不是一个 Element，无法进行 DOM 操作。于是 ref 绑定时，需要自定义函数 setRef 函数，内部过滤掉注释节点

```ts
// 父组件
<script setup lang="ts">
const setRef = (el: unknown) => {
  const resolvedEl = unrefElement(el as MaybeElement)
  if (resolvedEl instanceof Element) {
    popperRef.value = resolvedEl
  } else {
    popperRef.value = null
  }
}
</script>

<template>
  <Popper :ref="setRef"></Popper>
</template>
```

然而这样还存在一个问题，那就是 Transition 过渡动画。当 show 变化时，并不能同步获取到 `VueInstance` 下的 DOM，所以还需增加 `await nextTick()`

```diff
-const setRef = (el: unknown) => {
+const setRef = async (el: unknown) => {
+ await nextTick()
  const resolvedEl = unrefElement(el as MaybeElement)
  if (resolvedEl instanceof Element) {
    popperRef.value = resolvedEl
  } else {
    popperRef.value = null
  }
}
```

### 修改后

直接暴露 popper 组件中 `Transition` 下面的元素的 ref，即使 show 为 false，这个ref 的值也不会是一个注释节点，父组件直接使用暴露的 ref 属性即可，也不需要再关心异步问题

```vue
// Popper 组件
<script setup lang="ts">
defineExpose({
  popperRef,
})
</script>

<template>
  <Transition v-bind="transitionProps">
    <div v-if="show" class="tr-base-popper" ref="popperRef">
      <slot />
    </div>
  </Transition>
</template>
```

```ts
// 父组件
<script setup lang="ts">
const popperInstance = ref<InstanceType<typeof Popper> | null>(null)
const popperRef = computed(() => popperInstance.value?.popperRef || null)
</script>

<template>
  <Popper ref="popperInstance"></Popper>
</template>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The dropdown menu component now provides direct access to its DOM element, improving integration with parent components.

* **Refactor**
  * Unified and simplified the management of dropdown visibility state for improved consistency.
  * Streamlined the way references to dropdown and popper elements are handled, enhancing reactivity and maintainability.

* **Bug Fixes**
  * Improved detection and handling of clicks outside dropdown menus to ensure all dropdowns close reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->