### PR TITLE
fix: template editor only text nodes are out of focus

### DIFF
--- a/docs/demos/sender/Template.vue
+++ b/docs/demos/sender/Template.vue
@@ -118,6 +118,10 @@ const templates = [
       { type: 'text', content: '。' },
     ],
   },
+  {
+    name: '模板6',
+    data: [{ type: 'text', content: 'ECS 服务器的最新版本' }],
+  },
 ]
 
 // 选择模板

--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -881,21 +881,39 @@ const restoreDataAndCaretPosition = (historyItem: string) => {
   model.value = transformInternalToUser(originalData.value)
 }
 
+/**
+ * 将光标移动到指定元素的末尾
+ * @param id 元素id
+ * @param type 元素类型
+ */
+const setCaretToElementEnd = (id: string, type: 'text' | 'template') => {
+  // 查找目标元素
+  const el = editorRef.value?.querySelector(`[data-id="${id}"][data-type="${type}"]`)
+  if (!el) return // 元素不存在则直接返回
+
+  // 计算文本长度（作为光标偏移量），设置光标位置
+  const offset = el.textContent?.length || 0
+  setCaretPosition(el, offset)
+}
+
 const activateFirstField = () => {
   if (!editorRef.value) {
     return
   }
 
   nextTick(() => {
-    const firstTemplateItem = originalData.value.find((item) => item.type === 'template')
+    const data = originalData.value
 
+    // 场景1：存在template类型的项，定位到第一个template元素后面
+    const firstTemplateItem = data.find((item) => item.type === 'template')
     if (firstTemplateItem) {
-      const startEl = editorRef.value?.querySelector(`[data-id="${firstTemplateItem.id}"][data-type="template"]`)
+      setCaretToElementEnd(firstTemplateItem.id, 'template')
+    }
 
-      if (startEl) {
-        const startOffset = startEl.textContent?.length || 0
-        setCaretPosition(startEl, startOffset)
-      }
+    // 场景2：仅存在一个text类型的项，定位到该text元素后面
+    const onlyTextItem = data.find((item) => item.type === 'text')
+    if (onlyTextItem && data.length === 1) {
+      setCaretToElementEnd(onlyTextItem.id, 'text')
     }
   })
 }

--- a/packages/components/src/sender/components/TemplateEditor.vue
+++ b/packages/components/src/sender/components/TemplateEditor.vue
@@ -911,9 +911,9 @@ const activateFirstField = () => {
     }
 
     // 场景2：仅存在一个text类型的项，定位到该text元素后面
-    const onlyTextItem = data.find((item) => item.type === 'text')
+    const onlyTextItem = data.every((item) => item.type === 'text')
     if (onlyTextItem && data.length === 1) {
-      setCaretToElementEnd(onlyTextItem.id, 'text')
+      setCaretToElementEnd(data[0].id, 'text')
     }
   })
 }


### PR DESCRIPTION
### 一、问题背景：

在应用中，点击“纯文本”技能后，虽然文本内容能够回填到输入框中，但编辑光标未能自动激活，

导致用户无法直接编辑，必须再次点击一次以激活编辑状态。

### 二、问题分析

未对纯文本模板的光标定位做处理

### 三、预期效果

在点击“纯文本”技能后，自动填充文本内容并同时激活输入框的编辑状态，使用户能够直接编辑，无需额外点击。

### 四、测试步骤

点击 模板 6，文本内容回填到输入框中，激活输入框的编辑状态


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a sixth predefined template (模板6) to the sender demo, providing a new one-click text option and an extra template button in the UI. Selecting it populates the editor with a single preset text item.

- Refactor
  - Consolidated caret-placement behavior in the template editor to ensure more consistent initial cursor focus on the first editable field, improving usability while preserving existing public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->