### PR TITLE
docs: enhance useMessage documentation and fix type definitions

### DIFF
--- a/docs/src/tools/message.md
+++ b/docs/src/tools/message.md
@@ -11,11 +11,7 @@
 `onReceiveData` 的签名如下：
 
 ```ts
-onReceiveData?: <T = any>(
-  data: T,
-  messages: Ref<ChatMessage[]>,
-  preventDefault: () => void,
-) => void
+onReceiveData?: <T = any>(data: T, messages: Ref<ChatMessage[]>, preventDefault: () => void) => void
 ```
 
 `data` 是大模型响应， `messages` 是本地存储的对话记录， `preventDefault` 可以用来阻止默认行为。

--- a/docs/src/tools/message.md
+++ b/docs/src/tools/message.md
@@ -160,11 +160,13 @@ interface ChatCompletionResponseChoice {
   index: number
   message: ChatCompletionResponseMessage
   finish_reason: string
+  [x: string]: unknown
 }
 
 interface ChatCompletionResponseMessage {
   role: MessageRole
   content: string
+  [x: string]: unknown
 }
 
 interface ChatCompletionResponseUsage {
@@ -185,10 +187,12 @@ interface ChatCompletionStreamResponseChoice {
   index: number
   delta: ChatCompletionStreamResponseDelta
   finish_reason: string | null
+  [x: string]: unknown
 }
 
 interface ChatCompletionStreamResponseDelta {
   content?: string
   role?: MessageRole
+  [x: string]: unknown
 }
 ```

--- a/docs/src/tools/message.md
+++ b/docs/src/tools/message.md
@@ -11,7 +11,7 @@
 `onReceiveData` 的签名如下：
 
 ```ts
-onReceiveData?: <T extends ChatCompletionResponse | ChatCompletionStreamResponse>(
+onReceiveData?: <T = any>(
   data: T,
   messages: Ref<ChatMessage[]>,
   preventDefault: () => void,
@@ -66,11 +66,7 @@ interface UseMessageOptions {
   initialMessages?: ChatMessage[]
   /** 事件回调 */
   events?: {
-    onReceiveData?: <T extends ChatCompletionResponse | ChatCompletionStreamResponse>(
-      data: T,
-      messages: Ref<ChatMessage[]>,
-      preventDefault: () => void,
-    ) => void
+    onReceiveData?: <T = any>(data: T, messages: Ref<ChatMessage[]>, preventDefault: () => void) => void
   }
 }
 ```
@@ -123,76 +119,4 @@ enum STATUS {
 // 状态常量
 const GeneratingStatus = [STATUS.PROCESSING, STATUS.STREAMING]
 const FinalStatus = [STATUS.FINISHED, STATUS.ABORTED, STATUS.ERROR]
-```
-
-## 相关类型定义
-
-### ChatMessage
-
-```typescript
-interface ChatMessage {
-  role: MessageRole
-  content: string | { type: string; [x: string]: unknown }[]
-  name?: string
-  [x: string]: unknown
-}
-
-type MessageRole = 'system' | 'user' | 'assistant'
-```
-
-### AI客户端类型
-
-查看 [AIClient](./ai-client.html#方法)
-
-### 响应类型
-
-```typescript
-interface ChatCompletionResponse {
-  id: string
-  object: string
-  created: number
-  model: string
-  choices: ChatCompletionResponseChoice[]
-  usage: ChatCompletionResponseUsage
-}
-
-interface ChatCompletionResponseChoice {
-  index: number
-  message: ChatCompletionResponseMessage
-  finish_reason: string
-  [x: string]: unknown
-}
-
-interface ChatCompletionResponseMessage {
-  role: MessageRole
-  content: string
-  [x: string]: unknown
-}
-
-interface ChatCompletionResponseUsage {
-  prompt_tokens: number
-  completion_tokens: number
-  total_tokens: number
-}
-
-interface ChatCompletionStreamResponse {
-  id: string
-  object: string
-  created: number
-  model: string
-  choices: ChatCompletionStreamResponseChoice[]
-}
-
-interface ChatCompletionStreamResponseChoice {
-  index: number
-  delta: ChatCompletionStreamResponseDelta
-  finish_reason: string | null
-  [x: string]: unknown
-}
-
-interface ChatCompletionStreamResponseDelta {
-  content?: string
-  role?: MessageRole
-  [x: string]: unknown
-}
 ```

--- a/docs/src/tools/message.md
+++ b/docs/src/tools/message.md
@@ -1,9 +1,46 @@
-
 # 消息与数据管理 useMessage
 
 ## 示例
 
+### 基础用法
+
 <demo vue="../../demos/tools/message/Basic.vue" />
+
+### onReceiveData 事件
+
+`onReceiveData` 的签名如下：
+
+```ts
+onReceiveData?: <T extends ChatCompletionResponse | ChatCompletionStreamResponse>(
+  data: T,
+  messages: Ref<ChatMessage[]>,
+  preventDefault: () => void,
+) => void
+```
+
+`data` 是大模型响应， `messages` 是本地存储的对话记录， `preventDefault` 可以用来阻止默认行为。
+
+非流式 chat 内部的默认行为如下：
+
+```ts
+const assistantMessage: ChatMessage = {
+  role: 'assistant',
+  content: data.choices[0].message.content,
+}
+messages.value.push(assistantMessage)
+```
+
+流式 chat 内部的默认行为如下：
+
+```ts
+if (messages.value[messages.value.length - 1].role === 'user') {
+  messages.value.push({ role: 'assistant', content: '' })
+}
+const choice = data.choices?.[0]
+if (choice && choice.delta.content) {
+  messages.value[messages.value.length - 1].content += choice.delta.content
+}
+```
 
 ## API
 
@@ -15,48 +52,59 @@ const messageComposable: UseMessageReturn = useMessage(
 
 ### 选项
 
-
 `useMessage` 接受以下选项：
 
 ```typescript
 interface UseMessageOptions {
   /** AI客户端实例 */
-  client: AIClient;
+  client: AIClient
   /** 是否默认使用流式响应 */
-  useStreamByDefault?: boolean;
+  useStreamByDefault?: boolean
   /** 错误消息模板 */
-  errorMessage?: string;
+  errorMessage?: string
   /** 初始消息列表 */
-  initialMessages?: ChatMessage[];
+  initialMessages?: ChatMessage[]
+  /** 事件回调 */
+  events?: {
+    onReceiveData?: <T extends ChatCompletionResponse | ChatCompletionStreamResponse>(
+      data: T,
+      messages: Ref<ChatMessage[]>,
+      preventDefault: () => void,
+    ) => void
+  }
 }
 ```
 
 ### 返回值
 
 `useMessage` 返回以下内容：
+
 ```typescript
 interface UseMessageReturn {
-  messages: ChatMessage[];
+  messages: Ref<ChatMessage[]>
   /** 消息状态 */
-  messageState: Reactive<MessageState>;
+  messageState: Reactive<MessageState>
   /** 输入消息 */
-  inputMessage: Ref<string>;
+  inputMessage: Ref<string>
   /** 是否使用流式响应 */
-  useStream: Ref<boolean>;
+  useStream: Ref<boolean>
   /** 发送消息 */
-  sendMessage: () => Promise<void>;
+  sendMessage: (content?: ChatMessage['content'], clearInput?: boolean) => Promise<void>
+  /** 手动执行addMessage添加消息后，可以执行send发送消息 */
+  send: () => Promise<void>
   /** 清空消息 */
-  clearMessages: () => void;
+  clearMessages: () => void
   /** 添加消息 */
-  addMessage: (message: ChatMessage) => void;
+  addMessage: (message: ChatMessage | ChatMessage[]) => void
   /** 中止请求 */
-  abortRequest: () => void;
+  abortRequest: () => void
   /** 重试请求 */
-  retryRequest: () => Promise<void>;
+  retryRequest: (msgIndex: number) => Promise<void>
 }
 ```
 
 ### MessageState 接口
+
 ```typescript
 interface MessageState {
   status: STATUS
@@ -70,5 +118,77 @@ enum STATUS {
   FINISHED = 'finished', // AI请求已完成
   ABORTED = 'aborted', // 用户中止请求
   ERROR = 'error', // AI请求发生错误
+}
+
+// 状态常量
+const GeneratingStatus = [STATUS.PROCESSING, STATUS.STREAMING]
+const FinalStatus = [STATUS.FINISHED, STATUS.ABORTED, STATUS.ERROR]
+```
+
+## 相关类型定义
+
+### ChatMessage
+
+```typescript
+interface ChatMessage {
+  role: MessageRole
+  content: string | { type: string; [x: string]: unknown }[]
+  name?: string
+  [x: string]: unknown
+}
+
+type MessageRole = 'system' | 'user' | 'assistant'
+```
+
+### AI客户端类型
+
+查看 [AIClient](./ai-client.html#方法)
+
+### 响应类型
+
+```typescript
+interface ChatCompletionResponse {
+  id: string
+  object: string
+  created: number
+  model: string
+  choices: ChatCompletionResponseChoice[]
+  usage: ChatCompletionResponseUsage
+}
+
+interface ChatCompletionResponseChoice {
+  index: number
+  message: ChatCompletionResponseMessage
+  finish_reason: string
+}
+
+interface ChatCompletionResponseMessage {
+  role: MessageRole
+  content: string
+}
+
+interface ChatCompletionResponseUsage {
+  prompt_tokens: number
+  completion_tokens: number
+  total_tokens: number
+}
+
+interface ChatCompletionStreamResponse {
+  id: string
+  object: string
+  created: number
+  model: string
+  choices: ChatCompletionStreamResponseChoice[]
+}
+
+interface ChatCompletionStreamResponseChoice {
+  index: number
+  delta: ChatCompletionStreamResponseDelta
+  finish_reason: string | null
+}
+
+interface ChatCompletionStreamResponseDelta {
+  content?: string
+  role?: MessageRole
 }
 ```

--- a/packages/kit/src/types.ts
+++ b/packages/kit/src/types.ts
@@ -10,7 +10,7 @@ export type MessageRole = 'system' | 'user' | 'assistant'
  */
 export interface ChatMessage {
   role: MessageRole
-  content: string | { type: 'string'; [x: string]: unknown }[]
+  content: string | { type: string; [x: string]: unknown }[]
   name?: string
   [x: string]: unknown
 }

--- a/packages/kit/src/types.ts
+++ b/packages/kit/src/types.ts
@@ -57,7 +57,6 @@ export interface ChatCompletionResponseChoice {
   index: number
   message: ChatCompletionResponseMessage
   finish_reason: string
-  [x: string]: unknown
 }
 
 /**
@@ -97,7 +96,6 @@ export interface ChatCompletionStreamResponseChoice {
   index: number
   delta: ChatCompletionStreamResponseDelta
   finish_reason: string | null
-  [x: string]: unknown
 }
 
 /**

--- a/packages/kit/src/types.ts
+++ b/packages/kit/src/types.ts
@@ -47,6 +47,7 @@ export interface ChatCompletionRequest {
 export interface ChatCompletionResponseMessage {
   role: MessageRole
   content: string
+  [x: string]: unknown
 }
 
 /**
@@ -56,6 +57,7 @@ export interface ChatCompletionResponseChoice {
   index: number
   message: ChatCompletionResponseMessage
   finish_reason: string
+  [x: string]: unknown
 }
 
 /**
@@ -85,6 +87,7 @@ export interface ChatCompletionResponse {
 export interface ChatCompletionStreamResponseDelta {
   content?: string
   role?: MessageRole
+  [x: string]: unknown
 }
 
 /**
@@ -94,6 +97,7 @@ export interface ChatCompletionStreamResponseChoice {
   index: number
   delta: ChatCompletionStreamResponseDelta
   finish_reason: string | null
+  [x: string]: unknown
 }
 
 /**

--- a/packages/kit/src/vue/message/useMessage.ts
+++ b/packages/kit/src/vue/message/useMessage.ts
@@ -60,7 +60,7 @@ export interface UseMessageReturn {
   /** 是否使用流式响应 */
   useStream: Ref<boolean>
   /** 发送消息 */
-  sendMessage: (content?: string, clearInput?: boolean) => Promise<void>
+  sendMessage: (content?: ChatMessage['content'], clearInput?: boolean) => Promise<void>
   /** 手动执行addMessage添加消息后，可以执行send发送消息 */
   send: () => Promise<void>
   /** 清空消息 */

--- a/packages/kit/src/vue/message/useMessage.ts
+++ b/packages/kit/src/vue/message/useMessage.ts
@@ -40,11 +40,8 @@ export interface UseMessageOptions {
   /** 初始消息列表 */
   initialMessages?: ChatMessage[]
   events?: {
-    onReceiveData?: <T extends ChatCompletionResponse | ChatCompletionStreamResponse>(
-      data: T,
-      messages: Ref<ChatMessage[]>,
-      preventDefault: () => void,
-    ) => void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onReceiveData?: <T = any>(data: T, messages: Ref<ChatMessage[]>, preventDefault: () => void) => void
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an event hook to intercept incoming model data (with preventDefault); hook is more generic.
  * Messages are now reactive (observable).
  * sendMessage accepts optional content and clearInput; added send().
  * addMessage accepts single or multiple messages; retry can target a specific message index.
  * Exposes user-facing error message, broader message content formats, new ChatMessage/MessageRole and response typings.
  * Expanded status categories (includes initial and grouped generating/final statuses).

* **Documentation**
  * API docs updated with richer message/response typings and status definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->