### PR TITLE
feat: change upload tooltip default placement to "top-end"

### DIFF
--- a/packages/components/src/sender/components/ActionButtons.vue
+++ b/packages/components/src/sender/components/ActionButtons.vue
@@ -180,7 +180,7 @@ const handleUpload = () => {
       <template v-if="allowFiles && !loading">
         <tiny-tooltip
           effect="light"
-          placement="top"
+          placement="top-end"
           :render-content="fileTooltipRenderFn"
           :visible-arrow="false"
           popper-class="tr-sender-actions-upload-button-popper"


### PR DESCRIPTION
修改 文件上传按钮 的 tooltip 弹窗默认位置

由 `top` 修改为 `top-end`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the tooltip position on the file upload action button from top to top-end, improving alignment with its trigger and reducing overlap with adjacent controls, especially on compact layouts. No behavioral changes—only a visual placement tweak for clearer context, better readability, and consistency across different screen sizes, themes, and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->