### PR TITLE
fix: fix root package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "root",
+  "name": "tiny-robot-root",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.0",


### PR DESCRIPTION
当通过 `git submodule` 将 tiny-robot 仓库作为子仓库集成到其他仓库时，会通过 `pnpm -F root build` 之类的命令使用 root 这个包名，如果有多个子仓库都有 root 这个名字就容易冲突，建议用一个不容易冲突的名字，比如：`tiny-robot-root`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package name to “tiny-robot-root” for clearer identification in tooling and package managers.
  * No functional changes to features or behavior. No action required for users.
  * Installs, updates, and existing workflows remain unaffected; version and dependencies unchanged.
  * This is a metadata-only change and should not impact runtime or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->