### PR TITLE
style(mcp-server-picker): optimize plugin card border color effect

### DIFF
--- a/packages/components/src/mcp-server-picker/components/PluginCard.vue
+++ b/packages/components/src/mcp-server-picker/components/PluginCard.vue
@@ -186,7 +186,7 @@ const getHoverTitle = (isEnabled: boolean) => {
   position: relative;
   background: var(--tr-mcp-server-picker-bg-default-2);
   border-radius: 12px;
-  box-shadow: var(--tr-mcp-server-picker-shadow);
+  border: 1px solid var(--tr-mcp-server-picker-plugin-card-border-color);
 
   &__main {
     display: flex;

--- a/packages/components/src/styles/variables.css
+++ b/packages/components/src/styles/variables.css
@@ -113,6 +113,7 @@
   --tr-mcp-server-picker-bg-default: #ffffff;
   --tr-mcp-server-picker-bg-default-2: #ffffff;
   --tr-mcp-server-picker-tabs-nav-wrap-bg-color: #f0f0f0;
+  --tr-mcp-server-picker-plugin-card-border-color: #e6e6e6;
   --tr-mcp-server-picker-tabs-border-color-active: #191919;
   --tr-mcp-server-picker-bg-hover: rgba(0, 0, 0, 0.04);
   --tr-mcp-server-picker-button-bg-disabled: #f0f0f0;
@@ -179,6 +180,7 @@
   --tr-mcp-server-picker-bg-default: #191919;
   --tr-mcp-server-picker-bg-default-2: #262626;
   --tr-mcp-server-picker-tabs-nav-wrap-bg-color: rgba(255, 255, 255, .1);
+  --tr-mcp-server-picker-plugin-card-border-color: #4a4a4a;
   --tr-mcp-server-picker-tabs-border-color-active: #E6E6E6;
   --tr-mcp-server-picker-bg-hover: rgba(255, 255, 255, 0.1);
   --tr-mcp-server-picker-tool-count-color: #333333;

--- a/packages/svgs/src/assets/copy.svg
+++ b/packages/svgs/src/assets/copy.svg
@@ -2,5 +2,5 @@
     <defs />
     <path id="矢量 22"
         d="M4 4.76C2.89 4.76 2 5.66 2 6.76L2 11.99C2 13.1 2.89 13.99 4 13.99L9.23 13.99C10.33 13.99 11.23 13.1 11.23 11.99L11.23 6.76C11.23 5.66 10.33 4.76 9.23 4.76L4 4.76ZM14 8.46L14 3.84C14 2.82 13.17 2 12.15 2L7.53 2"
-        stroke="#191919" stroke-opacity="1.000000" stroke-width="1.000000" stroke-linecap="round" />
+        stroke="currentColor" stroke-opacity="1.000000" stroke-width="1.000000" stroke-linecap="round" />
 </svg>


### PR DESCRIPTION
### 1. 优化 mcp-server-picker 描边样式
    阴影 -> 描边
    
#### 修改前：
<img width="458" height="345" alt="image" src="https://github.com/user-attachments/assets/4cf47f17-3826-4e00-80b0-ae4779f9d778" />   
    
#### 修改后：
    
<img width="461" height="348" alt="image" src="https://github.com/user-attachments/assets/6ea9faa1-21b8-4ee8-9527-c6084de7e389" />

    
### 2.  `copy.svg` 暗色模式适配

copy.svg 增加描边 `currentColor`

#### 修改前：
     
<img width="75" height="32" alt="image" src="https://github.com/user-attachments/assets/db9a5e81-6acc-4f80-b7ca-429124226c10" />

     
#### 修改后：
     
<img width="141" height="54" alt="dark-icons" src="https://github.com/user-attachments/assets/8569917e-4378-4e61-86f1-941b34983254" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Plugin cards now use a subtle border instead of a drop shadow, improving visual clarity, contrast, and consistency across light and dark themes.
  * Introduces theme variables controlling border color per mode (light: #e6e6e6, dark: #4a4a4a), enhancing readability on varied backgrounds and aligning with design tokens.
  * No changes to behavior or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->