### PR TITLE
feat: expose update method in base-popper

### DIFF
--- a/packages/components/src/base-popper/index.vue
+++ b/packages/components/src/base-popper/index.vue
@@ -137,6 +137,7 @@ createTeleport(teleportProps, () => (
 defineExpose({
   triggerRef,
   popperRef,
+  update,
 })
 </script>
 

--- a/packages/components/src/dropdown-menu/index.vue
+++ b/packages/components/src/dropdown-menu/index.vue
@@ -64,6 +64,10 @@ const handleItemClick = (item: DropdownMenuItem) => {
   show.value = false
   emit('item-click', item)
 }
+
+defineExpose({
+  update: () => basePopperRef.value?.update(),
+})
 </script>
 
 <template>

--- a/packages/components/src/dropdown-menu/index.vue
+++ b/packages/components/src/dropdown-menu/index.vue
@@ -66,7 +66,9 @@ const handleItemClick = (item: DropdownMenuItem) => {
 }
 
 defineExpose({
-  update: () => basePopperRef.value?.update(),
+  update: () => {
+    basePopperRef.value?.update()
+  },
 })
 </script>
 

--- a/packages/components/src/suggestion-popover/index.vue
+++ b/packages/components/src/suggestion-popover/index.vue
@@ -199,7 +199,9 @@ const handleItemMouseleave = (event: MouseEvent) => {
 }
 
 defineExpose({
-  update: () => basePopperRef.value?.update(),
+  update: () => {
+    basePopperRef.value?.update()
+  },
 })
 </script>
 

--- a/packages/components/src/suggestion-popover/index.vue
+++ b/packages/components/src/suggestion-popover/index.vue
@@ -195,6 +195,10 @@ const handleItemMouseleave = (event: MouseEvent) => {
 
   tooltipShow.value = false
 }
+
+defineExpose({
+  update: () => basePopperRef.value?.update(),
+})
 </script>
 
 <template>


### PR DESCRIPTION
base-popper 使用了 vueuse 中的 `useElementBounding` 监听 trigger 位置，然后计算 popper 位置

虽然能监听 trigger 位置，但是仅限于滚动事件和 resize 事件。如果 trigger 因为其他原因导致位置变化，比如 trigger 上方有新的DOM插入、元素的容器是一个能托拽位置的悬浮容器等，此时 trigger 位置变化并不能被监听到。

解决方案：组件暴露出 `useElementBounding` 的 `update` 方法，外部根据不同场景要求自行决定是否更新 popper 位置

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an exposed `update` method to the popper, dropdown menu, and suggestion popover components, allowing external access to trigger updates on these components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->