### PR TITLE
fix: the scroll bar only controls the display of the card list

### DIFF
--- a/packages/components/src/mcp-server-picker/components/PluginCard.vue
+++ b/packages/components/src/mcp-server-picker/components/PluginCard.vue
@@ -182,7 +182,6 @@ const getHoverTitle = (isEnabled: boolean) => {
   background: rgb(255, 255, 255);
   border-radius: 12px;
   box-shadow: 0px 4px 16px 0px rgba(0, 0, 0, 0.08);
-  overflow: hidden;
 
   &__main {
     display: flex;
@@ -320,14 +319,7 @@ const getHoverTitle = (isEnabled: boolean) => {
   // 工具列表样式
   &__tools {
     background: rgb(255, 255, 255);
-  }
-
-  &__tool-item {
-    position: relative;
-
-    &:last-child .plugin-card__tool {
-      border-radius: 0 0 12px 12px;
-    }
+    border-radius: 0 0 16px 16px;
   }
 
   &__tool {

--- a/packages/components/src/mcp-server-picker/index.vue
+++ b/packages/components/src/mcp-server-picker/index.vue
@@ -328,20 +328,22 @@ const transitionName = computed(() => {
                 </TinyInput>
               </div>
 
-              <div class="mcp-server-picker__content-installed-list" v-if="hasFilteredPlugins">
+              <div class="mcp-server-picker__content-list" v-if="hasFilteredPlugins">
                 <div v-if="props.loading" class="mcp-server-picker__loading">加载中...</div>
                 <template v-else>
-                  <!-- 已添加插件列表 -->
-                  <PluginCard
-                    v-for="plugin in installedFilteredPlugins"
-                    :key="plugin.id"
-                    :plugin="plugin"
-                    mode="installed"
-                    :expandable="!!plugin.tools?.length"
-                    @toggle-plugin="(enabled) => handlePluginToggle(plugin, enabled)"
-                    @toggle-tool="(toolId, enabled) => handleToolToggle(plugin, toolId, enabled)"
-                    @delete-plugin="() => handleDeletePlugin(plugin)"
-                  />
+                  <div class="mcp-server-picker__content-list-wrapper">
+                    <!-- 已添加插件列表 -->
+                    <PluginCard
+                      v-for="plugin in installedFilteredPlugins"
+                      :key="plugin.id"
+                      :plugin="plugin"
+                      mode="installed"
+                      :expandable="!!plugin.tools?.length"
+                      @toggle-plugin="(enabled) => handlePluginToggle(plugin, enabled)"
+                      @toggle-tool="(toolId, enabled) => handleToolToggle(plugin, toolId, enabled)"
+                      @delete-plugin="() => handleDeletePlugin(plugin)"
+                    />
+                  </div>
                 </template>
               </div>
               <NoData v-else :search-query="installedSearch" />
@@ -374,19 +376,21 @@ const transitionName = computed(() => {
               </div>
             </div>
 
-            <div v-if="hasFilteredPlugins" class="mcp-server-picker__content-market-list">
+            <div v-if="hasFilteredPlugins" class="mcp-server-picker__content-list">
               <div v-if="props.marketLoading" class="mcp-server-picker__loading">加载中...</div>
               <template v-else>
-                <!-- 插件市场列表 -->
-                <PluginCard
-                  v-for="plugin in marketFilteredPlugins"
-                  :key="plugin.id"
-                  :plugin="plugin"
-                  mode="market"
-                  :expandable="false"
-                  :show-tool-count="false"
-                  @add-plugin="(added: boolean) => handleAddPlugin(plugin, added)"
-                />
+                <div class="mcp-server-picker__content-list-wrapper">
+                  <!-- 插件市场列表 -->
+                  <PluginCard
+                    v-for="plugin in marketFilteredPlugins"
+                    :key="plugin.id"
+                    :plugin="plugin"
+                    mode="market"
+                    :expandable="false"
+                    :show-tool-count="false"
+                    @add-plugin="(added: boolean) => handleAddPlugin(plugin, added)"
+                  />
+                </div>
               </template>
             </div>
             <NoData v-else :search-query="marketSearch || marketCategory" />
@@ -414,16 +418,12 @@ const transitionName = computed(() => {
   // 默认样式(fixed模式)
   &.popup-type-fixed {
     width: 482px;
-    height: auto;
-    overflow-y: auto;
   }
 
   // 抽屉模式样式
   &.popup-type-drawer {
     width: 482px;
     padding-top: 20px;
-    height: 100vh;
-    overflow-y: auto;
   }
 
   &__header {
@@ -496,22 +496,20 @@ const transitionName = computed(() => {
       justify-content: space-between;
     }
 
-    &-market-list {
-      display: flex;
-      flex-direction: column;
-      overflow: visible;
-      gap: 16px;
-    }
-
     &-installed-search {
       margin: 16px 0;
     }
 
-    &-installed-list {
-      display: flex;
-      flex-direction: column;
-      overflow: visible;
-      gap: 16px;
+    &-list {
+      max-height: calc(100vh - 170px);
+      overflow-y: auto;
+      padding: 5px;
+
+      &-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
     }
   }
 

--- a/packages/components/src/mcp-server-picker/index.vue
+++ b/packages/components/src/mcp-server-picker/index.vue
@@ -319,35 +319,31 @@ const transitionName = computed(() => {
       <div class="mcp-server-picker__content">
         <TinyTabs v-model="activeTab">
           <TinyTabItem v-if="props.showInstalledTab" :title="props.installedTabTitle" name="installed">
-            <div class="mcp-server-picker__content-item">
-              <div v-if="props.enableSearch" class="mcp-server-picker__content-installed-search">
-                <TinyInput v-model="installedSearch" :placeholder="props.searchPlaceholder">
-                  <template #suffix>
-                    <IconSearch style="font-size: 16px; cursor: pointer" />
-                  </template>
-                </TinyInput>
-              </div>
-
-              <div class="mcp-server-picker__content-list" v-if="hasFilteredPlugins">
-                <div v-if="props.loading" class="mcp-server-picker__loading">加载中...</div>
-                <template v-else>
-                  <div class="mcp-server-picker__content-list-wrapper">
-                    <!-- 已添加插件列表 -->
-                    <PluginCard
-                      v-for="plugin in installedFilteredPlugins"
-                      :key="plugin.id"
-                      :plugin="plugin"
-                      mode="installed"
-                      :expandable="!!plugin.tools?.length"
-                      @toggle-plugin="(enabled) => handlePluginToggle(plugin, enabled)"
-                      @toggle-tool="(toolId, enabled) => handleToolToggle(plugin, toolId, enabled)"
-                      @delete-plugin="() => handleDeletePlugin(plugin)"
-                    />
-                  </div>
+            <div v-if="props.enableSearch" class="mcp-server-picker__content-installed-search">
+              <TinyInput v-model="installedSearch" :placeholder="props.searchPlaceholder">
+                <template #suffix>
+                  <IconSearch style="font-size: 16px; cursor: pointer" />
                 </template>
-              </div>
-              <NoData v-else :search-query="installedSearch" />
+              </TinyInput>
             </div>
+
+            <div v-if="hasFilteredPlugins" class="mcp-server-picker__content-list">
+              <div v-if="props.loading" class="mcp-server-picker__loading">加载中...</div>
+              <div v-else class="mcp-server-picker__content-list-wrapper">
+                <!-- 已添加插件列表 -->
+                <PluginCard
+                  v-for="plugin in installedFilteredPlugins"
+                  :key="plugin.id"
+                  :plugin="plugin"
+                  mode="installed"
+                  :expandable="!!plugin.tools?.length"
+                  @toggle-plugin="(enabled) => handlePluginToggle(plugin, enabled)"
+                  @toggle-tool="(toolId, enabled) => handleToolToggle(plugin, toolId, enabled)"
+                  @delete-plugin="() => handleDeletePlugin(plugin)"
+                />
+              </div>
+            </div>
+            <NoData v-else :search-query="installedSearch" />
           </TinyTabItem>
 
           <TinyTabItem v-if="props.showMarketTab" :title="props.marketTabTitle" name="market">
@@ -378,20 +374,18 @@ const transitionName = computed(() => {
 
             <div v-if="hasFilteredPlugins" class="mcp-server-picker__content-list">
               <div v-if="props.marketLoading" class="mcp-server-picker__loading">加载中...</div>
-              <template v-else>
-                <div class="mcp-server-picker__content-list-wrapper">
-                  <!-- 插件市场列表 -->
-                  <PluginCard
-                    v-for="plugin in marketFilteredPlugins"
-                    :key="plugin.id"
-                    :plugin="plugin"
-                    mode="market"
-                    :expandable="false"
-                    :show-tool-count="false"
-                    @add-plugin="(added: boolean) => handleAddPlugin(plugin, added)"
-                  />
-                </div>
-              </template>
+              <div v-else class="mcp-server-picker__content-list-wrapper">
+                <!-- 插件市场列表 -->
+                <PluginCard
+                  v-for="plugin in marketFilteredPlugins"
+                  :key="plugin.id"
+                  :plugin="plugin"
+                  mode="market"
+                  :expandable="false"
+                  :show-tool-count="false"
+                  @add-plugin="(added: boolean) => handleAddPlugin(plugin, added)"
+                />
+              </div>
             </div>
             <NoData v-else :search-query="marketSearch || marketCategory" />
           </TinyTabItem>
@@ -418,12 +412,16 @@ const transitionName = computed(() => {
   // 默认样式(fixed模式)
   &.popup-type-fixed {
     width: 482px;
+    display: flex;
+    flex-direction: column;
   }
 
   // 抽屉模式样式
   &.popup-type-drawer {
     width: 482px;
     padding-top: 20px;
+    display: flex;
+    flex-direction: column;
   }
 
   &__header {
@@ -431,6 +429,7 @@ const transitionName = computed(() => {
     justify-content: space-between;
     align-items: center;
     margin-bottom: 18px;
+    flex-shrink: 0;
 
     &-left {
       color: #191919;
@@ -484,6 +483,8 @@ const transitionName = computed(() => {
     display: flex;
     flex-direction: column;
     gap: 10px;
+    flex: 1;
+    min-height: 0;
 
     :deep(.tiny-tabs__content) {
       margin: 0;
@@ -494,16 +495,19 @@ const transitionName = computed(() => {
       display: flex;
       padding: 16px 0;
       justify-content: space-between;
+      flex-shrink: 0;
     }
 
     &-installed-search {
       margin: 16px 0;
+      flex-shrink: 0;
     }
 
     &-list {
-      max-height: calc(100vh - 170px);
-      overflow-y: auto;
+      flex: 1;
+      margin-bottom: 16px;
       padding: 5px;
+      overflow-y: auto;
 
       &-wrapper {
         display: flex;
@@ -557,6 +561,27 @@ const transitionName = computed(() => {
   &-leave-to {
     opacity: 0;
   }
+}
+
+:deep(.tiny-tabs) {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+:deep(.tiny-tabs__header) {
+  flex-shrink: 0;
+}
+
+:deep(.tiny-tabs__content) {
+  flex: 1;
+  height: 100%;
+}
+
+:deep(.tiny-tab-pane) {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 // 深度选择器样式

--- a/packages/components/src/mcp-server-picker/index.vue
+++ b/packages/components/src/mcp-server-picker/index.vue
@@ -329,7 +329,7 @@ const transitionName = computed(() => {
 
             <div v-if="hasFilteredPlugins" class="mcp-server-picker__content-list">
               <div v-if="props.loading" class="mcp-server-picker__loading">加载中...</div>
-              <div v-else class="mcp-server-picker__content-list-wrapper">
+              <template v-else>
                 <!-- 已添加插件列表 -->
                 <PluginCard
                   v-for="plugin in installedFilteredPlugins"
@@ -341,7 +341,7 @@ const transitionName = computed(() => {
                   @toggle-tool="(toolId, enabled) => handleToolToggle(plugin, toolId, enabled)"
                   @delete-plugin="() => handleDeletePlugin(plugin)"
                 />
-              </div>
+              </template>
             </div>
             <NoData v-else :search-query="installedSearch" />
           </TinyTabItem>
@@ -374,7 +374,7 @@ const transitionName = computed(() => {
 
             <div v-if="hasFilteredPlugins" class="mcp-server-picker__content-list">
               <div v-if="props.marketLoading" class="mcp-server-picker__loading">加载中...</div>
-              <div v-else class="mcp-server-picker__content-list-wrapper">
+              <template v-else>
                 <!-- 插件市场列表 -->
                 <PluginCard
                   v-for="plugin in marketFilteredPlugins"
@@ -385,7 +385,7 @@ const transitionName = computed(() => {
                   :show-tool-count="false"
                   @add-plugin="(added: boolean) => handleAddPlugin(plugin, added)"
                 />
-              </div>
+              </template>
             </div>
             <NoData v-else :search-query="marketSearch || marketCategory" />
           </TinyTabItem>
@@ -509,11 +509,9 @@ const transitionName = computed(() => {
       padding: 5px;
       overflow-y: auto;
 
-      &-wrapper {
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-      }
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
     }
   }
 


### PR DESCRIPTION
### 一、问题描述

mcp 面板滚动时，面板所有内容都滚动。

预期效果是：mcp 面板滚动时，只有卡片列表进行滚动

### 二、实现方案

设置 卡片列表的 最大高度，优化 样式内容 及 结构

### 三、效果对比

**优化前**

![scroll-before](https://github.com/user-attachments/assets/12ce67d7-fcd2-4618-9c09-f602883c60da)


**优化后**

![scroll-after](https://github.com/user-attachments/assets/0227f5d0-2ce4-47c8-850d-a4f431928040)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Unified visual layout for installed and marketplace plugin lists with consistent spacing, padding and vertical flow.
  - Popup/drawer modes now use flexible full-height stacking; content scrolls smoothly and headers don’t shrink.
  - Plugin tool area corners now round as a single block; tabs enforce full-height column layout.
  - Installed list shows a NoData fallback when no results; market NoData remains filter-driven.

- Refactor
  - Simplified both lists into a shared, reusable content-list structure without changing behavior.

- Chores
  - No public API, props, or events changed; existing actions continue to work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->