### PR TITLE
feat(useMessage): new api send, new option events.onReceiveData

### DIFF
--- a/packages/kit/src/types.ts
+++ b/packages/kit/src/types.ts
@@ -10,8 +10,9 @@ export type MessageRole = 'system' | 'user' | 'assistant'
  */
 export interface ChatMessage {
   role: MessageRole
-  content: string
+  content: string | { type: 'string'; [x: string]: unknown }[]
   name?: string
+  [x: string]: unknown
 }
 
 /**

--- a/packages/kit/src/vue/conversation/useConversation.ts
+++ b/packages/kit/src/vue/conversation/useConversation.ts
@@ -5,7 +5,7 @@
 
 import { reactive, watch } from 'vue'
 import type { ChatMessage } from '../../types'
-import { useMessage, type UseMessageReturn } from '../message/useMessage'
+import { useMessage, type UseMessageOptions, type UseMessageReturn } from '../message/useMessage'
 import type { AIClient } from '../../client'
 
 /**
@@ -91,6 +91,7 @@ export interface UseConversationOptions {
   useStreamByDefault?: boolean
   /** 错误消息模板 */
   errorMessage?: string
+  events?: UseMessageOptions['events']
 }
 
 /**
@@ -157,6 +158,7 @@ export function useConversation(options: UseConversationOptions): UseConversatio
     useStreamByDefault,
     errorMessage,
     initialMessages: [],
+    events: options.events,
   })
 
   // 监听消息变化，自动更新会话


### PR DESCRIPTION
`onReceiveData` 的签名如下：

```ts
onReceiveData?: <T extends ChatCompletionResponse | ChatCompletionStreamResponse>(
  data: T,
  messages: Ref<ChatMessage[]>,
  preventDefault: () => void,
) => void
```

`data` 是大模型响应， `messages` 是本地存储的对话记录， `preventDefault` 可以用来阻止默认行为。

非流式 chat 内部的默认行为如下：

```ts
const assistantMessage: ChatMessage = {
  role: 'assistant',
  content: data.choices[0].message.content,
}
messages.value.push(assistantMessage)

```

流式 chat 内部的默认行为如下：

```ts
if (messages.value[messages.value.length - 1].role === 'user') {
  messages.value.push({ role: 'assistant', content: '' })
}
const choice = data.choices?.[0]
if (choice && choice.delta.content) {
  messages.value[messages.value.length - 1].content += choice.delta.content
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Suggestion pills in the chat input are now interactive dropdown menus, allowing easier access to related actions.
  * Added event-driven extensibility for handling incoming AI response data in chat conversations.

* **Improvements**
  * Enhanced input validation for chat messages, supporting both string and array content and rejecting empty inputs.
  * Simplified and clarified the data structure for suggestion pills.
  * Improved flexibility in sending and adding chat messages.

* **Bug Fixes**
  * Cleaned up unused styles and imports for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->