### PR TITLE
feat(sender): adjust when clear button is displayed

### DIFF
--- a/docs/demos/sender/Clearable.vue
+++ b/docs/demos/sender/Clearable.vue
@@ -1,0 +1,7 @@
+<template>
+  <tr-sender clearable />
+</template>
+
+<script setup lang="ts">
+import { TrSender } from '@opentiny/tiny-robot'
+</script>

--- a/docs/src/components/sender.md
+++ b/docs/src/components/sender.md
@@ -72,11 +72,7 @@ Sender 是一个灵活的输入组件，支持多种输入方式和功能，包�
 
 通过`clearable`属性添加清空按钮，方便用户快速清除输入内容。
 
-<tr-sender :clearable="true" />
-
-```vue
-<tr-sender :clearable="true" />
-```
+<demo vue="../../demos/sender/Clearable.vue" title="清空内容" description="在用户输入内容后才显示，没有内容时自动隐藏，" />
 
 ### 高级功能
 

--- a/docs/src/components/sender.md
+++ b/docs/src/components/sender.md
@@ -72,7 +72,7 @@ Sender 是一个灵活的输入组件，支持多种输入方式和功能，包�
 
 通过`clearable`属性添加清空按钮，方便用户快速清除输入内容。
 
-<demo vue="../../demos/sender/Clearable.vue" title="清空内容" description="在用户输入内容后才显示，没有内容时自动隐藏，" />
+<demo vue="../../demos/sender/Clearable.vue" title="清空内容" description="在用户输入内容后才显示，没有内容时自动隐藏" />
 
 ### 高级功能
 

--- a/packages/components/src/sender/components/ActionButtons.vue
+++ b/packages/components/src/sender/components/ActionButtons.vue
@@ -208,8 +208,8 @@ const fileTooltipPlacement = computed(() => props.buttonGroup?.file?.tooltipPlac
         </div>
       </template>
 
-      <!-- 清除按钮 -->
-      <template v-if="showClear">
+      <!-- 清除按钮：仅在有内容时显示 -->
+      <template v-if="showClear && hasContent && !loading">
         <tiny-tooltip content="清空内容" placement="top">
           <div class="action-buttons__button" @click="handleClear">
             <IconClear class="action-buttons__icon" />

--- a/packages/components/src/sender/components/ActionButtons.vue
+++ b/packages/components/src/sender/components/ActionButtons.vue
@@ -209,7 +209,7 @@ const fileTooltipPlacement = computed(() => props.buttonGroup?.file?.tooltipPlac
       </template>
 
       <!-- 清除按钮：仅在有内容时显示 -->
-      <template v-if="showClear && hasContent && !loading">
+      <template v-if="showClear && hasContent">
         <tiny-tooltip content="清空内容" placement="top">
           <div class="action-buttons__button" @click="handleClear">
             <IconClear class="action-buttons__icon" />


### PR DESCRIPTION
**问题：**

配置 `clearable` 属性后，清除按钮 会一直显示在输入框内

**需求：**

用户希望 清除按钮 只在输入框中 有内容时显示，没有内容时隐藏


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Clearable” demo showcasing the sender with the clearable option.

* **Bug Fixes**
  * Clear button now appears only when there is content (and sender isn’t loading), preventing empty/unused controls.

* **Documentation**
  * Replaced inline clearable examples with the new demo for consistency and cleaner presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->