### PR TITLE
fix: remove MCP component's built-in notification and optimize plugin title

### DIFF
--- a/packages/components/src/mcp-server-picker/components/PluginCard.vue
+++ b/packages/components/src/mcp-server-picker/components/PluginCard.vue
@@ -229,6 +229,10 @@ const getHoverTitle = (isEnabled: boolean) => {
     line-height: 24px;
     color: rgb(25, 25, 25);
     text-align: justify;
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__count {

--- a/packages/components/src/mcp-server-picker/index.vue
+++ b/packages/components/src/mcp-server-picker/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TinyTabs, TinyTabItem, TinyInput, TinySelect, TinyOption, TinyModal } from '@opentiny/vue'
+import { TinyTabs, TinyTabItem, TinyInput, TinySelect, TinyOption } from '@opentiny/vue'
 import { ref, computed, watch } from 'vue'
 import { PluginCard, PluginModal, NoData } from './components'
 import { IconClose, IconSearch, IconPlus } from '@opentiny/tiny-robot-svgs'
@@ -170,21 +170,11 @@ const handleToolToggle = (plugin: PluginInfo, toolId: string, enabled: boolean) 
 
 const handleDeletePlugin = (plugin: PluginInfo) => {
   if (!props.allowPluginDelete) return
-  TinyModal.message({
-    message: `${plugin.name} 已移除`,
-    status: 'success',
-  })
   emit('plugin-delete', plugin)
 }
 
 const handleAddPlugin = (plugin: PluginInfo, added: boolean) => {
   if (!props.allowPluginAdd) return
-  if (added) {
-    TinyModal.message({
-      message: `${plugin.name} 已添加`,
-      status: 'success',
-    })
-  }
   emit('plugin-add', plugin, added)
 }
 


### PR DESCRIPTION
1. 移除 mcp 组件内置的通知

2. mcp 插件 title 过长时显示省略号

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed built-in toast notifications from the server picker’s add/delete flow; actions now emit events only and rely on the surrounding app for user feedback, preventing duplicate messaging without changing add/delete behavior.
- Style
  - Plugin card now truncates long plugin names with an ellipsis to improve layout and prevent wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->