### PR TITLE
fix: sender component footer-left slot location error

### DIFF
--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -389,22 +389,6 @@ const handleBlur = (event: FocusEvent) => {
 
 const currentType = computed(() => (currentMode.value === 'multiple' ? 'textarea' : 'text'))
 
-const justifyContent = computed(
-  (): {
-    display: string
-    justifyContent: 'space-between' | 'flex-end'
-    alignItems: string
-  } => {
-    const justifyContent = props.showWordLimit && props.maxLength !== Infinity ? 'space-between' : 'flex-end'
-
-    return {
-      display: 'flex',
-      justifyContent,
-      alignItems: 'center',
-    }
-  },
-)
-
 type SlotsType = {
   decorativeContent?: () => boolean
   [key: string]: (() => any) | undefined // eslint-disable-line
@@ -585,11 +569,7 @@ defineExpose({
 
         <!-- 底部插槽 - 底部工具栏作为默认内容 -->
         <Transition name="tiny-sender-slide-up">
-          <div
-            v-if="currentMode === 'multiple'"
-            :style="justifyContent"
-            class="tiny-sender__footer-slot tiny-sender__bottom-row"
-          >
+          <div v-if="currentMode === 'multiple'" class="tiny-sender__footer-slot tiny-sender__bottom-row">
             <!-- 底部左侧区域 -->
             <div class="tiny-sender__footer-left">
               <!-- 左侧自定义插槽 -->


### PR DESCRIPTION
### 一、问题描述

基于 sender 组件的 `footer-left` 插槽创建的元素出现在组件的 **右下方**， 

### 二、预期效果

基于 sender 组件的  `footer-left` 插槽创建的元素出现在组件的 **左下方**

### 三、问题分析

组件的 `footer-left` 插槽受到 限制字数显示 的影响，

如果 `showWordLimit` 为 `false`，或者 `maxLength` 不设置。布局就有问题。

即 显示限制字数，则  `footer-left` 插槽元素位置表现正常，反之则不正常。

### 四、解决方案

去除无效的计算样式 justifyContent 即可

### 五、效果对比

**示例代码**
<img width="389" height="100" alt="image" src="https://github.com/user-attachments/assets/0d7b1177-b4ce-40a4-b5cd-a2d6bd8321f2" />

**处理前：**
<img width="664" height="146" alt="image" src="https://github.com/user-attachments/assets/c8dbac67-e417-4d6c-980f-ee34eb9c35e4" />


**处理后：**
<img width="687" height="126" alt="image" src="https://github.com/user-attachments/assets/609aaf94-70f0-40fd-9c9e-b05a341e3ca1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated footer alignment in multi-select mode to use CSS-based layout, improving visual consistency. Alignment may appear slightly adjusted in some scenarios.

* **Refactor**
  * Simplified layout handling by removing runtime style computation in favor of class-based styling for the sender component’s footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->