### PR TITLE
feat(kit): useConversation add allowEmpty

### DIFF
--- a/docs/demos/tools/conversation/Basic.vue
+++ b/docs/demos/tools/conversation/Basic.vue
@@ -9,9 +9,10 @@
 </template>
 
 <script setup lang="ts">
-import { BubbleRoleConfig } from '@opentiny/tiny-robot'
+import { TrBubbleList, BubbleRoleConfig } from '@opentiny/tiny-robot'
 import { useConversation, AIClient, ConversationStorageStrategy, Conversation } from '@opentiny/tiny-robot-kit'
 import { IconAi, IconUser } from '@opentiny/tiny-robot-svgs'
+import { TinySelect, TinyButton } from '@opentiny/vue'
 import { computed, h } from 'vue'
 
 class MockStorageStrategy implements ConversationStorageStrategy {

--- a/docs/src/tools/ai-client.md
+++ b/docs/src/tools/ai-client.md
@@ -1,3 +1,7 @@
+---
+outline: deep
+---
+
 # AI模型交互工具类 AIClient
 
 客户端类，用于与AI模型交互。

--- a/docs/src/tools/conversation.md
+++ b/docs/src/tools/conversation.md
@@ -1,3 +1,6 @@
+---
+outline: deep
+---
 
 # 对话管理 useConversation
 
@@ -9,7 +12,27 @@
 
 ## API
 
-`useConversation` 返回以下内容：
+### 选项
+```typescript
+interface UseConversationOptions {
+  /** AI客户端实例 */
+  client: AIClient
+  /** 存储策略 */
+  storage?: ConversationStorageStrategy
+  /** 是否自动保存 (default: true) */
+  autoSave?: boolean
+  /** 是否允许空会话 (default: false) */
+  allowEmpty?: boolean
+  /** 是否默认使用流式响应 (default: true)*/
+  useStreamByDefault?: boolean
+  /** 错误消息模板 */
+  errorMessage?: string
+  events?: UseMessageOptions['events']
+}
+```
+
+
+### 返回值
 
 ```typescript
 interface UseConversationReturn {
@@ -38,7 +61,7 @@ interface UseConversationReturn {
 }
 ```
 
-#### 会话状态
+### 会话状态
 
 ```typescript
 interface ConversationState {
@@ -51,7 +74,7 @@ interface ConversationState {
 }
 ```
 
-#### 会话接口
+### 会话接口
 
 ```typescript
 
@@ -72,7 +95,7 @@ interface Conversation {
 ```
 
 
-#### 自定义存储策略
+### 自定义存储策略
 
 默认使用 LocalStorage 存储会话数据，你也可以实现自定义的存储策略：
 

--- a/docs/src/tools/message.md
+++ b/docs/src/tools/message.md
@@ -1,3 +1,7 @@
+---
+outline: deep
+---
+
 # 消息与数据管理 useMessage
 
 ## 示例

--- a/packages/kit/src/vue/conversation/useConversation.ts
+++ b/packages/kit/src/vue/conversation/useConversation.ts
@@ -87,6 +87,8 @@ export interface UseConversationOptions {
   storage?: ConversationStorageStrategy
   /** 是否自动保存 */
   autoSave?: boolean
+  /** 是否允许空会话 */
+  allowEmpty?: boolean
   /** 是否默认使用流式响应 */
   useStreamByDefault?: boolean
   /** 错误消息模板 */
@@ -141,6 +143,7 @@ export function useConversation(options: UseConversationOptions): UseConversatio
     client,
     storage = new LocalStorageStrategy(),
     autoSave = true,
+    allowEmpty = false,
     useStreamByDefault = true,
     errorMessage = '请求失败，请稍后重试',
   } = options
@@ -183,6 +186,11 @@ export function useConversation(options: UseConversationOptions): UseConversatio
    * 创建新会话
    */
   const createConversation = (title: string = '新会话', metadata: Record<string, unknown> = {}): string => {
+    // 空会话则不再创建新会话
+    if (!allowEmpty && messageManager.messages.value.length === 0 && state.currentId) {
+      return state.currentId
+    }
+
     const id = generateId()
     const newConversation: Conversation = {
       id,


### PR DESCRIPTION
- 添加allowEmpty（是否允许新会话）参数，默认不允许在新会话中继续创建新会话

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to control creation of empty conversations. By default, new empty conversations won’t be created if the current one has no messages.

- Documentation
  - Overhauled Conversation tool docs with a structured API, state definitions, and a custom storage example.
  - Enabled deep outlines on AI Client and Message docs for improved navigation.
  - Updated conversation demo to include additional UI components for future examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->