### PR TITLE
fix(ci): refactor workflow to securely support preview & cleanup for fork PRs

### DIFF
--- a/.github/workflows/pr-ci-build.yml
+++ b/.github/workflows/pr-ci-build.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Save PR number
         if: github.event_name == 'pull_request'
-        run: echo "${{ github.event.number }}" > pr_number.txt
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-ci-build.yml
+++ b/.github/workflows/pr-ci-build.yml
@@ -42,12 +42,21 @@ jobs:
       - name: Build components
         run: pnpm build
 
+      - name: Build docs
+        run: pnpm -F docs build
+
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.number }}" > pr_number.txt
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ github.sha }}
+          name: build-${{ github.event.pull_request.head.sha || github.sha }}
           path: |
             packages/components/dist
             packages/kit/dist
             packages/svgs/dist
+            docs/dist
+            pr_number.txt
           retention-days: 1

--- a/.github/workflows/pr-ci-publish-packages.yml
+++ b/.github/workflows/pr-ci-publish-packages.yml
@@ -1,13 +1,17 @@
-name: 'CI: E2E Test'
+name: 'CI: Publish Packages'
 
 on:
   workflow_call:
+    inputs:
+      pr-number:
+        description: 'Pull Request number'
+        type: number
+        required: true
 
 jobs:
-  test-job:
-    name: e2e-test
+  preview-job:
+    name: preview
     runs-on: ubuntu-latest
-    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,6 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -41,18 +46,27 @@ jobs:
           name: build-${{ github.event.pull_request.head.sha || github.sha }}
           path: .
 
-      - name: Install Playwright Browser
+      - name: Publish to pkg.pr.new
+        id: pkg-pr-new
         run: |
-          cd packages/test
-          npx playwright install --with-deps chromium
+          npx pkg-pr-new publish \
+            ./packages/components \
+            ./packages/kit \
+            ./packages/svgs \
+            --pnpm \
+            --json output.json \
+            --comment=off
 
-      - name: Run Playwright Tests
-        run: pnpm test
+      - name: Save pkg.pr.new output
+        run: |
+          if [ -f output.json ]; then
+            cp output.json pkg-pr-new-output.json
+          fi
 
-      - name: Upload Playwright Test Report
+      - name: Upload pkg.pr.new output
         uses: actions/upload-artifact@v4
-        if: always()
         with:
-          name: playwright-report-${{ github.sha }}
-          path: packages/test/playwright-report/
-          retention-days: 13
+          name: pkg-pr-new-output-${{ github.event.pull_request.head.sha || github.sha }}
+          path: pkg-pr-new-output.json
+          retention-days: 1
+          if-no-files-found: ignore

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -28,16 +28,16 @@ jobs:
     with:
       skip-playground: true
 
-  # 生成预览（依赖构建，仅 PR 事件）
-  preview:
+  # 发布包预览（依赖构建，仅 PR 事件）
+  publish-packages:
     needs: [build]
     if: github.event_name == 'pull_request'
-    uses: ./.github/workflows/pr-ci-preview.yml
+    uses: ./.github/workflows/pr-ci-publish-packages.yml
     with:
       pr-number: ${{ github.event.pull_request.number }}
     secrets: inherit
 
-  # E2E 测试（依赖构建，与预览并行）
+  # E2E 测试（依赖构建）
   e2e-test:
     needs: [build]
     uses: ./.github/workflows/pr-ci-e2e-test.yml

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,8 +1,11 @@
-name: PR Docs Cleanup
+name: 'CI: Docs Cleanup'
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
+
+permissions:
+  pull-requests: write
 
 jobs:
   cleanup:

--- a/.github/workflows/pr-deploy-preview.yml
+++ b/.github/workflows/pr-deploy-preview.yml
@@ -1,95 +1,80 @@
-name: 'CI: Preview'
+name: 'CI: Deploy Preview'
 
 on:
-  workflow_call:
-    inputs:
-      pr-number:
-        description: 'Pull Request number'
-        type: number
-        required: true
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  actions: read
+  contents: read
 
 jobs:
-  preview-job:
-    name: preview
+  deploy:
+    # 只在 PR 触发且 CI 成功时运行
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm i --no-frozen-lockfile
-
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: build-${{ github.sha }}
-          path: packages
+          name: build-${{ github.event.workflow_run.head_sha }}
+          path: artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Build docs only (components already built)
-        run: pnpm -F docs build
+      - name: Read PR Number
+        id: pr
+        run: |
+          if [ -f artifacts/pr_number.txt ]; then
+            echo "number=$(cat artifacts/pr_number.txt)" >> $GITHUB_OUTPUT
+          else
+            echo "PR number file not found"
+            exit 1
+          fi
+
+      - name: Download pkg.pr.new output
+        uses: actions/download-artifact@v4
+        with:
+          name: pkg-pr-new-output-${{ github.event.workflow_run.head_sha }}
+          path: pkg-artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+        continue-on-error: true
 
       - name: Comment build generating
-        if: github.event_name == 'pull_request'
         uses: actions-cool/maintain-one-comment@v3.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             [<img width="400" src="https://github.com/user-attachments/assets/c25bbbe4-0cf5-4aca-b4b3-db49e7a264d9">](#)
             
-            🔨 Building packages...
+            🔨 Deploying preview...
             <!-- TINY_ROBOT_BUILD -->
           body-include: '<!-- TINY_ROBOT_BUILD -->'
-          number: ${{ inputs.pr-number }}
-
-      - name: Publish to pkg.pr.new
-        id: pkg-pr-new
-        run: |
-          npx pkg-pr-new publish \
-            ./packages/components \
-            ./packages/kit \
-            ./packages/svgs \
-            --pnpm \
-            --json output.json \
-            --comment=off
+          number: ${{ steps.pr.outputs.number }}
 
       - name: Post or update pkg.pr.new comment
-        if: github.event_name == 'pull_request'
+        if: hashFiles('pkg-artifacts/pkg-pr-new-output.json') != ''
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
+            const output = JSON.parse(fs.readFileSync('pkg-artifacts/pkg-pr-new-output.json', 'utf8'));
             
-            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const sha = '${{ github.event.workflow_run.head_sha }}'.substring(0, 7);
             
             const packages = output.packages.map((p) => {
               const shortUrl = p.url.replace(/@[a-f0-9]{40}/, '@' + sha);
               return 'pnpm add ' + shortUrl;
             }).join('\n\n');
             
-            const commitUrl = 'https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/commit/' + sha;
+            const commitUrl = 'https://github.com/${{ github.repository }}/commit/' + sha;
             
             const body = '## 📦 Package Preview\n\n' + packages + '\n\n**commit:** [' + sha + '](' + commitUrl + ')\n\n<!-- PKG_PR_NEW_COMMENT -->';
             const botCommentIdentifier = '<!-- PKG_PR_NEW_COMMENT -->';
@@ -97,7 +82,7 @@ jobs:
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: ${{ steps.pr.outputs.number }},
             });
             
             const existingComment = comments.data.find((comment) =>
@@ -113,7 +98,7 @@ jobs:
               });
             } else {
               await github.rest.issues.createComment({
-                issue_number: context.issue.number,
+                issue_number: ${{ steps.pr.outputs.number }},
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: body,
@@ -123,20 +108,20 @@ jobs:
       - name: Deploy Site to Surge
         id: deploy
         run: |
-          DEPLOY_DOMAIN=preview-${{ inputs.pr-number }}-tiny-robot.surge.sh
+          DEPLOY_DOMAIN=preview-${{ steps.pr.outputs.number }}-tiny-robot.surge.sh
           echo "Deploying to: https://$DEPLOY_DOMAIN"
-          npx surge --project ./docs/dist --domain $DEPLOY_DOMAIN --token $SURGE_TOKEN
+          npx surge --project ./artifacts/docs/dist --domain $DEPLOY_DOMAIN --token $SURGE_TOKEN
           echo "url=https://$DEPLOY_DOMAIN" >> $GITHUB_OUTPUT
         env:
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
 
       - name: Comment build success
-        if: ${{ success() && github.event_name == 'pull_request' }}
+        if: success()
         uses: actions-cool/maintain-one-comment@v3.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            [<img width="400" src="https://github.com/user-attachments/assets/2a0bb639-dfaf-4384-8d73-cec616ea4b97">](https://preview-${{ inputs.pr-number }}-tiny-robot.surge.sh)
+            [<img width="400" src="https://github.com/user-attachments/assets/2a0bb639-dfaf-4384-8d73-cec616ea4b97">](https://preview-${{ steps.pr.outputs.number }}-tiny-robot.surge.sh)
             
             ✅ Preview build completed successfully!
             
@@ -144,17 +129,17 @@ jobs:
             > Preview will be automatically removed when this PR is closed.  
             <!-- TINY_ROBOT_BUILD -->
           body-include: '<!-- TINY_ROBOT_BUILD -->'
-          number: ${{ inputs.pr-number }}
+          number: ${{ steps.pr.outputs.number }}
 
       - name: Comment build failed
-        if: ${{ failure() && github.event_name == 'pull_request' }}
+        if: failure()
         uses: actions-cool/maintain-one-comment@v3.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             [<img width="400" src="https://github.com/user-attachments/assets/acfe799d-40be-4ffb-8190-da33f84056dc">](#)
             
-            ❌ Build failed. Please check the logs for details.
+            ❌ Deploy failed. Please check the logs for details.
             <!-- TINY_ROBOT_BUILD -->
           body-include: '<!-- TINY_ROBOT_BUILD -->'
-          number: ${{ inputs.pr-number }}
+          number: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## 修复 Fork 仓库 PR 无法触发预览和评论的问题 (CI Workflow)

描述：

### 1. 问题背景 (Why)
此前，当外部贡献者从 Fork 仓库提交 Pull Request 时，CI 工作流会报错或部分功能失效。主要原因如下：

权限限制：出于安全考虑，GitHub 默认将来自 Fork 的 PR 的 GITHUB_TOKEN 降级为 只读 (Read-only)，导致无法自动发表评论（如预览链接）。

Secrets 隔离：Fork 的 PR 无法访问原仓库的 Secrets（如 SURGE_TOKEN），导致部署预览站点失败。

### 2. 解决方案 (What)
本 PR 对 CI 架构进行了重构，采用了 GitHub 推荐的 “接力模式 (Relay Pattern)”，将构建与部署分离：

#### 构建阶段 (低权限)：

修改 pr-ci-build.yml。

该阶段仍在 pull_request 事件下运行（安全沙箱环境）。

负责构建代码，并将构建产物 (dist) 和 PR 编号 (pr_number.txt) 打包为 Artifact 上传。

#### 部署阶段 (高权限)：

新增 workflow_preview.yml。

使用 workflow_run 事件触发，监听主 CI 完成。

该阶段运行在原仓库上下文中，拥有 Write 权限 和 Secrets 访问权。

负责下载 Artifact，执行 Surge 部署，并回写评论到对应的 PR。

#### 清理阶段：

修改 pr-cleanup.yml 的触发器为 pull_request_target，确保 PR 关闭时有权限清理 Surge 部署资源。

### 3. 安全性说明

构建过程不依赖任何 Secrets，且在低权限下运行，防止恶意代码通过 npm install/build 窃取凭证。

高权限的部署流程不 checkout 外部代码，仅处理预构建的静态资源，符合安全最佳实践。

### 4. 验证
已在 Fork 仓库模拟测试，外部 PR 提交后：

主 CI 构建成功 (Pass)。

Preview 工作流自动触发并成功发表预览链接评论。

**可以参考：** https://github.com/SonyLeo/tiny-robot/pull/18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now builds docs and includes them in artifacts.
  * Artifact naming and download logic updated to use PR head SHA when available.
  * PR number is captured and propagated via artifacts for downstream jobs.
  * New package publishing workflow added to publish package previews.
  * Preview deployment workflow reworked for artifact-driven deploys and adjusted permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->