### PR TITLE
feat: BasePopper supports custom display area via css variables

### DIFF
--- a/docs/demos/suggestion/pills-popper.vue
+++ b/docs/demos/suggestion/pills-popper.vue
@@ -21,6 +21,10 @@
       <TrDropdownMenu
         v-for="(button, index) in buttons"
         :items="dropdownMenuItems"
+        :style="{
+          '--tr-dropdown-menu-min-left': leftRange.left,
+          '--tr-dropdown-menu-max-right': leftRange.right,
+        }"
         @item-click="handleDropdownMenuItemClick"
         :key="index"
         v-model:show="dropdownShowModels[index]"
@@ -64,7 +68,7 @@
 import { TrDropdownMenu, TrSuggestionPillButton, TrSuggestionPills, TrSuggestionPopover } from '@opentiny/tiny-robot'
 import { IconSparkles } from '@opentiny/tiny-robot-svgs'
 import { TinyRadioGroup, TinySwitch } from '@opentiny/vue'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 const showAll = ref(false)
 const showAllRef = ref<InstanceType<typeof TinySwitch>>()
@@ -174,6 +178,18 @@ const handleClickResetButton = () => {
 }
 
 const pillsRef = ref<InstanceType<typeof TrSuggestionPills>>()
+
+const leftRange = computed(() => {
+  const el = pillsRef.value?.$el
+  if (!el) {
+    return { left: '0px', right: '100%' }
+  }
+  const { left, right } = el.getBoundingClientRect()
+  return {
+    left: `${left}px`,
+    right: `${right}px`,
+  }
+})
 
 watch(
   () => [pillsRef.value?.$el, pillsRef.value?.children.map((el) => el)] as const,

--- a/docs/src/components/dropdown-menu.md
+++ b/docs/src/components/dropdown-menu.md
@@ -28,7 +28,6 @@ outline: deep
 属性详细说明
 
 1. **`show` 属性行为**：
-
    - 当 `trigger` 为 `'click'` 或 `'hover'` 时：
      - 可作为双向绑定属性使用 (`v-model:show`)
      - 组件内外均可修改显示状态
@@ -37,7 +36,6 @@ outline: deep
      - 组件内部不会自动修改此值
 
 2. **`trigger` 模式区别**：
-
    - `click`：点击触发元素显示/隐藏菜单
    - `hover`：鼠标悬停触发元素显示菜单，移出后隐藏
    - `manual`：完全通过外部控制的显示状态
@@ -72,11 +70,15 @@ outline: deep
 
 ### CSS Variables
 
-| 变量名                                   | 说明               | 默认值                         |
-| ---------------------------------------- | ------------------ | ------------------------------ |
-| `--tr-dropdown-menu-bg-color`            | 下拉菜单背景色     | `#ffffff`                      |
-| `--tr-dropdown-menu-box-shadow`          | 下拉菜单阴影       | `0 0 20px rgba(0, 0, 0, 0.08)` |
-| `--tr-dropdown-menu-min-width`           | 下拉菜单最小宽度   | `130px`                        |
-| `--tr-dropdown-menu-item-color`          | 菜单项文字颜色     | `rgb(25, 25, 25)`              |
-| `--tr-dropdown-menu-item-hover-bg-color` | 菜单项悬停时背景色 | `#f5f5f5`                      |
-| `--tr-dropdown-menu-item-font-weight`    | 菜单项字体粗细     | `normal`                       |
+| 变量名                                   | 说明                     | 默认值                         |
+| ---------------------------------------- | ------------------------ | ------------------------------ |
+| `--tr-dropdown-menu-bg-color`            | 下拉菜单背景色           | `#ffffff`                      |
+| `--tr-dropdown-menu-box-shadow`          | 下拉菜单阴影             | `0 0 20px rgba(0, 0, 0, 0.08)` |
+| `--tr-dropdown-menu-min-width`           | 下拉菜单最小宽度         | `130px`                        |
+| `--tr-dropdown-menu-item-color`          | 菜单项文字颜色           | `rgb(25, 25, 25)`              |
+| `--tr-dropdown-menu-item-hover-bg-color` | 菜单项悬停时背景色       | `#f5f5f5`                      |
+| `--tr-dropdown-menu-item-font-weight`    | 菜单项字体粗细           | `normal`                       |
+| `--tr-dropdown-menu-min-top`             | 下拉菜单最小 `top` 值    | `0px`                          |
+| `--tr-dropdown-menu-max-bottom`          | 下拉菜单最大 `bottom` 值 | `100%`                         |
+| `--tr-dropdown-menu-min-left`            | 下拉菜单最小 `left` 值   | `0px`                          |
+| `--tr-dropdown-menu-max-right`           | 下拉菜单最大 `right` 值  | `100%`                         |

--- a/packages/components/src/base-popper/index.vue
+++ b/packages/components/src/base-popper/index.vue
@@ -64,7 +64,7 @@ const { width: popperWidth, height: popperHeight } = useElementSize(popperRef, u
 
 const popperStyles = computed<CSSProperties>(() => {
   const { placement, preventOverflow } = props
-  type Side = 'top' | 'bottom' | 'left' | 'right'
+  type Side = 'top' | 'left'
   const styles: Pick<CSSProperties, Side> = {}
 
   const set = (side: Side, value: string) => {
@@ -73,24 +73,30 @@ const popperStyles = computed<CSSProperties>(() => {
       return
     }
 
-    const isVertical = side === 'top' || side === 'bottom'
-    const maxViewport = isVertical ? '100%' : '100%'
+    const isVertical = side === 'top'
     const size = toCssUnit(isVertical ? popperHeight.value : popperWidth.value)
 
-    styles[side] = `clamp(0px, ${value}, calc(${maxViewport} - ${size}))`
+    if (side === 'top') {
+      styles[side] = `clamp(var(--tr-base-popper-min-top), ${value}, calc(var(--tr-base-popper-max-bottom) - ${size}))`
+    } else if (side === 'left') {
+      styles[side] = `clamp(var(--tr-base-popper-min-left), ${value}, calc(var(--tr-base-popper-max-right) - ${size}))`
+    }
   }
 
+  // 只用 top/left 定位
   if (placement.includes('top')) {
     set('top', toCssUnit(top.value - popperHeight.value - resolvedOffset.value.mainAxis))
   }
   if (placement.includes('bottom')) {
-    set('bottom', `calc(100% - ${toCssUnit(bottom.value + popperHeight.value + resolvedOffset.value.mainAxis)})`)
+    // bottom 定位转换为 top 定位
+    set('top', toCssUnit(bottom.value + resolvedOffset.value.mainAxis))
   }
   if (placement.includes('left')) {
     set('left', toCssUnit(left.value + resolvedOffset.value.crossAxis))
   }
   if (placement.includes('right')) {
-    set('right', `calc(100% - ${toCssUnit(right.value + resolvedOffset.value.crossAxis)})`)
+    // right 定位转换为 left 定位
+    set('left', toCssUnit(right.value - popperWidth.value + resolvedOffset.value.crossAxis))
   }
   if (placement.includes('center')) {
     set('left', toCssUnit(left.value + width.value / 2 - popperWidth.value / 2 + resolvedOffset.value.crossAxis))
@@ -136,6 +142,15 @@ defineExpose({
 <template>
   <component :is="triggerVNodes[0]" :ref="setRef" v-bind="resolveEventHandlers(props.triggerEvents)" />
 </template>
+
+<style lang="less">
+:root {
+  --tr-base-popper-min-top: 0px;
+  --tr-base-popper-max-bottom: 100%;
+  --tr-base-popper-min-left: 0px;
+  --tr-base-popper-max-right: 100%;
+}
+</style>
 
 <style lang="less" scoped>
 .tr-base-popper {

--- a/packages/components/src/dropdown-menu/index.vue
+++ b/packages/components/src/dropdown-menu/index.vue
@@ -110,9 +110,19 @@ defineExpose({
   --tr-dropdown-menu-item-color: rgb(25, 25, 25);
   --tr-dropdown-menu-item-hover-bg-color: #f5f5f5;
   --tr-dropdown-menu-item-font-weight: normal;
+
+  --tr-dropdown-menu-min-top: 0px;
+  --tr-dropdown-menu-max-bottom: 100%;
+  --tr-dropdown-menu-min-left: 0px;
+  --tr-dropdown-menu-max-right: 100%;
 }
 
 .tr-dropdown-menu {
+  --tr-base-popper-min-top: var(--tr-dropdown-menu-min-top);
+  --tr-base-popper-max-bottom: var(--tr-dropdown-menu-max-bottom);
+  --tr-base-popper-min-left: var(--tr-dropdown-menu-min-left);
+  --tr-base-popper-max-right: var(--tr-dropdown-menu-max-right);
+
   z-index: var(--tr-z-index-dropdown);
   min-width: var(--tr-dropdown-menu-min-width);
   padding: 8px;


### PR DESCRIPTION
`BasePopper` 支持通过 css 变量自定义显示区域。如果 `BasePopper` 设置了 `prevent-overflow` 属性，那么弹出框位置不会超出 `viewpoint`。在此基础上，增加了自定义显示区域的功能，让弹出框位置不会超出自定义的显示区域

新增如下 css 变量：

- `--tr-base-popper-min-top`，默认值 `0px`
- `--tr-base-popper-max-bottom`，默认值 `100%`
- `--tr-base-popper-min-left`，默认值 `0px`
- `--tr-base-popper-max-right`，默认值 `100%`

`DropdownMenu` 使用了基础的 `BasePopper` 组件。如果只需要配置 DropdownMenu 的自定义显示区域，设置如下 css 变量

- `--tr-dropdown-menu-min-top`，默认值 `0px`
- `--tr-dropdown-menu-max-bottom`，默认值 `100%`
- `--tr-dropdown-menu-min-left`，默认值 `0px`
- `--tr-dropdown-menu-max-right`，默认值 `100%`

以上的 css 变量都是 `:root` 范围的，如果只需要针对具体的元素自定义区域，增加 css 选择器优先级即可


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added configurable CSS variables for minimum and maximum top/left positioning of dropdown menus, allowing for more precise control over menu placement.
  * Dynamic calculation of dropdown menu boundaries based on the pills container's position in the suggestion pills demo.

* **Documentation**
  * Updated documentation to describe new CSS variables for dropdown menu positioning and improved formatting for clarity.

* **Style**
  * Enhanced dropdown and popper components to use only top/left positioning and support new CSS variable constraints for consistent alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->