### PR TITLE
chore: revert package version to 0.3.0-rc.4

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-robot",
-  "version": "0.3.0-alpha.26",
+  "version": "0.3.0-rc.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-robot-kit",
-  "version": "0.3.0-alpha.26",
+  "version": "0.3.0-rc.4",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/svgs/package.json
+++ b/packages/svgs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/tiny-robot-svgs",
-  "version": "0.3.0-alpha.26",
+  "version": "0.3.0-rc.4",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Promoted packages to release candidate (0.3.0-rc.4) across the component library, kit, and SVG assets.
  - No functional changes or new features; existing behavior and APIs remain unchanged.
  - Compatibility and usage are unaffected; no migration steps required.
  - Users installing or updating will receive the rc.4 versions to align with the upcoming stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->