### PR TITLE
chore: add option support only publish docs

### DIFF
--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: '选择发布版本的tag (alpha/beta/latest)'
+        description: '选择发布/部署版本tag (alpha/beta/rc/latest)'
         required: true
         default: 'alpha'
         type: choice
@@ -17,6 +17,11 @@ on:
           - beta
           - rc
           - latest
+      publish_npm:
+        description: '是否发布npm包（未勾选则只部署文档）'
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
@@ -71,6 +76,7 @@ jobs:
 
       # 步骤8: 发布组件到NPM
       - name: Publish components
+        if: ${{ inputs.publish_npm == 'true' }}
         run: pnpm lerna publish from-package --pre-dist-tag ${{ inputs.tag }} --yes
         env:
           # 使用NPM令牌进行身份验证


### PR DESCRIPTION
手动执行publish action时，添加是否发布npm包选项

使用场景：
- 选择某个分支单独部署文档，不发布NPM包
- 支持fork仓库部署文档到个人空间

git action界面：
<img width="346" height="303" alt="image" src="https://github.com/user-attachments/assets/4d2d02d1-5335-4834-adba-2eb9bd450ee8" />

验证：
<img width="789" height="869" alt="image" src="https://github.com/user-attachments/assets/34003424-58e2-428a-bccd-5b8c6f462906" />

<img width="1480" height="621" alt="image" src="https://github.com/user-attachments/assets/64706362-af2a-426c-ac2a-5976441f6028" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow to support a new "rc" option for release tags.
  * Added an option to control whether the npm package is published or only documentation is deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->