### PR TITLE
fix: add TrHistory import to HistoryGroup component demo

### DIFF
--- a/docs/demos/history/group.vue
+++ b/docs/demos/history/group.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup lang="ts">
-import { HistoryGroup, HistoryItem } from '@opentiny/tiny-robot'
+import { HistoryGroup, HistoryItem, TrHistory } from '@opentiny/tiny-robot'
 import { reactive, ref } from 'vue'
 
 const selected = ref('2')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the history group demo to include the TrHistory import from the library, aligning the example with current exports.
  - No changes to demo behavior, interactions, or UI; the update affects only the demo code presentation.
  - Helps ensure the demo code reflects the available components, improving clarity for readers without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->