### PR TITLE
fix: update mcp-picker-server form type value

### DIFF
--- a/packages/components/src/mcp-server-picker/components/FormEditor.vue
+++ b/packages/components/src/mcp-server-picker/components/FormEditor.vue
@@ -13,8 +13,8 @@ const formData = defineModel<PluginFormData>('formData', { required: true })
 
 // 类型选项
 const typeOptions = [
-  { value: 'sse', label: '服务器发送事件（sse）' },
-  { value: 'streamableHttp', label: '可流式传输的HTTP（streamableHttp）' },
+  { label: 'sse', text: '服务器发送事件（sse）' },
+  { label: 'streamableHttp', text: '可流式传输的HTTP（streamableHttp）' },
 ]
 
 const { open: openFileDialog, files } = useFileDialog({

--- a/packages/components/src/mcp-server-picker/components/FormEditor.vue
+++ b/packages/components/src/mcp-server-picker/components/FormEditor.vue
@@ -13,8 +13,8 @@ const formData = defineModel<PluginFormData>('formData', { required: true })
 
 // 类型选项
 const typeOptions = [
-  { label: 'sse', text: '服务器发送事件（sse）' },
-  { label: 'streamableHttp', text: '可流式传输的HTTP（streamableHttp）' },
+  { label: 'sse', text: '服务器发送事件（SSE）' },
+  { label: 'streamableHttp', text: '流式HTTP（Streamable HTTP）' },
 ]
 
 const { open: openFileDialog, files } = useFileDialog({


### PR DESCRIPTION
自定义添加插件的表单中：

预期效果：选中插件类型后显示原始的 type 值

     如：选中 `服务器发送事件（sse）` 则 `type` = 'sse'

现状：
     选中 `服务器发送事件（sse）` ,   `type` = '服务器发送事件（sse）'
     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal structure of radio group options for improved clarity. No changes to the available options or their display text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->