### PR TITLE
refactor: update mcp-add-form styles to use CSS variables

### DIFF
--- a/docs/demos/mcp-add-form/basic.vue
+++ b/docs/demos/mcp-add-form/basic.vue
@@ -12,7 +12,7 @@ import { TrMcpAddForm } from '@opentiny/tiny-robot'
 .form-container {
   max-width: 570px;
   width: 100%;
-  background-color: #fff;
+  background-color: var(--tr-container-bg-default);
   border-radius: 10px;
   box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
 }

--- a/packages/components/src/mcp-add-form/components/CodeEditor.vue
+++ b/packages/components/src/mcp-add-form/components/CodeEditor.vue
@@ -49,12 +49,12 @@ const codeData = defineModel<string>('codeData', { required: true })
     padding: 12px;
     font-size: 13px;
     line-height: 1.4;
-    color: #191919;
-    background-color: #f5f5f5;
+    color: var(--tr-text-primary);
+    background-color: var(--tr-page-bg-default);
     box-sizing: border-box;
 
     &::placeholder {
-      color: #999999;
+      color: var(--tr-text-tertiary);
     }
 
     &:focus {

--- a/packages/components/src/mcp-add-form/components/FormEditor.vue
+++ b/packages/components/src/mcp-add-form/components/FormEditor.vue
@@ -123,6 +123,10 @@ onUnmounted(() => {
     display: flex;
     flex-direction: column;
     gap: 16px;
+
+    :deep(.tiny-radio) {
+      --tv-Radio-text-color: var(--tr-text-primary);
+    }
   }
 
   &__item {
@@ -134,7 +138,7 @@ onUnmounted(() => {
   &__label {
     font-size: 14px;
     font-weight: 500;
-    color: #191919;
+    color: var(--tr-text-primary);
     line-height: 20px;
     width: 56px;
 
@@ -146,23 +150,23 @@ onUnmounted(() => {
   &__input {
     width: 100%;
     padding: 8px 12px;
-    border: 1px solid #d9d9d9;
+    border: 1px solid var(--tr-border-color-disabled);
     border-radius: 6px;
     height: 32px;
     font-size: 14px;
     line-height: 22px;
-    color: #191919;
-    background-color: #ffffff;
+    color: var(--tr-text-primary);
+    background-color: var(--tr-container-bg-default);
     transition: border-color 0.2s;
     box-sizing: border-box;
 
     &:focus {
       outline: none;
-      border-color: #1890ff;
+      border-color: var(--tr-color-primary);
     }
 
     &::placeholder {
-      color: #999999;
+      color: var(--tr-text-tertiary);
     }
   }
 
@@ -180,12 +184,12 @@ onUnmounted(() => {
   &__textarea {
     width: 100%;
     padding: 8px 12px;
-    border: 1px solid #d9d9d9;
+    border: 1px solid var(--tr-border-color-disabled);
     border-radius: 6px;
     font-size: 14px;
     line-height: 22px;
-    color: #191919;
-    background-color: #ffffff;
+    color: var(--tr-text-primary);
+    background-color: var(--tr-container-bg-default);
     resize: none;
     height: 60px;
     font-family: inherit;
@@ -194,11 +198,11 @@ onUnmounted(() => {
 
     &:focus {
       outline: none;
-      border-color: #1890ff;
+      border-color: var(--tr-color-primary);
     }
 
     &::placeholder {
-      color: #999999;
+      color: var(--tr-text-tertiary);
     }
   }
 
@@ -263,18 +267,18 @@ onUnmounted(() => {
   &__file-label {
     display: inline-block;
     padding: 8px 16px;
-    border: 1px solid #d9d9d9;
+    border: 1px solid var(--tr-border-color-disabled);
     border-radius: 6px;
-    background-color: #fafafa;
+    background-color: var(--tr-container-bg-default-2);
     font-size: 14px;
     line-height: 22px;
-    color: #191919;
+    color: var(--tr-text-primary);
     cursor: pointer;
     transition: all 0.2s;
 
     &:hover {
-      border-color: #1890ff;
-      background-color: #f0f9ff;
+      border-color: var(--tr-color-primary);
+      background-color: var(--tr-container-bg-hover);
     }
   }
 

--- a/packages/components/src/mcp-add-form/index.vue
+++ b/packages/components/src/mcp-add-form/index.vue
@@ -95,7 +95,7 @@ const handleUpdateAddType = (type: AddType) => {
     add-type-label-font-size: 14px;
     add-type-label-font-weight: 400;
     add-type-label-line-height: 20px;
-    add-type-label-color: #191919;
+    add-type-label-color: var(--tr-text-primary);
 
     /* 底部区域变量 */
     footer-padding: 0 32px 32px 32px;

--- a/packages/components/src/mcp-server-picker/components/PluginModal.vue
+++ b/packages/components/src/mcp-server-picker/components/PluginModal.vue
@@ -61,7 +61,7 @@ const handleConfirm = (addType: 'form' | 'code', formData: PluginFormData | stri
   transform: translate(-50%, -50%);
   max-width: 570px;
   width: 100%;
-  background-color: #ffffff;
+  background-color: var(--tr-container-bg-default);
   border-radius: 12px;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
   display: flex;
@@ -98,7 +98,7 @@ const handleConfirm = (addType: 'form' | 'code', formData: PluginFormData | stri
 
   &__title {
     margin: 0;
-    color: #191919;
+    color: var(--tr-text-primary);
     font-size: 18px;
     line-height: 24px;
     font-weight: 700;
@@ -113,7 +113,7 @@ const handleConfirm = (addType: 'form' | 'code', formData: PluginFormData | stri
   }
 
   &__close:hover {
-    background: #f5f5f5;
+    background: var(--tr-container-bg-hover);
     border-radius: 8px;
   }
 }


### PR DESCRIPTION

<img width="555" height="562" alt="image" src="https://github.com/user-attachments/assets/120173e1-3713-462a-8900-c907878b4ac4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Replaced hard-coded colors with theme variables across MCP Add Form (FormEditor, CodeEditor, index) and Plugin Modal.
  * Improves visual consistency, supports theming/dark mode, and aligns placeholder, labels, inputs, textareas, and focus/hover states with design tokens.
  * Modal and editor backgrounds/text now derive from theme variables for cohesive appearance.

* **Documentation**
  * Updated the MCP Add Form demo background to use a theme variable for consistent theming in examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->