### PR TITLE
fix: fix type compatibility of getComposedRanges in TS version 5.9.x

### DIFF
--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -13,15 +13,6 @@ import type {
 } from '../types/editor.type'
 import Block from './Block.vue'
 
-declare global {
-  interface Selection {
-    getComposedRanges?: (options?: { shadowRoots: ShadowRoot[] } | ShadowRoot) => Range[]
-  }
-  interface ShadowRoot {
-    getSelection?: () => Selection
-  }
-}
-
 const SUPPORTS_SHADOW_SELECTION = typeof window.ShadowRoot.prototype.getSelection === 'function'
 const SUPPORTS_COMPOSED_RANGES = typeof window.Selection.prototype.getComposedRanges === 'function'
 
@@ -235,8 +226,12 @@ const isEditor = (node: Node) => {
   return node === editorRef.value
 }
 
+interface CompatibleSelection extends Omit<Selection, 'getComposedRanges'> {
+  getComposedRanges?: (options?: { shadowRoots: ShadowRoot[] } | ShadowRoot) => StaticRange[]
+}
+
 const getSelectionRange = (el: Element) => {
-  const selection = window.getSelection()
+  const selection = window.getSelection() as CompatibleSelection | null
 
   if (!selection) {
     return null

--- a/packages/components/src/sender/components/global.d.ts
+++ b/packages/components/src/sender/components/global.d.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface Selection {
+    getComposedRanges?: (options?: { shadowRoots: ShadowRoot[] } | ShadowRoot) => StaticRange[]
+  }
+
+  interface ShadowRoot {
+    getSelection?: () => Selection
+  }
+}
+
+export {}


### PR DESCRIPTION
ts 5.9.x 版本新增了 getComposedRanges 的类型，但是由于和 safari 浏览器的 getComposedRanges 使用方式不兼容。导致构建时报错

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal handling of selection and shadow root interfaces to improve compatibility with TypeScript.
  * No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->