### PR TITLE
fix(sender): use reactive refs for file dialog options

### DIFF
--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch, nextTick, useSlots } from 'vue'
+import { computed, ref, watch, nextTick, useSlots, toRef } from 'vue'
 import { TinyInput } from '@opentiny/vue'
 import { useFileDialog } from '@vueuse/core'
 import type { SenderProps, SenderEmits, InputHandler, KeyboardHandler, UserItem } from './index.type'
@@ -479,9 +479,11 @@ const activateTemplateFirstField = () => {
   }
 }
 
-const { accept = '*', multiple = true, reset = true } = props.buttonGroup?.file || {}
-
-const { open: openFileDialog, files } = useFileDialog({ accept, multiple, reset })
+const { open: openFileDialog, files } = useFileDialog({
+  accept: toRef(() => props.buttonGroup?.file?.accept ?? '*'),
+  multiple: toRef(() => props.buttonGroup?.file?.multiple ?? true),
+  reset: toRef(() => props.buttonGroup?.file?.reset ?? true),
+})
 
 watch(files, (selectedFiles) => {
   if (selectedFiles && selectedFiles.length > 0) {


### PR DESCRIPTION
修复 Sender 组件解构上传对象参数丢失响应式

关联 issue -> #281 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File dialog accept, multiple, and reset options now dynamically respond to configuration changes at runtime rather than remaining static
  * Added 'files-selected' event that emits whenever users select files through the dialog, providing the selected files array and allowing applications to react to selections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->