### PR TITLE
fix: Adjust viewport unit usage for Chrome < 108 compatibility

### DIFF
--- a/packages/components/src/base-popper/index.vue
+++ b/packages/components/src/base-popper/index.vue
@@ -74,7 +74,7 @@ const popperStyles = computed<CSSProperties>(() => {
     }
 
     const isVertical = side === 'top' || side === 'bottom'
-    const maxViewport = isVertical ? '100dvh' : '100dvw'
+    const maxViewport = isVertical ? '100%' : '100%'
     const size = toCssUnit(isVertical ? popperHeight.value : popperWidth.value)
 
     styles[side] = `clamp(0px, ${value}, calc(${maxViewport} - ${size}))`

--- a/packages/components/src/suggestion-popover/index.vue
+++ b/packages/components/src/suggestion-popover/index.vue
@@ -129,7 +129,7 @@ const popoverStyles = computed<CSSProperties>(() => {
       right: 0,
       bottom: 0,
       top: 'unset',
-      minWidth: '100dvw',
+      minWidth: '100%',
     }
   }
 
@@ -300,8 +300,8 @@ defineExpose({
   z-index: var(--tr-z-index-popover);
   width: var(--tr-suggestion-popover-width);
   height: var(--tr-suggestion-popover-height);
-  max-width: 100dvw;
-  max-height: 100dvh;
+  max-width: 100%;
+  max-height: 100%;
   padding: 20px;
   padding-bottom: 16px;
   border-radius: 24px;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated popover and suggestion popover sizing to use percentage-based units instead of viewport-relative units for width and height constraints. This may affect how popovers are displayed and sized across different devices and screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->