### PR TITLE
fix: sender component width is abnormal in the example project

### DIFF
--- a/docs/demos/examples/Assistant.vue
+++ b/docs/demos/examples/Assistant.vue
@@ -52,7 +52,7 @@
     ></tr-bubble-list>
 
     <template #footer>
-      <div class="chat-input max-container">
+      <div class="chat-input" :class="{ 'max-container': fullscreen }">
         <div class="chat-input-pills">
           <tr-suggestion-popover
             style="--tr-suggestion-popover-width: 440px"


### PR DESCRIPTION
### 一、问题：

示例项目的 输入框 在非全屏模式下，宽度显示异常

### 二、分析：

外层的样式缺少判断，导致内部组件的宽度受到影响

### 三、处理：

补充 `max-container` 的判断

### 四、截图：

修改前：

<img width="607" height="181" alt="image" src="https://github.com/user-attachments/assets/b2d1fe25-4eac-4c43-9972-c9bddcbb5d7d" />


修改后：

<img width="596" height="144" alt="image" src="https://github.com/user-attachments/assets/ae7fe505-859a-45e6-80ef-282f2b105fa7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat input responsiveness: max-width styling now applies only in fullscreen. Resolves cramped or misaligned layouts in standard view while preserving an expanded experience when fullscreen is enabled. No functional changes.
* **Style**
  * Chat input container now visually aligns with fullscreen state for a more consistent, predictable UI across display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->