### PR TITLE
feat(sender): add file upload button tooltipPlacement property

### DIFF
--- a/docs/demos/sender/FileUpload.vue
+++ b/docs/demos/sender/FileUpload.vue
@@ -1,12 +1,16 @@
 <template>
   <div style="display: flex; flex-direction: column; gap: 20px">
-    <tr-sender
-      mode="multiple"
-      :allow-files="true"
-      :button-group="buttonGroup"
-      @files-selected="handleFilesSelected"
-      @submit="handleSubmit"
-    />
+    <!-- 默认位置 (top) -->
+    <div>
+      <h4 style="margin: 0 0 10px 0; font-size: 14px; color: #666">默认 Tooltip 位置 (top)</h4>
+      <tr-sender
+        mode="multiple"
+        :allow-files="true"
+        :button-group="buttonGroup"
+        @files-selected="handleFilesSelected"
+        @submit="handleSubmit"
+      />
+    </div>
   </div>
 </template>
 

--- a/docs/src/components/sender.md
+++ b/docs/src/components/sender.md
@@ -121,6 +121,26 @@ Sender 组件支持在多行模式下灵活定制底部区域。通过 `footer-l
 
 结合 `buttonGroup` 属性，您可以实现更复杂的交互逻辑。例如，通过监听 `files-selected` 事件返回的文件列表，动态地禁用上传按钮或提交按钮，并更新其 `tooltips` 提示信息，以引导用户操作。
 
+**自定义 Tooltip 位置**
+
+通过 `buttonGroup.file.tooltipPlacement` 属性可以自定义文件上传按钮的 tooltip 弹窗位置：
+
+```vue
+<tr-sender 
+  :allowFiles="true" 
+  :buttonGroup="{
+    file: {
+      tooltips: '点击上传文件',
+      tooltipPlacement: 'bottom' // 自定义 tooltip 位置
+    }
+  }"
+/>
+```
+
+支持的位置选项：`'top'` | `'top-start'` | `'top-end'` | `'bottom'` | `'bottom-start'` | `'bottom-end'` | `'left'` | `'left-start'` | `'left-end'` | `'right'` | `'right-start'` | `'right-end'`
+
+默认值为 `'top'`。
+
 <demo vue="../../demos/sender/FileUpload.vue" title="文件上传" description="Sender 组件支持文件上传功能，并可通过 buttonGroup 动态控制按钮状态。" />
 
 #### 模版填充
@@ -370,6 +390,7 @@ interface SpeechConfig {
 export interface ControlState {
   tooltips?: string | Function // 工具提示
   disabled?: boolean // 是否禁用
+  tooltipPlacement?: 'top' | 'top-start' | 'top-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end' | 'right' | 'right-start' | 'right-end' // tooltip 弹窗位置
 }
 
 interface fileUploadConfig {

--- a/packages/components/src/sender/components/ActionButtons.vue
+++ b/packages/components/src/sender/components/ActionButtons.vue
@@ -166,6 +166,11 @@ const handleUpload = () => {
     emit('trigger-select')
   }
 }
+
+/**
+ * 文件上传按钮 tooltip 位置
+ */
+const fileTooltipPlacement = computed(() => props.buttonGroup?.file?.tooltipPlacement || 'top')
 </script>
 
 <template>
@@ -180,7 +185,7 @@ const handleUpload = () => {
       <template v-if="allowFiles && !loading">
         <tiny-tooltip
           effect="light"
-          placement="top-end"
+          :placement="fileTooltipPlacement"
           :render-content="fileTooltipRenderFn"
           :visible-arrow="false"
           popper-class="tr-sender-actions-upload-button-popper"

--- a/packages/components/src/sender/index.type.ts
+++ b/packages/components/src/sender/index.type.ts
@@ -29,6 +29,19 @@ export type TooltipRender = () => VNode | string
 export interface ControlState {
   tooltips?: string | TooltipRender // 工具提示
   disabled?: boolean // 是否禁用
+  tooltipPlacement?:
+    | 'top'
+    | 'top-start'
+    | 'top-end'
+    | 'bottom'
+    | 'bottom-start'
+    | 'bottom-end'
+    | 'left'
+    | 'left-start'
+    | 'left-end'
+    | 'right'
+    | 'right-start'
+    | 'right-end' // tooltip 弹窗位置
 }
 
 interface fileUploadConfig {


### PR DESCRIPTION
**自定义文件上传按钮的 Tooltip 位置**

通过 `buttonGroup.file.tooltipPlacement` 属性可以自定义文件上传按钮的 tooltip 弹窗位置：

```vue
<tr-sender 
  :allowFiles="true" 
  :buttonGroup="{
    file: {
      tooltips: '点击上传文件',
      tooltipPlacement: 'bottom' // 自定义 tooltip 位置
    }
  }"
/>
```

支持的位置选项：`'top'` | `'top-start'` | `'top-end'` | `'bottom'` | `'bottom-start'` | `'bottom-end'` | `'left'` | `'left-start'` | `'left-end'` | `'right'` | `'right-start'` | `'right-end'`

默认值为 `'top'`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable tooltip placement for the sender’s file upload button, with a default of “top”. Supports positions like top/bottom/left/right and their -start/-end variants.

- Documentation
  - Updated sender documentation to include the new tooltipPlacement option, examples, supported values, and default behavior.

- Demos
  - Enhanced demo by adding a visible label indicating the default tooltip position above the sender component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->