### PR TITLE
fix: template editor cursor position and style

### DIFF
--- a/docs/demos/examples/Assistant.vue
+++ b/docs/demos/examples/Assistant.vue
@@ -55,6 +55,7 @@
           ref="senderRef"
           mode="single"
           v-model="inputMessage"
+          :class="{ 'tr-sender-compact': !fullscreen }"
           :placeholder="GeneratingStatus.includes(messageState.status) ? '正在思考中...' : '请输入您的问题'"
           :clearable="true"
           :loading="GeneratingStatus.includes(messageState.status)"

--- a/packages/components/src/sender/components/ActionButtons.vue
+++ b/packages/components/src/sender/components/ActionButtons.vue
@@ -254,8 +254,8 @@ const handleCancel = () => {
 
     /* 关闭图标 */
     &--clear {
-      width: 32px;
-      height: 32px;
+      width: var(--tr-sender-action-buttons-icon-size);
+      height: var(--tr-sender-action-buttons-icon-size);
       padding: 4px;
       font-size: var(--tr-sender-action-buttons-icon-size-clear);
     }

--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -417,12 +417,11 @@ const insertToText = (text: string, insertedText: string, startOffset: number, e
   return text.slice(0, startOffset) + insertedText + text.slice(endOffset)
 }
 
-const adjustSelectionForSentinelNode = (
+const handleSentinelNodeForwardDeletion = (
   selectedItems: SelectedItem[],
   range: EditorRange,
   inputType: string,
 ): SelectedItem[] => {
-  // 仅处理 deleteContentBackward
   if (inputType !== 'deleteContentForward' || selectedItems.length !== 1) {
     return selectedItems
   }
@@ -463,7 +462,7 @@ const processInput = (range: EditorRange, inputType: string, inputData: string) 
     return
   }
 
-  const adjustedSelected = adjustSelectionForSentinelNode(selected, range, inputType)
+  const adjustedSelected = handleSentinelNodeForwardDeletion(selected, range, inputType)
 
   const selectedOrCreateItems = transformSelected(adjustedSelected, range, inputType, inputData)
 

--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -900,7 +900,7 @@ defineExpose({
 }
 </style>
 
-<style lang="less">
+<style lang="less" scoped>
 .editor-container {
   [contenteditable] {
     display: block;
@@ -922,7 +922,9 @@ defineExpose({
     }
   }
 }
+</style>
 
+<style lang="less">
 .tr-sender-compact {
   --tr-sender-template-editor-font-size: 14px;
 }

--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -72,11 +72,13 @@ const transformInternalToUser = (items: (TextItem | TemplateItem)[]): UserItem[]
 const originalData = ref<(TextItem | TemplateItem)[]>(transformUserToInternal(model.value || []))
 
 const setOriginalData = (items: (TextItem | TemplateItem)[]) => {
+  const zeroWidthLocatorNode = { type: 'text', content: '\u200B', id: randomId() } as TextItem | TemplateItem
+
   if (items.length > 0) {
-    if (items[0].type === 'template') {
-      originalData.value = [{ type: 'text', content: '\u200B', id: randomId() } as TextItem | TemplateItem].concat(
-        items,
-      )
+    if (isSafariBrowser && items[items.length - 1].type === 'template') {
+      originalData.value = items.concat([zeroWidthLocatorNode])
+    } else if (items[0].type === 'template') {
+      originalData.value = [zeroWidthLocatorNode].concat(items)
     } else {
       originalData.value = items
       const firstItem = items[0]

--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -417,6 +417,45 @@ const insertToText = (text: string, insertedText: string, startOffset: number, e
   return text.slice(0, startOffset) + insertedText + text.slice(endOffset)
 }
 
+const adjustSelectionForSentinelNode = (
+  selectedItems: SelectedItem[],
+  range: EditorRange,
+  inputType: string,
+): SelectedItem[] => {
+  // 仅处理 deleteContentBackward
+  if (inputType !== 'deleteContentForward' || selectedItems.length !== 1) {
+    return selectedItems
+  }
+
+  const item = selectedItems[0]
+  const dataItem = originalData.value.find((d) => d.id === item.id)
+
+  // 检查是否是哨兵节点（仅包含零宽字符的文本节点）
+  if (!dataItem || dataItem.type !== 'text' || dataItem.content !== '\u200B' || range.collapsed) {
+    return selectedItems
+  }
+
+  // 是哨兵节点，我们将光标移动到下一个元素
+  const currentIndex = flattenedData.value.findIndex((flatItem) => flatItem.id === item.id)
+
+  if (currentIndex < 0 || currentIndex >= flattenedData.value.length - 1) {
+    // 如果是最后一个元素，或者没找到，就只阻止删除（通过折叠选区）
+    return [{ ...item, startOffset: 0, endOffset: 0 }]
+  }
+
+  const nextItem = flattenedData.value[currentIndex + 1]
+
+  // 返回一个指向下一个元素开头的新选区
+  return [
+    {
+      id: nextItem.id,
+      type: nextItem.type,
+      startOffset: 0,
+      endOffset: 0,
+    },
+  ]
+}
+
 const processInput = (range: EditorRange, inputType: string, inputData: string) => {
   const selected = getSelected(range)
 
@@ -424,7 +463,9 @@ const processInput = (range: EditorRange, inputType: string, inputData: string) 
     return
   }
 
-  const selectedOrCreateItems = transformSelected(selected, range, inputType, inputData)
+  const adjustedSelected = adjustSelectionForSentinelNode(selected, range, inputType)
+
+  const selectedOrCreateItems = transformSelected(adjustedSelected, range, inputType, inputData)
 
   if (selectedOrCreateItems.some((item) => (item as CreateItem).tag === 'new')) {
     const { afterId, content } = selectedOrCreateItems[0] as CreateItem
@@ -473,12 +514,13 @@ const processInput = (range: EditorRange, inputType: string, inputData: string) 
       if (item.type === 'text') {
         return item.content.length > 0
       }
-      return [item.prefix, item.suffix, item.content].join('').length > 0
+      const templateItem = item as TemplateItem
+      return [templateItem.prefix, templateItem.suffix, templateItem.content].join('').length > 0
     }),
   )
 
   // 恢复分隔符
-  for (const dataItem of originalData.value.filter((item) => item.type === 'template')) {
+  for (const dataItem of originalData.value.filter((item): item is TemplateItem => item.type === 'template')) {
     if (dataItem.prefix.length === 0) {
       dataItem.prefix = PREFIX
     }

--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -71,6 +71,34 @@ const transformInternalToUser = (items: (TextItem | TemplateItem)[]): UserItem[]
 
 const originalData = ref<(TextItem | TemplateItem)[]>(transformUserToInternal(model.value || []))
 
+const setOriginalData = (items: (TextItem | TemplateItem)[]) => {
+  if (items.length > 0) {
+    if (items[0].type === 'template') {
+      originalData.value = [{ type: 'text', content: '\u200B', id: randomId() } as TextItem | TemplateItem].concat(
+        items,
+      )
+    } else {
+      originalData.value = items
+      const firstItem = items[0]
+      const lastItem = items[items.length - 1]
+
+      if (isSafariBrowser) {
+        // 在 safari 环境下，如果最后一个元素是 text，清空 content
+        if (lastItem.content !== '\u200B') {
+          lastItem.content = lastItem.content.replace(/\u200B/g, '')
+        }
+      } else {
+        // 在 chrome 环境下，如果第一个元素是 text，清空 content
+        if (firstItem.content !== '\u200B') {
+          firstItem.content = firstItem.content.replace(/\u200B/g, '')
+        }
+      }
+    }
+  } else {
+    originalData.value = items
+  }
+}
+
 const flattenedData = computed<ExtendedTextItem[]>(() => {
   return originalData.value
     .map((item) => {
@@ -160,7 +188,7 @@ watch(
   () => model.value,
   (newModel) => {
     // 当 props 变化时，更新内部状态
-    originalData.value = transformUserToInternal(newModel || [])
+    setOriginalData(transformUserToInternal(newModel || []))
 
     history.commit(serializeWithTimestamp(originalData.value))
   },
@@ -259,15 +287,17 @@ const insertNewTextAndSetCaretPosition = (content: string, insertAfter?: string)
   if (insertAfter) {
     const index = originalData.value.findIndex((item) => item.id === insertAfter)
     if (index !== -1) {
-      originalData.value = originalData.value
-        .slice(0, index + 1)
-        .concat(textItem)
-        .concat(originalData.value.slice(index + 1))
+      setOriginalData(
+        originalData.value
+          .slice(0, index + 1)
+          .concat(textItem)
+          .concat(originalData.value.slice(index + 1)),
+      )
     } else {
       console.warn(`can not find item with id: ${insertAfter}`)
     }
   } else {
-    originalData.value.unshift(textItem)
+    setOriginalData([textItem as TextItem | TemplateItem].concat(originalData.value))
   }
 
   nextTick(() => {
@@ -437,13 +467,15 @@ const processInput = (range: EditorRange, inputType: string, inputData: string) 
   }
 
   // 删除空数据
-  originalData.value = originalData.value.filter((item) => !toDeleted.includes(item.id))
-  originalData.value = originalData.value.filter((item) => {
-    if (item.type === 'text') {
-      return item.content.length > 0
-    }
-    return [item.prefix, item.suffix, item.content].join('').length > 0
-  })
+  setOriginalData(originalData.value.filter((item) => !toDeleted.includes(item.id)))
+  setOriginalData(
+    originalData.value.filter((item) => {
+      if (item.type === 'text') {
+        return item.content.length > 0
+      }
+      return [item.prefix, item.suffix, item.content].join('').length > 0
+    }),
+  )
 
   // 恢复分隔符
   for (const dataItem of originalData.value.filter((item) => item.type === 'template')) {
@@ -757,7 +789,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
 
 const restoreDataAndCaretPosition = (historyItem: string) => {
   const { data } = parseSerializedData(historyItem)
-  originalData.value = data
+  setOriginalData(data)
   if (rangeMap.has(historyItem)) {
     const range = rangeMap.get(historyItem)!
     nextTick(() => {

--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -77,7 +77,7 @@ const setOriginalData = (items: (TextItem | TemplateItem)[]) => {
   if (items.length > 0) {
     if (isSafariBrowser && items[items.length - 1].type === 'template') {
       originalData.value = items.concat([zeroWidthLocatorNode])
-    } else if (items[0].type === 'template') {
+    } else if (!isSafariBrowser && items[0].type === 'template') {
       originalData.value = [zeroWidthLocatorNode].concat(items)
     } else {
       originalData.value = items

--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -900,7 +900,7 @@ defineExpose({
 }
 </style>
 
-<style lang="less" scoped>
+<style lang="less">
 .editor-container {
   [contenteditable] {
     display: block;
@@ -921,5 +921,9 @@ defineExpose({
       border: none;
     }
   }
+}
+
+.tr-sender-compact {
+  --tr-sender-template-editor-font-size: 14px;
 }
 </style>

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -276,6 +276,12 @@ const clearInput = () => {
 }
 
 const handleTemplateUpdate = (data: UserItem[]) => {
+  // 如果模板数据为空，则退出模板编辑模式
+  if (data && data.length === 1 && data[0].type === 'text' && data[0].content === '\u200B') {
+    exitTemplateMode()
+    return
+  }
+
   emit('update:templateData', data)
 }
 

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -276,8 +276,11 @@ const clearInput = () => {
 }
 
 const handleTemplateUpdate = (data: UserItem[]) => {
+  const isTemplateEmpty =
+    data.length === 0 || (data.length === 1 && data[0].type === 'text' && data[0].content === '\u200B')
+
   // 如果模板数据为空，则退出模板编辑模式
-  if (data && data.length === 1 && data[0].type === 'text' && data[0].content === '\u200B') {
+  if (isTemplateEmpty) {
     exitTemplateMode()
     return
   }


### PR DESCRIPTION
1. 模板编辑器只有一个编辑块时，删除后编辑，光标在编辑块内，输入文本显示在编辑块外侧
2. 模板编辑器清空内容后，输入框的光标未正常激活
3. 模板编辑器修复字体大小：
   在 紧凑模式（tr-sender-compact）下，文字大小为 14px； 全屏模式下，文字大小为 16px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of empty template data in the template editor, automatically exiting template mode when appropriate.
  * Enhanced deletion behavior for special zero-width space nodes, ensuring smoother editing experience.

* **Style**
  * Updated clear icon button sizing to use theme variables for better flexibility.
  * Added compact styling for sender input when not in fullscreen mode.

* **Bug Fixes**
  * Improved browser-specific handling of zero-width space characters in template editing to ensure consistent behavior across browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->