### PR TITLE
fix(playground): add Tiptap editor dependencies to import map

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,9 +17,16 @@
     "type-check": "vue-tsc --noEmit"
   },
   "peerDependencies": {
-    "dompurify": "^3.3.1",
-    "markdown-it": "^14.1.0",
     "vue": "^3.3.11",
+    "dompurify": "^3.3.1",
+    "markdown-it": "^14.1.0"
+  },
+  "dependencies": {
+    "@floating-ui/dom": "^1.6.0",
+    "@opentiny/tiny-robot-svgs": "workspace:*",
+    "@opentiny/vue": "^3.20.0",
+    "@vueuse/core": "^13.1.0",
+    "jsonrepair": "^3.13.1",
     "@tiptap/core": "^3.11.0",
     "@tiptap/vue-3": "^3.11.0",
     "@tiptap/pm": "^3.11.0",
@@ -29,13 +36,6 @@
     "@tiptap/extension-history": "^3.11.0",
     "@tiptap/extension-placeholder": "^3.11.0",
     "@tiptap/extension-character-count": "^3.11.0"
-  },
-  "dependencies": {
-    "@floating-ui/dom": "^1.6.0",
-    "@opentiny/tiny-robot-svgs": "workspace:*",
-    "@opentiny/vue": "^3.20.0",
-    "@vueuse/core": "^13.1.0",
-    "jsonrepair": "^3.13.1"
   },
   "devDependencies": {
     "@types/dom-speech-recognition": "^0.0.6",

--- a/packages/playground/src/utils/import-map.ts
+++ b/packages/playground/src/utils/import-map.ts
@@ -39,6 +39,21 @@ export function generateImportMap(options: ImportMapOptions) {
       'markdown-it': 'https://cdn.jsdelivr.net/npm/markdown-it@14/dist/markdown-it.min.js',
       echarts: 'https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js',
 
+      // Tiptap 编辑器相关包 (用于 Sender 组件)
+      // 使用 esm.sh CDN，自动处理子路径导入和依赖解析
+      // 添加 ?external=vue 参数，避免 Vue 版本冲突
+      '@tiptap/core': 'https://esm.sh/@tiptap/core@3.11.0',
+      '@tiptap/vue-3': 'https://esm.sh/@tiptap/vue-3@3.11.0?external=vue',
+      '@tiptap/pm/state': 'https://esm.sh/@tiptap/pm@3.11.0/state',
+      '@tiptap/pm/view': 'https://esm.sh/@tiptap/pm@3.11.0/view',
+      '@tiptap/pm/model': 'https://esm.sh/@tiptap/pm@3.11.0/model',
+      '@tiptap/extension-document': 'https://esm.sh/@tiptap/extension-document@3.11.0',
+      '@tiptap/extension-paragraph': 'https://esm.sh/@tiptap/extension-paragraph@3.11.0',
+      '@tiptap/extension-text': 'https://esm.sh/@tiptap/extension-text@3.11.0',
+      '@tiptap/extension-history': 'https://esm.sh/@tiptap/extension-history@3.11.0',
+      '@tiptap/extension-placeholder': 'https://esm.sh/@tiptap/extension-placeholder@3.11.0',
+      '@tiptap/extension-character-count': 'https://esm.sh/@tiptap/extension-character-count@3.11.0',
+
       ...extraImportsMap,
     },
   }


### PR DESCRIPTION
## 一、当前问题

1. 新版本 sender 组件基于 TipTap 重构，由于 ImportMap 未添加 TipTap 相关依赖，
    导致 playground 中无法正常对 组件示例 的效果进行预览。

    **问题截图**
    
    <img width="1925" height="945" alt="image" src="https://github.com/user-attachments/assets/68601c3d-a1c5-4a40-85da-7d5824292612" />
    
2. Tiptap 用的 `peerDependencies` 依赖, 部分包管理器可能需要手动安装相关依赖

## 二、问题处理

1. 基于 esm.sh 添加 TipTip 相关依赖

    **更新截图** 
    
    <img width="1910" height="815" alt="image" src="https://github.com/user-attachments/assets/1be69c8a-03e6-42bb-bb47-5a51c6c7d706" />


2. Tiptap 相关的 `peerDependencies` 依赖移动至 `dependencies` 依赖列表

---

**扩展阅读**  

根据 Tiptap 官方文档和业界最佳实践，有两种主要方案：

1. **使用 esm.sh**（推荐，自动处理依赖）
2. **使用 jsdelivr 的 +esm 功能**（自动打包）

根据 [Tiptap 官方文档](https://tiptap.dev/installation/vanilla-javascript) 和 [GitHub Issue #4873](https://github.com/ueberdosis/tiptap/issues/4873)，推荐使用 **esm.sh CDN**：

**优势：**
1. **自动处理 subpath exports**：esm.sh 能正确解析 package.json 的 exports 字段
2. **自动依赖管理**：避免 ProseMirror 版本冲突（这是 Tiptap 的常见问题）
4. **官方推荐**：Tiptap 官方文档使用 esm.sh 作为 CDN 示例
5. **简洁的 URL**：`https://esm.sh/@tiptap/pm@3.11.0/state` 而不是 `https://cdn.jsdelivr.net/npm/@tiptap/pm@3.11.0/dist/state/index.js`

### 最终方案

使用 esm.sh 导入所有 Tiptap 相关包：
- 主包：`https://esm.sh/@tiptap/core@3.11.0`
- 子路径：`https://esm.sh/@tiptap/pm@3.11.0/state`

这种方式符合 Tiptap 官方推荐，能自动处理复杂的依赖关系和子路径导入，避免版本冲突问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TipTap editor packages enabled in the playground for development and testing.

* **Chores**
  * dompurify and markdown-it moved to runtime dependencies so editor-related content renders consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->