### PR TITLE
feat: add support for template-editor autoSize property

### DIFF
--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -537,6 +537,7 @@ defineExpose({
                 <TemplateEditor
                   ref="templateEditorRef"
                   :model-value="props.templateData"
+                  :auto-size="autoSize"
                   @update:model-value="handleTemplateUpdate"
                   @submit="triggerSubmit"
                 />


### PR DESCRIPTION
## 一、背景

选择推荐问题后输入框内输入文字没有高度限制

## 二、解决方案

把 autoSize 属性传递给 TemplateEditor，实现相关逻辑

## 三、界面截图

### 处理前

<img width="631" height="260" alt="image" src="https://github.com/user-attachments/assets/d061490d-5a8a-4075-bd14-9dca8207da13" />


### 处理后
<img width="643" height="244" alt="image" src="https://github.com/user-attachments/assets/3072c83c-eb10-49d7-829a-ce43594b506f" />

