### PR TITLE
fix(kit): conversation convert reactive objects to plain objects before saving

### DIFF
--- a/packages/kit/src/vue/conversation/useConversation.ts
+++ b/packages/kit/src/vue/conversation/useConversation.ts
@@ -296,7 +296,9 @@ export function useConversation(options: UseConversationOptions): UseConversatio
    */
   const saveConversations = async (): Promise<void> => {
     try {
-      await storage.saveConversations(state.conversations)
+      // 将响应式对象转换为普通对象，避免 IndexedDB 的 DataCloneError
+      const plainConversations = JSON.parse(JSON.stringify(state.conversations))
+      await storage.saveConversations(plainConversations)
     } catch (error) {
       console.error('保存会话失败:', error)
     }


### PR DESCRIPTION
## 修复 IndexedDB DataCloneError 问题

### 问题描述
在使用 `useConversation` 配合 IndexedDB 存储策略时，会抛出 `DataCloneError: Failed to execute 'put' on 'IDBObjectStore'` 错误。

**根本原因：**
- Vue 的 `ref` 和 `reactive` 会将对象转换为 Proxy（代理对象）
- IndexedDB 的结构化克隆算法不支持 Proxy 对象

### 修改内容

**useConversation.ts - saveConversations**
   - 使用 `JSON.parse(JSON.stringify())` 深度转换响应式对象


### 验证方式
**修改前：**
<img width="779" height="154" alt="error" src="https://github.com/user-attachments/assets/7e4a76f4-20d9-477c-ac8d-3e419ba36d94" />

<img width="971" height="790" alt="console-01" src="https://github.com/user-attachments/assets/fccfc668-1439-4346-b61c-cf7572ef64d0" />

**修改后：**

<img width="764" height="818" alt="console-02" src="https://github.com/user-attachments/assets/06bb4865-665a-4ec9-8dbe-da313f4a2a82" />

- ✅ 发送消息后刷新页面，数据正确持久化
- ✅ 浏览器控制台无 DataCloneError 错误
- ✅ 使用 DevTools 检查 IndexedDB 存储的数据结构正确

### 影响范围
- 修复了所有使用 IndexedDB 或其他需要结构化克隆的存储策略时的兼容性问题
- 不影响现有 localStorage 策略的使用
- 对使用者透明，无需修改业务代码

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a storage issue that occasionally prevented conversations from saving and persisting correctly across sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->