### PR TITLE
feat: add mcp server picker header slot

### DIFF
--- a/docs/src/components/mcp-server-picker.md
+++ b/docs/src/components/mcp-server-picker.md
@@ -80,6 +80,13 @@ const handlePluginAdd = (plugin: PluginInfo) => {
 | loading                    | `boolean`                 | `false`                                                           | 已安装插件加载状态                           |
 | marketLoading              | `boolean`                 | `false`                                                           | 市场插件加载状态                             |
 
+
+## Slots
+
+| 插槽名称          | 描述                             | 默认内容                |
+| ----------------- | -------------------------------- | ----------------------- |
+| `header-actions`   | 头部右侧操作区插槽               | 无                      |
+
 ## Events
 
 | 事件名                   | 说明                   | 回调参数                                                |

--- a/packages/components/src/mcp-server-picker/index.vue
+++ b/packages/components/src/mcp-server-picker/index.vue
@@ -303,6 +303,7 @@ const SelectDropStyle = {
       <div class="mcp-server-picker__header">
         <div class="mcp-server-picker__header-left">{{ props.title }}</div>
         <div class="mcp-server-picker__header-right">
+          <slot name="header-actions" />
           <div v-if="props.showCustomAddButton" class="mcp-server-picker__header-right-item" @click="handleCustomAdd">
             <IconPlus class="mcp-server-picker__icon" />
             <span>{{ props.customAddButtonText }}</span>


### PR DESCRIPTION
增加头部操作插槽

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom header actions in MCP Server Picker via a named slot, enabling customization of the component header.

* **Documentation**
  * Added Slots section to MCP Server Picker documentation describing the header-actions slot and its default content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->