### PR TITLE
fix: replace the Select with BaseSelect component

### DIFF
--- a/docs/demos/drag-overlay/basic.vue
+++ b/docs/demos/drag-overlay/basic.vue
@@ -59,12 +59,12 @@
       <!-- accept 属性 -->
       <div class="demo-section-body">
         <label style="margin-right: 8px">accept:</label>
-        <TinySelect v-model="accept">
+        <TinyBaseSelect v-model="accept">
           <TinyOption label="图片" value="image/*" />
           <TinyOption label="视频" value="video/*" />
           <TinyOption label="音频" value="audio/*" />
           <TinyOption label="其他" value="application/*" />
-        </TinySelect>
+        </TinyBaseSelect>
       </div>
 
       <!-- multiple 属性 radio 示例 -->
@@ -79,7 +79,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { TinySwitch, TinySelect, TinyOption } from '@opentiny/vue'
+import { TinySwitch, TinyBaseSelect, TinyOption } from '@opentiny/vue'
 import { TrDragOverlay, vDropzone, type FileRejection } from '@opentiny/tiny-robot'
 
 interface Event {

--- a/packages/components/src/mcp-server-picker/index.vue
+++ b/packages/components/src/mcp-server-picker/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TinyTabs, TinyTabItem, TinyInput, TinySelect, TinyOption } from '@opentiny/vue'
+import { TinyTabs, TinyTabItem, TinyInput, TinyBaseSelect, TinyOption } from '@opentiny/vue'
 import { ref, computed, watch } from 'vue'
 import { PluginCard, PluginModal, NoData } from './components'
 import { IconClose, IconSearch, IconPlus } from '@opentiny/tiny-robot-svgs'
@@ -342,7 +342,7 @@ const transitionName = computed(() => {
               v-if="props.enableSearch || props.enableMarketCategoryFilter"
             >
               <div v-if="props.enableMarketCategoryFilter" style="width: 168px">
-                <TinySelect v-model="marketCategory" :placeholder="props.marketCategoryPlaceholder">
+                <TinyBaseSelect v-model="marketCategory" :placeholder="props.marketCategoryPlaceholder">
                   <TinyOption
                     v-for="option in props.marketCategoryOptions"
                     :key="option.value"
@@ -351,7 +351,7 @@ const transitionName = computed(() => {
                   >
                     {{ option.label }}
                   </TinyOption>
-                </TinySelect>
+                </TinyBaseSelect>
               </div>
               <div v-if="props.enableSearch" style="width: 264px; flex-shrink: 0">
                 <TinyInput v-model="marketSearch" :placeholder="currentSearchPlaceholder">


### PR DESCRIPTION
使用 BaseSelect 组件替换 Select 组件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Replaced the market category dropdown with TinyBaseSelect in the MCP Server Picker. Added explicit option labels for clearer display. No functional changes expected, though dropdown visuals may be slightly updated.
- Documentation
  - Updated the drag overlay demo to use TinyBaseSelect for the accept field, aligning the demo with current component usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->