### PR TITLE
fix: tabs color abnormality in dark mode

### DIFF
--- a/docs/demos/mcp-server-picker/basic-usage.vue
+++ b/docs/demos/mcp-server-picker/basic-usage.vue
@@ -246,7 +246,6 @@ const handleMarketSearchFn = (query: string, item: PluginInfo) => {
 .demo-controls {
   margin-bottom: 20px;
   padding: 16px;
-  background-color: #f8f9fa;
   border-radius: 8px;
 }
 

--- a/packages/components/src/mcp-server-picker/index.vue
+++ b/packages/components/src/mcp-server-picker/index.vue
@@ -583,6 +583,14 @@ const SelectDropStyle = {
 
 :deep(.tiny-tabs__header) {
   flex-shrink: 0;
+
+  .tiny-tabs__active-bar {
+    background: var(--tr-mcp-server-picker-tabs-border-color-active);
+  }
+
+  .tiny-tabs__nav-wrap-not-separator::after {
+    background: var(--tr-mcp-server-picker-tabs-nav-wrap-bg-color);
+  }
 }
 
 :deep(.tiny-tabs__content) {

--- a/packages/components/src/styles/variables.css
+++ b/packages/components/src/styles/variables.css
@@ -112,6 +112,8 @@
   /* ===== MCP Server Picker ===== */
   --tr-mcp-server-picker-bg-default: #ffffff;
   --tr-mcp-server-picker-bg-default-2: #ffffff;
+  --tr-mcp-server-picker-tabs-nav-wrap-bg-color: #f0f0f0;
+  --tr-mcp-server-picker-tabs-border-color-active: #191919;
   --tr-mcp-server-picker-bg-hover: rgba(0, 0, 0, 0.04);
   --tr-mcp-server-picker-button-bg-disabled: #f0f0f0;
   --tr-mcp-server-picker-divider-color: rgba(0, 0, 0, 0.1);
@@ -176,6 +178,8 @@
   /* ===== MCP Server Picker ===== */
   --tr-mcp-server-picker-bg-default: #191919;
   --tr-mcp-server-picker-bg-default-2: #262626;
+  --tr-mcp-server-picker-tabs-nav-wrap-bg-color: rgba(255, 255, 255, .1);
+  --tr-mcp-server-picker-tabs-border-color-active: #E6E6E6;
   --tr-mcp-server-picker-bg-hover: rgba(255, 255, 255, 0.1);
   --tr-mcp-server-picker-tool-count-color: #333333;
   --tr-mcp-server-picker-button-bg-disabled: rgba(255, 255, 255, 0.15);


### PR DESCRIPTION
修复深色模式 tabs 导航条颜色异常

<img width="472" height="100" alt="image" src="https://github.com/user-attachments/assets/d40196f4-0a79-41f9-af65-316120b96b89" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined MCP Server Picker tab header visuals with clearer active-tab indicator and improved contrast.
  * Enhanced light/dark theme consistency for tabs, improving readability and visual polish.

* **Documentation**
  * Demo no longer forces a background color, allowing it to follow theme defaults for a more accurate preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->