### PR TITLE
refactor: improve DropdownMenu hover handling

### DIFF
--- a/packages/components/src/dropdown-menu/composables/usePopperHover.ts
+++ b/packages/components/src/dropdown-menu/composables/usePopperHover.ts
@@ -102,7 +102,7 @@ export const usePopperHover = (
   const isHovering = ref(false)
   const hoveringArea = ref<'trigger' | 'popper' | 'polygon' | 'outside' | null>(null)
 
-  let timer: NodeJS.Timeout | null = null
+  let timer: ReturnType<typeof setTimeout> | null = null
 
   const toggle = (entering: boolean) => {
     const delay = entering ? delayEnter : delayLeave

--- a/packages/components/src/dropdown-menu/composables/usePopperHover.ts
+++ b/packages/components/src/dropdown-menu/composables/usePopperHover.ts
@@ -94,7 +94,7 @@ export interface UsePopperHoverOptions {
 
 export const usePopperHover = (
   triggerRef: MaybeComputedElementRef,
-  dropdownMenuRef: MaybeComputedElementRef,
+  popperRef: MaybeComputedElementRef,
   options?: UsePopperHoverOptions,
 ) => {
   const { delayEnter = 0, delayLeave = 0 } = options || {}
@@ -142,7 +142,7 @@ export const usePopperHover = (
     [pointerX, pointerY],
     ([x, y]) => {
       const trigger = unrefElement(triggerRef)
-      const popper = unrefElement(dropdownMenuRef)
+      const popper = unrefElement(popperRef)
 
       const triggerRect = trigger?.getBoundingClientRect()
       const popperRect = popper?.getBoundingClientRect()

--- a/packages/components/src/dropdown-menu/composables/usePopperHover.ts
+++ b/packages/components/src/dropdown-menu/composables/usePopperHover.ts
@@ -61,8 +61,6 @@ const isPointInPolygon = (point: Point, polygon: Polygon, includeBoundary = fals
   return inside
 }
 
-const emptyPolygon: Polygon = []
-
 const calcHoverPolygon = (triggerRect: DOMRect, popperRect: DOMRect) => {
   // popper 在 trigger 的上方
   if (popperRect.bottom > triggerRect.top) {
@@ -84,7 +82,7 @@ const calcHoverPolygon = (triggerRect: DOMRect, popperRect: DOMRect) => {
     ]
   }
 
-  return emptyPolygon
+  return []
 }
 
 const { x: pointerX, y: pointerY } = useGlobalPointer()

--- a/packages/components/src/dropdown-menu/composables/usePopperHover.ts
+++ b/packages/components/src/dropdown-menu/composables/usePopperHover.ts
@@ -61,7 +61,7 @@ const isPointInPolygon = (point: Point, polygon: Polygon, includeBoundary = fals
   return inside
 }
 
-const calcHoverPolygon = (triggerRect: DOMRect, popperRect: DOMRect) => {
+const calcHoverPolygon = (triggerRect: DOMRect, popperRect: DOMRect): Polygon => {
   // popper 在 trigger 的上方
   if (popperRect.bottom < triggerRect.top) {
     return [
@@ -100,7 +100,7 @@ export const usePopperHover = (
   const { delayEnter = 0, delayLeave = 0 } = options || {}
 
   const isHovering = ref(false)
-  const hoveringArea = ref<'trigger' | 'popper' | 'polygon' | 'outside' | null>(null)
+  const hoveringArea = ref<'trigger' | 'popper' | 'polygon' | 'outside'>('outside')
 
   let timer: ReturnType<typeof setTimeout> | null = null
 
@@ -129,7 +129,7 @@ export const usePopperHover = (
   watch(
     hoveringArea,
     (area) => {
-      if (area && ['trigger', 'popper', 'polygon'].includes(area)) {
+      if (['trigger', 'popper', 'polygon'].includes(area)) {
         toggle(true)
       } else {
         toggle(false)

--- a/packages/components/src/dropdown-menu/composables/usePopperHover.ts
+++ b/packages/components/src/dropdown-menu/composables/usePopperHover.ts
@@ -1,5 +1,5 @@
 import { MaybeComputedElementRef, unrefElement, watchThrottled } from '@vueuse/core'
-import { ref, watch } from 'vue'
+import { onUnmounted, ref, watch } from 'vue'
 import { useGlobalPointer } from '../../shared/utils'
 
 type Point = { x: number; y: number }
@@ -63,7 +63,7 @@ const isPointInPolygon = (point: Point, polygon: Polygon, includeBoundary = fals
 
 const calcHoverPolygon = (triggerRect: DOMRect, popperRect: DOMRect) => {
   // popper 在 trigger 的上方
-  if (popperRect.bottom > triggerRect.top) {
+  if (popperRect.bottom < triggerRect.top) {
     return [
       { x: triggerRect.left, y: triggerRect.top },
       { x: triggerRect.right, y: triggerRect.top },
@@ -73,7 +73,7 @@ const calcHoverPolygon = (triggerRect: DOMRect, popperRect: DOMRect) => {
   }
 
   // popper 在 trigger 的下方
-  if (popperRect.top < triggerRect.bottom) {
+  if (popperRect.top > triggerRect.bottom) {
     return [
       { x: triggerRect.left, y: triggerRect.bottom },
       { x: triggerRect.right, y: triggerRect.bottom },
@@ -104,12 +104,20 @@ export const usePopperHover = (
 
   let timer: ReturnType<typeof setTimeout> | null = null
 
-  const toggle = (entering: boolean) => {
-    const delay = entering ? delayEnter : delayLeave
+  const clearTimer = () => {
     if (timer) {
       clearTimeout(timer)
       timer = null
     }
+  }
+
+  onUnmounted(() => {
+    clearTimer()
+  })
+
+  const toggle = (entering: boolean) => {
+    const delay = entering ? delayEnter : delayLeave
+    clearTimer()
 
     if (delay) {
       timer = setTimeout(() => (isHovering.value = entering), delay)

--- a/packages/components/src/dropdown-menu/composables/usePopperHover.ts
+++ b/packages/components/src/dropdown-menu/composables/usePopperHover.ts
@@ -1,0 +1,177 @@
+import { MaybeComputedElementRef, unrefElement, watchThrottled } from '@vueuse/core'
+import { ref, watch } from 'vue'
+import { useGlobalPointer } from '../../shared/utils'
+
+type Point = { x: number; y: number }
+type Polygon = Point[]
+
+const isPointInRect = (point: Point, rect: DOMRect) => {
+  return point.x >= rect.left && point.x <= rect.right && point.y >= rect.top && point.y <= rect.bottom
+}
+
+/**
+ * 判断点是否在多边形内
+ * @param point 点
+ * @param polygon 多边形
+ * @param includeBoundary 是否包含边界
+ * @returns 是否在多边形内
+ */
+const isPointInPolygon = (point: Point, polygon: Polygon, includeBoundary = false): boolean => {
+  if (polygon.length < 3) return false
+
+  const px = point.x
+  const py = point.y
+  let inside = false
+
+  // 边界检查辅助函数
+  const isOnEdge = (px: number, py: number, x1: number, y1: number, x2: number, y2: number) => {
+    const cross = (x2 - x1) * (py - y1) - (y2 - y1) * (px - x1)
+    if (Math.abs(cross) > 1e-10) return false // 容差判断是否共线
+
+    const minX = Math.min(x1, x2)
+    const maxX = Math.max(x1, x2)
+    const minY = Math.min(y1, y2)
+    const maxY = Math.max(y1, y2)
+
+    // 判断点是否在线段的包围盒内
+    return px >= minX && px <= maxX && py >= minY && py <= maxY
+  }
+
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x
+    const yi = polygon[i].y
+    const xj = polygon[j].x
+    const yj = polygon[j].y
+
+    // 首先检查点是否在多边形的任何一条边上
+    if (includeBoundary && isOnEdge(px, py, xi, yi, xj, yj)) {
+      return true
+    }
+
+    // 射线法核心逻辑
+    const intersects = (yi > py && yj <= py) || (yj > py && yi <= py)
+    if (intersects) {
+      const intersectX = ((xj - xi) * (py - yi)) / (yj - yi) + xi
+      if (px < intersectX) {
+        inside = !inside
+      }
+    }
+  }
+
+  return inside
+}
+
+const emptyPolygon: Polygon = []
+
+const calcHoverPolygon = (triggerRect: DOMRect, popperRect: DOMRect) => {
+  // popper 在 trigger 的上方
+  if (popperRect.bottom > triggerRect.top) {
+    return [
+      { x: triggerRect.left, y: triggerRect.top },
+      { x: triggerRect.right, y: triggerRect.top },
+      { x: popperRect.right, y: popperRect.bottom },
+      { x: popperRect.left, y: popperRect.bottom },
+    ]
+  }
+
+  // popper 在 trigger 的下方
+  if (popperRect.top < triggerRect.bottom) {
+    return [
+      { x: triggerRect.left, y: triggerRect.bottom },
+      { x: triggerRect.right, y: triggerRect.bottom },
+      { x: popperRect.right, y: popperRect.top },
+      { x: popperRect.left, y: popperRect.top },
+    ]
+  }
+
+  return emptyPolygon
+}
+
+const { x: pointerX, y: pointerY } = useGlobalPointer()
+
+export interface UsePopperHoverOptions {
+  delayEnter?: number
+  delayLeave?: number
+}
+
+export const usePopperHover = (
+  triggerRef: MaybeComputedElementRef,
+  dropdownMenuRef: MaybeComputedElementRef,
+  options?: UsePopperHoverOptions,
+) => {
+  const { delayEnter = 0, delayLeave = 0 } = options || {}
+
+  const isHovering = ref(false)
+  const hoveringArea = ref<'trigger' | 'popper' | 'polygon' | 'outside' | null>(null)
+
+  let timer: NodeJS.Timeout | null = null
+
+  const toggle = (entering: boolean) => {
+    const delay = entering ? delayEnter : delayLeave
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+
+    if (delay) {
+      timer = setTimeout(() => (isHovering.value = entering), delay)
+    } else {
+      isHovering.value = entering
+    }
+  }
+
+  watch(
+    hoveringArea,
+    (area) => {
+      if (area && ['trigger', 'popper', 'polygon'].includes(area)) {
+        toggle(true)
+      } else {
+        toggle(false)
+      }
+    },
+    { immediate: true },
+  )
+
+  watchThrottled(
+    [pointerX, pointerY],
+    ([x, y]) => {
+      const trigger = unrefElement(triggerRef)
+      const popper = unrefElement(dropdownMenuRef)
+
+      const triggerRect = trigger?.getBoundingClientRect()
+      const popperRect = popper?.getBoundingClientRect()
+
+      if (triggerRect && isPointInRect({ x, y }, triggerRect)) {
+        hoveringArea.value = 'trigger'
+        return
+      }
+
+      if (popperRect && isPointInRect({ x, y }, popperRect)) {
+        hoveringArea.value = 'popper'
+        return
+      }
+
+      if (
+        !triggerRect ||
+        !popperRect ||
+        triggerRect.width === 0 ||
+        triggerRect.height === 0 ||
+        popperRect.width === 0 ||
+        popperRect.height === 0
+      ) {
+        hoveringArea.value = 'outside'
+        return
+      }
+
+      const inPolygon = isPointInPolygon({ x, y }, calcHoverPolygon(triggerRect, popperRect), true)
+      if (inPolygon) {
+        hoveringArea.value = 'polygon'
+      } else {
+        hoveringArea.value = 'outside'
+      }
+    },
+    { throttle: 10 },
+  )
+
+  return isHovering
+}

--- a/packages/components/src/dropdown-menu/index.vue
+++ b/packages/components/src/dropdown-menu/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { onClickOutside, useElementHover } from '@vueuse/core'
+import { onClickOutside } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 import TrBasePopper from '../base-popper'
+import { usePopperHover } from './composables/usePopperHover'
 import { DropdownMenuEmits, DropdownMenuItem, DropdownMenuProps } from './index.type'
 
 const props = withDefaults(defineProps<DropdownMenuProps>(), {
@@ -42,16 +43,11 @@ if (props.trigger === 'click' || props.trigger === 'manual') {
     { ignore: [triggerRef] },
   )
 } else if (props.trigger === 'hover') {
-  // TODO 计算多边形
-  const isTriggerHovered = useElementHover(triggerRef, { delayEnter: 100, delayLeave: 300 })
-  const isDropdownMenuHovered = useElementHover(dropdownMenuRef, { delayEnter: 100, delayLeave: 300 })
+  const isHovering = usePopperHover(triggerRef, dropdownMenuRef, { delayEnter: 100, delayLeave: 100 })
 
-  watch(
-    () => [isTriggerHovered.value, isDropdownMenuHovered.value],
-    ([isTriggerHovered, isDropdownMenuHovered]) => {
-      show.value = isTriggerHovered || isDropdownMenuHovered
-    },
-  )
+  watch(isHovering, (isHovering) => {
+    show.value = isHovering
+  })
 }
 
 const handleTriggerClick = () => {

--- a/packages/components/src/shared/utils.ts
+++ b/packages/components/src/shared/utils.ts
@@ -1,4 +1,4 @@
-import { usePointer } from '@vueuse/core'
+import { usePointer, UsePointerReturn } from '@vueuse/core'
 
 export function toCssUnit(value?: number | string): string {
   if (typeof value === 'number') return `${value}px`
@@ -31,8 +31,10 @@ export function isShadowDOM(target: HTMLElement) {
   return rootNode instanceof ShadowRoot
 }
 
-const { x: pointerX, y: pointerY } = usePointer()
-
+let pointer: UsePointerReturn | null = null
 export function useGlobalPointer() {
-  return { x: pointerX, y: pointerY }
+  if (!pointer) {
+    pointer = usePointer()
+  }
+  return { x: pointer.x, y: pointer.y }
 }

--- a/packages/components/src/shared/utils.ts
+++ b/packages/components/src/shared/utils.ts
@@ -1,3 +1,5 @@
+import { usePointer } from '@vueuse/core'
+
 export function toCssUnit(value?: number | string): string {
   if (typeof value === 'number') return `${value}px`
 
@@ -27,4 +29,10 @@ export function getSelectionFromTarget(target?: HTMLElement) {
 export function isShadowDOM(target: HTMLElement) {
   const rootNode = target.getRootNode()
   return rootNode instanceof ShadowRoot
+}
+
+const { x: pointerX, y: pointerY } = usePointer()
+
+export function useGlobalPointer() {
+  return { x: pointerX, y: pointerY }
 }


### PR DESCRIPTION
dropdown组件中，触发元素和弹出框直接可能会有间隙，如果此时使用 hover 来打开弹出框，当鼠标移动到这个间隙之间，会导致弹出框关闭。常见的解决方案有两种：

1. 弹出框使用一个透明的wrapper包裹，这个wrapper始终紧贴触发元素，在 wrapper 元素上监听 mouseenter
2. 监听鼠标相对于页面左上角的位置，使用鼠标位置判断是否在下列多边形内来决定是否在 hovering
   - trigger 矩形
   - popper 矩形
   - trigger 和 popper 距离最近的两条边组成的多边形

当前pr采用了第二种方案，示例图如下

```
+---------------+
|               |
|    popper     |
|               |
+---------------+
\              /
 \   polygon  /
  \          /
  +---------+
  | trigger |
  +---------+
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved dropdown menu hover behavior, allowing the menu to remain open when the pointer moves between the trigger and dropdown, including the area connecting them.
  * Added a new utility to track global pointer position reactively.

* **Refactor**
  * Unified hover state management for dropdown menus, simplifying logic and improving responsiveness.
  * Adjusted hover leave delay for dropdown menus for a more responsive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->