### PR TITLE
feat: add custom content field support in Bubble component

### DIFF
--- a/docs/demos/bubble/custom-content-field.vue
+++ b/docs/demos/bubble/custom-content-field.vue
@@ -1,0 +1,48 @@
+<template>
+  <tr-bubble-list :items="items" :roles="roles" />
+  <hr />
+  <div>
+    <label>指定渲染属性为 my-content: </label>
+    <tiny-switch v-model="custom" />
+  </div>
+  <hr />
+</template>
+
+<script setup lang="ts">
+import { BubbleContentItem, BubbleListProps, BubbleRoleConfig, TrBubbleList } from '@opentiny/tiny-robot'
+import { IconAi } from '@opentiny/tiny-robot-svgs'
+import { TinySwitch } from '@opentiny/vue'
+import { h, reactive, ref, watch } from 'vue'
+
+const aiAvatar = h(IconAi, { style: { fontSize: '32px' } })
+
+const custom = ref(true)
+
+const thinkingContent = `已获取到西安明天（2025年5月31日）的天气，最高温度28℃，最低温度17℃，有小雨。下一步，使用高德地图的文本搜索工具查找西安适合游玩的地点。`
+
+const items: BubbleListProps['items'] & { 'my-content'?: BubbleContentItem[] }[] = [
+  {
+    role: 'ai',
+    content: thinkingContent,
+    'my-content': [
+      {
+        type: 'collapsible-text',
+        title: '思考过程（折叠消息渲染器）',
+        content: thinkingContent,
+      },
+    ],
+  },
+]
+
+const roles: Record<string, BubbleRoleConfig> = reactive({
+  ai: {
+    placement: 'start',
+    avatar: aiAvatar,
+    customContentField: 'my-content',
+  },
+})
+
+watch(custom, (val) => {
+  roles.ai.customContentField = val ? 'my-content' : undefined
+})
+</script>

--- a/docs/src/components/bubble.md
+++ b/docs/src/components/bubble.md
@@ -127,6 +127,12 @@ content 对象中的所有属性都将传递给组件，onXXX会当作事件传�
 
 <demo vue="../../demos/bubble/messages.vue" />
 
+### 指定渲染属性
+
+和大模型交互数据时，交互的原始数据中的 content 字段可能需要经过前端二次处理再展示到UI上，但此时我们又不想改动原始的 content 字段。此时可以通过 `customContentField` 属性来在前端指定你需要渲染的属性
+
+<demo vue="../../demos/bubble/custom-content-field.vue" />
+
 ### 插槽
 
 气泡组件提供了三个插槽，分别是 默认插槽, `loading` 插槽 和 `footer` 插槽
@@ -162,14 +168,15 @@ type BubblePlacement = 'start' | 'end'
 
 气泡通用属性配置。
 
-| 属性              | 类型                    | 默认值     | 说明                                                                            |
-| ----------------- | ----------------------- | ---------- | ------------------------------------------------------------------------------- |
-| `placement`       | `BubblePlacement`       | -          | 气泡对齐位置 (`'start'` 或 `'end'`)                                             |
-| `avatar`          | `VNode`                 | -          | 气泡头像部分的自定义 Vue 节点                                                   |
-| `shape`           | `'rounded' \| 'corner'` | `'corner'` | 气泡形状                                                                        |
-| `contentRenderer` | `BubbleContentRenderer` | -          | 气泡内容渲染器（当 content 是非空数组时无效，使用 BubbleProvider 注册的渲染器） |
-| `hidden`          | `boolean`               | -          | 是否隐藏气泡                                                                    |
-| `maxWidth`        | `string \| number`      | -          | 气泡内容的最大宽度                                                              |
+| 属性                 | 类型                    | 默认值     | 说明                                                                                                          |
+| -------------------- | ----------------------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| `placement`          | `BubblePlacement`       | -          | 气泡对齐位置 (`'start'` 或 `'end'`)                                                                           |
+| `avatar`             | `VNode`                 | -          | 气泡头像部分的自定义 Vue 节点                                                                                 |
+| `shape`              | `'rounded' \| 'corner'` | `'corner'` | 气泡形状                                                                                                      |
+| `contentRenderer`    | `BubbleContentRenderer` | -          | 气泡内容渲染器（当 content 是非空数组时无效，使用 BubbleProvider 注册的渲染器）                               |
+| `customContentField` | `string`                | -          | 自定义气泡内容字段。比如 customContentField 设置为 'my-content'，则 Bubble 优先渲染 my-content 属性到气泡内容 |
+| `hidden`             | `boolean`               | -          | 是否隐藏气泡                                                                                                  |
+| `maxWidth`           | `string \| number`      | -          | 气泡内容的最大宽度                                                                                            |
 
 ### BubbleProps
 

--- a/packages/components/src/bubble/Bubble.vue
+++ b/packages/components/src/bubble/Bubble.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, useAttrs } from 'vue'
 import { toCssUnit } from '../shared/utils'
 import { BubbleContentFunctionRenderer, BubbleProps, BubbleSlots } from './index.type'
 import { BubbleContentClassRenderer } from './renderers'
@@ -33,17 +33,36 @@ const contentRenderer = computed(() => {
   return { isComponent: true, vNodeOrComponent: renderer }
 })
 
+const attrs = useAttrs()
+
+const customContent = computed(() => {
+  if (!props.customContentField) {
+    return null
+  }
+
+  const value = attrs[props.customContentField]
+
+  // value 是字符串，或者是数组且长度大于0
+  if (typeof value === 'string' || (Array.isArray(value) && value.length > 0)) {
+    return value
+  }
+
+  return null
+})
+
+const finalContent = computed(() => customContent.value || props.content)
+
 const bubbleContent = computed(() => {
-  if (Array.isArray(props.content)) {
+  if (Array.isArray(finalContent.value)) {
     return ''
   }
 
-  return props.content
+  return finalContent.value
 })
 
 const contentItems = computed(() => {
-  if (Array.isArray(props.content)) {
-    return props.content
+  if (Array.isArray(finalContent.value)) {
+    return finalContent.value
   }
 
   return []

--- a/packages/components/src/bubble/index.type.ts
+++ b/packages/components/src/bubble/index.type.ts
@@ -20,6 +20,10 @@ export interface BubbleCommonProps {
    * 如果 Bubble 中的 content 是长度大于 0 的数组，则 contentRenderer 无效。将会使用 BubbleProvider 中注册的渲染器
    */
   contentRenderer?: BubbleContentRenderer
+  /**
+   * 自定义气泡内容字段。比如 customContentField 设置为 'my-content'，则 Bubble 优先渲染 my-content 属性到气泡内容
+   */
+  customContentField?: string
   hidden?: boolean
   maxWidth?: string | number
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add option to specify a custom content field for Bubble items so bubbles can render alternate content instead of the default.
  * Demo added showing toggling between default and custom bubble content (including collapsible custom content).

* **Documentation**
  * Docs updated to describe the custom content field and how to use it; API reference expanded to list the new property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->