### PR TITLE
feat(history): add item-prefix and item-title slots

### DIFF
--- a/docs/demos/history/icon.vue
+++ b/docs/demos/history/icon.vue
@@ -1,0 +1,31 @@
+<template>
+  <tr-history
+    :data="data"
+    :selected="selected"
+    :show-rename-controls="isTouchDevice"
+    rename-control-on-click-outside="cancel"
+    @item-click="(item) => (selected = item.id)"
+    @item-title-change="(newTitle, item) => (item.title = newTitle)"
+    @item-action="(item) => console.log(item)"
+  />
+</template>
+
+<script setup lang="ts">
+import { TrHistory, useTouchDevice } from '@opentiny/tiny-robot'
+import { IconCheck, IconCopy, IconDelete } from '@opentiny/tiny-robot-svgs'
+import { h, reactive, ref } from 'vue'
+
+const { isTouchDevice } = useTouchDevice()
+
+const data = reactive([
+  { title: '如何训练一只聪明的小狗', id: '1', icon: h(IconCheck, { style: { fontSize: '16px' } }) },
+  { title: 'How to make a perfect soufflé', id: '2', icon: h(IconCopy, { style: { fontSize: '16px' } }) },
+  {
+    title: 'The Art of Origami: Advanced Paper Folding',
+    id: '3',
+    icon: h(IconDelete, { style: { fontSize: '16px' } }),
+  },
+])
+
+const selected = ref<string | undefined>('2')
+</script>

--- a/docs/demos/history/slot-item-prefix.vue
+++ b/docs/demos/history/slot-item-prefix.vue
@@ -1,0 +1,69 @@
+<template>
+  <div style="display: flex; align-items: center; gap: 4px">
+    <label>全选</label>
+    <input type="checkbox" v-model="allSelection" :indeterminate="isIndeterminate" />
+  </div>
+  <hr />
+  <tr-history
+    :data="data"
+    :selected="selected"
+    :show-rename-controls="isTouchDevice"
+    rename-control-on-click-outside="cancel"
+    @item-click="(item) => (selected = item.id)"
+    @item-title-change="(newTitle, item) => (item.title = newTitle)"
+    @item-action="(item) => console.log(item)"
+  >
+    <template #item-prefix="{ item }">
+      <input type="checkbox" v-model="multipleSelection" :value="item.id" @click.stop />
+    </template>
+  </tr-history>
+  <hr />
+  <div>
+    <div>
+      <label>已选：</label>
+      <span>{{ multipleSelection.length }} 项</span>
+    </div>
+    <ul>
+      <li v-for="id in multipleSelection" :key="id">
+        <span>{{ data.find((item) => item.id === id)?.title }}</span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { TrHistory, useTouchDevice } from '@opentiny/tiny-robot'
+import { computed, reactive, ref } from 'vue'
+
+const { isTouchDevice } = useTouchDevice()
+
+const data = reactive([
+  { title: '如何训练一只聪明的小狗', id: '1' },
+  { title: 'How to make a perfect soufflé', id: '2' },
+  { title: 'The Art of Origami: Advanced Paper Folding', id: '3' },
+])
+
+const selected = ref<string | undefined>('2')
+
+const multipleSelection = ref<string[]>([])
+
+const allSelection = computed({
+  get() {
+    return data.every((item) => multipleSelection.value.includes(item.id))
+  },
+  set(value) {
+    if (value) {
+      multipleSelection.value = data.map((item) => item.id)
+    } else {
+      multipleSelection.value = []
+    }
+  },
+})
+
+const isIndeterminate = computed(() => {
+  const selectedCount = multipleSelection.value.length
+  return selectedCount > 0 && selectedCount < data.length
+})
+</script>
+
+<style scoped></style>

--- a/docs/demos/history/slot-item-title.vue
+++ b/docs/demos/history/slot-item-title.vue
@@ -1,0 +1,40 @@
+<template>
+  <tr-history
+    :data="data"
+    :selected="selected"
+    :show-rename-controls="isTouchDevice"
+    rename-control-on-click-outside="cancel"
+    @item-click="(item) => (selected = item.id)"
+    @item-title-change="(newTitle, item) => (item.title = newTitle)"
+    @item-action="(item) => console.log(item)"
+  >
+    <template #item-title="{ item }">
+      <span class="item" :title="item.title">{{ item.title }}</span>
+    </template>
+  </tr-history>
+</template>
+
+<script setup lang="ts">
+import { TrHistory, useTouchDevice } from '@opentiny/tiny-robot'
+import { reactive, ref } from 'vue'
+
+const { isTouchDevice } = useTouchDevice()
+
+const data = reactive([
+  { title: '如何训练一只聪明的小狗', id: '1' },
+  { title: 'How to make a perfect soufflé', id: '2' },
+  { title: 'The Art of Origami: Advanced Paper Folding', id: '3' },
+])
+
+const selected = ref<string | undefined>('2')
+</script>
+
+<style scoped>
+.item {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-style: italic;
+}
+</style>

--- a/docs/src/components/history.md
+++ b/docs/src/components/history.md
@@ -22,6 +22,22 @@ outline: [1, 3]
 
 <demo vue="../../demos/history/custom-menu.vue" />
 
+### 前置图标
+
+通过 `icon` 属性可以为历史项添加前置图标。
+
+<demo vue="../../demos/history/icon.vue" />
+
+### 插槽
+
+通过 `item-prefix` 插槽可以自定义历史项的前置内容。例如：复选框等。
+
+<demo vue="../../demos/history/slot-item-prefix.vue" />
+
+通过 `item-title` 插槽可以自定义历史项的标题显示内容。
+
+<demo vue="../../demos/history/slot-item-title.vue" />
+
 ## API
 
 ### Props
@@ -48,26 +64,27 @@ type HistoryData<T extends HistoryItem> = T[] | HistoryGroup<T>[]
 
 ### HistoryGroup
 
-| 属性    | 类型               | 说明                 |
-| ------- | ------------------ | -------------------- |
-| `group` | `string \| symbol` | 分组标识             |
-| `items` | `T[]`              | 该分组下的历史项列表 |
+| 属性    | 类型               | 必填 | 说明                 |
+| ------- | ------------------ | ---- | -------------------- |
+| `group` | `string \| symbol` | 是   | 分组标识             |
+| `items` | `T[]`              | 是   | 该分组下的历史项列表 |
 
 ### HistoryItem
 
-| 属性          | 类型      | 说明             |
-| ------------- | --------- | ---------------- |
-| `id`          | `string`  | 唯一标识（可选） |
-| `title`       | `string`  | 标题             |
-| `[x: string]` | `unknown` | 其他自定义属性   |
+| 属性          | 类型                 | 必填 | 说明           |
+| ------------- | -------------------- | ---- | -------------- |
+| `id`          | `string`             | 否   | 唯一标识       |
+| `title`       | `string`             | 是   | 标题           |
+| `icon`        | `Component \| VNode` | 否   | 前置图标       |
+| `[x: string]` | `any`                | 否   | 其他自定义属性 |
 
 ### HistoryMenuItem
 
-| 属性   | 类型                 | 说明               |
-| ------ | -------------------- | ------------------ |
-| `id`   | `string`             | 菜单项唯一标识     |
-| `text` | `string`             | 菜单项显示文本     |
-| `icon` | `Component \| VNode` | 菜单项图标（可选） |
+| 属性   | 类型                 | 必填 | 说明           |
+| ------ | -------------------- | ---- | -------------- |
+| `id`   | `string`             | 是   | 菜单项唯一标识 |
+| `text` | `string`             | 是   | 菜单项显示文本 |
+| `icon` | `Component \| VNode` | 否   | 菜单项图标     |
 
 ### Events
 
@@ -76,6 +93,13 @@ type HistoryData<T extends HistoryItem> = T[] | HistoryGroup<T>[]
 | `item-click`        | `item: T`                          | 点击历史项时触发 |
 | `item-title-change` | `newTitle: string, item: T`        | 标题修改时触发   |
 | `item-action`       | `action: HistoryMenuItem, item: T` | 点击菜单项时触发 |
+
+### Slots
+
+| 插槽名        | 参数       | 说明                                       |
+| ------------- | ---------- | ------------------------------------------ |
+| `item-prefix` | `{ item }` | 自定义历史项的前置内容，例如图标、复选框等 |
+| `item-title`  | `{ item }` | 自定义历史项的标题显示内容                 |
 
 ### CSS 变量
 
@@ -91,16 +115,18 @@ type HistoryData<T extends HistoryItem> = T[] | HistoryGroup<T>[]
 
 历史项
 
-| 变量名                              | 说明               |
-| ----------------------------------- | ------------------ |
-| `--tr-history-item-font-size`       | 历史项字体大小     |
-| `--tr-history-item-line-height`     | 历史项行高         |
-| `--tr-history-item-color`           | 历史项文字颜色     |
-| `--tr-history-item-padding`         | 历史项内边距       |
-| `--tr-history-item-padding-editing` | 编辑状态下的内边距 |
-| `--tr-history-item-hover-bg`        | 悬停背景色         |
-| `--tr-history-item-border-radius`   | 历史项圆角         |
-| `--tr-history-item-selected-bg`     | 选中背景色         |
+| 变量名                              | 说明                 |
+| ----------------------------------- | -------------------- |
+| `--tr-history-item-font-size`       | 历史项字体大小       |
+| `--tr-history-item-line-height`     | 历史项行高           |
+| `--tr-history-item-color`           | 历史项文字颜色       |
+| `--tr-history-item-padding`         | 历史项内边距         |
+| `--tr-history-item-padding-editing` | 编辑状态下的内边距   |
+| `--tr-history-item-space-y`         | 历史项之间的垂直间距 |
+| `--tr-history-item-hover-bg`        | 悬停背景色           |
+| `--tr-history-item-border-radius`   | 历史项圆角           |
+| `--tr-history-item-selected-bg`     | 选中背景色           |
+| `--tr-history-item-selected-color`  | 选中文字颜色         |
 
 操作按钮
 
@@ -115,8 +141,9 @@ type HistoryData<T extends HistoryItem> = T[] | HistoryGroup<T>[]
 | ---------------------------------------- | -------------- |
 | `--tr-history-item-editor-border-color`  | 编辑器边框颜色 |
 | `--tr-history-item-editor-border-radius` | 编辑器圆角     |
-| `--tr-history-item-editor-padding`       | 编辑器内边距   |
 | `--tr-history-item-editor-border-width`  | 编辑器边框宽度 |
+| `--tr-history-item-editor-padding`       | 编辑器内边距   |
+| `--tr-history-item-editor-outline`       | 编辑器轮廓线   |
 | `--tr-history-item-editor-confirm-color` | 确认按钮颜色   |
 | `--tr-history-item-editor-cancel-color`  | 取消按钮颜色   |
 

--- a/packages/components/src/history/index.type.ts
+++ b/packages/components/src/history/index.type.ts
@@ -4,6 +4,7 @@ import type { Component, VNode } from 'vue'
 export interface HistoryItem {
   id?: string
   title: string
+  icon?: Component | VNode
   [x: string]: any
 }
 
@@ -27,4 +28,9 @@ export type HistoryProps<T extends HistoryItem = HistoryItem> = {
   renameControlOnClickOutside?: 'confirm' | 'cancel' | 'none'
   menuItems?: HistoryMenuItem[]
   menuListGap?: number
+}
+
+export interface HistorySlots<T extends HistoryItem = HistoryItem> {
+  'item-prefix'?: (slotProps: { item: T }) => VNode | VNode[]
+  'item-title'?: (slotProps: { item: T }) => VNode | VNode[]
 }

--- a/packages/components/src/history/index.vue
+++ b/packages/components/src/history/index.vue
@@ -6,7 +6,7 @@ import Empty from './components/Empty.vue'
 import MenuList from './components/MenuList.vue'
 import { useRenameEditor } from './composables/useRenameEditor'
 import { NO_GROUP } from './constants'
-import type { HistoryData, HistoryGroup, HistoryItem, HistoryMenuItem, HistoryProps } from './index.type'
+import type { HistoryData, HistoryGroup, HistoryItem, HistoryMenuItem, HistoryProps, HistorySlots } from './index.type'
 
 const props = withDefaults(defineProps<HistoryProps<T>>(), {
   showRenameControls: false,
@@ -22,6 +22,7 @@ const emit = defineEmits<{
   'item-title-change': [newTitle: string, item: T]
   'item-action': [action: HistoryMenuItem, item: T]
 }>()
+defineSlots<HistorySlots<T>>()
 
 const isGroup = <T extends HistoryItem>(data: HistoryData<T>): data is HistoryGroup<T>[] => {
   const typeOfGroup = typeof (data[0] as HistoryGroup<T>)?.group
@@ -110,6 +111,8 @@ const handleClickMenuItem = (action: HistoryMenuItem) => {
             :key="item.id || index"
             @click="emit('item-click', item)"
           >
+            <slot name="item-prefix" :item="item"></slot>
+            <component :is="item.icon" v-if="item.icon" />
             <input
               class="tr-history__item-editor"
               v-if="editingItem === item"
@@ -120,7 +123,9 @@ const handleClickMenuItem = (action: HistoryMenuItem) => {
               @keydown.enter="handleEditConfirm"
               @keydown.escape="handleEditCancel"
             />
-            <span class="text" v-else :title="item.title">{{ item.title }}</span>
+            <slot v-else name="item-title" :item="item">
+              <span class="text" :title="item.title">{{ item.title }}</span>
+            </slot>
             <span class="tr-history__item-actions" @click.stop>
               <button
                 class="editor-confirm"

--- a/packages/components/src/styles/components/history.less
+++ b/packages/components/src/styles/components/history.less
@@ -27,7 +27,7 @@
 
     /* Editor variables */
     item-editor-border-color: var(--tr-border-color-default);
-    item-editor-border-radius: 4px;
+    item-editor-border-radius: 0;
     item-editor-padding: 0;
     item-editor-border-width: 0;
     item-editor-confirm-color: inherit;


### PR DESCRIPTION
 for custom history item rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icon property to display custom icons in history items.
  * Added item-prefix slot for pre-content customization (e.g., checkboxes).
  * Added item-title slot for custom title display formatting.

* **Documentation**
  * Added demo examples showcasing new icon and slot features.
  * Updated API documentation with new properties and slots.

* **Style**
  * Adjusted editor border radius styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->