### PR TITLE
fix: fix root package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "root",
+  "name": "tiny-robot-root",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.0",


### PR DESCRIPTION
当通过 `git submodule` 将 tiny-robot 仓库作为子仓库集成到其他仓库时，会通过 `pnpm -F root build` 之类的命令使用 root 这个包名，如果有多个子仓库都有 root 这个名字就容易冲突，建议用一个不容易冲突的名字，比如：`tiny-robot-root`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the top-level package to “tiny-robot-root” for clearer identification across tooling and workspaces.
  * No changes to scripts, dependencies, or configuration beyond the package name.
  * No impact on app functionality, performance, or UI.
  * Build, install, and run commands remain unchanged; versioning unaffected.
  * You may notice the updated package name in package managers and logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->