### PR TITLE
feat(sender): add enterkeyhint prop and extract type definition

### DIFF
--- a/docs/src/components/sender.md
+++ b/docs/src/components/sender.md
@@ -278,6 +278,7 @@ Sender 提供了多个插槽位置，方便扩展功能：
 | disabled | 是否禁用 | `boolean` | `false` |
 | loading | 是否加载中 | `boolean` | `false` |
 | autofocus | 自动获取焦点 | `boolean` | `false` |
+| enterkeyhint @0.4 | 移动端虚拟键盘回车键提示 | `EnterKeyHint` | `'send'` |
 | autoSize | 自动调整高度 | `boolean \| { minRows: number, maxRows: number }` | `{ minRows: 1, maxRows: 5 }` |
 | clearable | 是否可清空 | `boolean` | `false` |
 | maxLength | 最大输入长度 | `number` | `Infinity` |
@@ -662,6 +663,9 @@ type StructuredData = TemplateItem[] | MentionStructuredItem[]
 
 // 输入模式
 type InputMode = 'single' | 'multiple'
+
+// 移动端虚拟键盘回车键提示
+type EnterKeyHint = 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'
 
 // 扩展类型
 import type { Extension } from '@tiptap/core'

--- a/packages/components/src/sender/composables/useEditor.ts
+++ b/packages/components/src/sender/composables/useEditor.ts
@@ -11,7 +11,8 @@ import History from '@tiptap/extension-history'
 import Placeholder from '@tiptap/extension-placeholder'
 import CharacterCount from '@tiptap/extension-character-count'
 import type { AnyExtension } from '@tiptap/core'
-import type { SenderProps, SenderEmits, UseEditorReturn } from '../index.type'
+import type { SenderEmits, UseEditorReturn } from '../index.type'
+import type { SenderPropsWithDefaults } from '../index.vue'
 
 /**
  * 编辑器 Hook
@@ -23,7 +24,7 @@ import type { SenderProps, SenderEmits, UseEditorReturn } from '../index.type'
  * - 提供编辑器实例
  *
  */
-export function useEditor(props: SenderProps, emit: SenderEmits): UseEditorReturn {
+export function useEditor(props: SenderPropsWithDefaults, emit: SenderEmits): UseEditorReturn {
   const editorRef = ref<HTMLElement | null>(null)
 
   // 将 placeholder 转换为响应式引用
@@ -62,7 +63,7 @@ export function useEditor(props: SenderProps, emit: SenderEmits): UseEditorRetur
     editorProps: {
       attributes: {
         class: 'tr-sender-editor',
-        enterkeyhint: props.enterkeyhint as string,
+        enterkeyhint: props.enterkeyhint,
       },
       // 处理粘贴事件 - 只粘贴纯文本
       handlePaste(view, event) {

--- a/packages/components/src/sender/composables/useEditor.ts
+++ b/packages/components/src/sender/composables/useEditor.ts
@@ -62,6 +62,8 @@ export function useEditor(props: SenderProps, emit: SenderEmits): UseEditorRetur
     editorProps: {
       attributes: {
         class: 'tr-sender-editor',
+        // 移动端虚拟键盘回车键提示
+        ...(props.enterkeyhint && { enterkeyhint: props.enterkeyhint }),
       },
       // 处理粘贴事件 - 只粘贴纯文本
       handlePaste(view, event) {
@@ -115,6 +117,21 @@ export function useEditor(props: SenderProps, emit: SenderEmits): UseEditorRetur
         const { state } = editor.value
         const tr = state.tr
         editor.value.view.dispatch(tr)
+      }
+    },
+  )
+
+  // 监听 enterkeyhint 变化，动态更新属性
+  watch(
+    () => props.enterkeyhint,
+    (newHint) => {
+      if (editor.value) {
+        const editorElement = editor.value.view.dom
+        if (newHint) {
+          editorElement.setAttribute('enterkeyhint', newHint)
+        } else {
+          editorElement.removeAttribute('enterkeyhint')
+        }
       }
     },
   )

--- a/packages/components/src/sender/composables/useEditor.ts
+++ b/packages/components/src/sender/composables/useEditor.ts
@@ -62,8 +62,7 @@ export function useEditor(props: SenderProps, emit: SenderEmits): UseEditorRetur
     editorProps: {
       attributes: {
         class: 'tr-sender-editor',
-        // 移动端虚拟键盘回车键提示
-        ...(props.enterkeyhint && { enterkeyhint: props.enterkeyhint }),
+        enterkeyhint: props.enterkeyhint as string,
       },
       // 处理粘贴事件 - 只粘贴纯文本
       handlePaste(view, event) {

--- a/packages/components/src/sender/composables/useSenderCore.ts
+++ b/packages/components/src/sender/composables/useSenderCore.ts
@@ -10,7 +10,8 @@
 
 import { EditorView } from '@tiptap/pm/view'
 import { computed, provide, toRef, watch } from 'vue'
-import type { SenderProps, SenderEmits, StructuredData } from '../index.type'
+import type { SenderEmits, StructuredData } from '../index.type'
+import type { SenderPropsWithDefaults } from '../index.vue'
 import {
   MentionPluginKey,
   SuggestionPluginKey,
@@ -56,7 +57,7 @@ export interface UseSenderCoreReturn {
  *
  * 一键获取完整的 context 和 expose 对象
  */
-export function useSenderCore(props: SenderProps, emit: SenderEmits): UseSenderCoreReturn {
+export function useSenderCore(props: SenderPropsWithDefaults, emit: SenderEmits): UseSenderCoreReturn {
   // ========================================
   // 1. 初始化编辑器（必须最先初始化，因为其他逻辑依赖它）
   // ========================================

--- a/packages/components/src/sender/index.type.ts
+++ b/packages/components/src/sender/index.type.ts
@@ -1,5 +1,5 @@
 import type { Extension } from '@tiptap/core'
-import type { InputMode, SubmitTrigger, DefaultActions, AutoSize, StructuredData } from './types/base'
+import type { InputMode, SubmitTrigger, DefaultActions, AutoSize, StructuredData, EnterKeyHint } from './types/base'
 
 // 导出所有子模块类型
 export * from './types/base'
@@ -76,6 +76,15 @@ export interface SenderProps {
    * @default false
    */
   autofocus?: boolean
+
+  /**
+   * 移动端虚拟键盘回车键提示
+   *
+   * 用于自定义移动端虚拟键盘上回车键的显示文本或图标
+   *
+   * @default 'send'
+   */
+  enterkeyhint?: EnterKeyHint
 
   // ===== 模式控制 =====
 

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -14,12 +14,12 @@ const props = withDefaults(defineProps<SenderProps>(), {
   autoSize: () => ({ minRows: 1, maxRows: 5 }),
 })
 
+export type SenderPropsWithDefaults = typeof props
+
 const emit = defineEmits<SenderEmits>()
 
-// 核心逻辑一键引入
 const { context, expose } = useSenderCore(props, emit)
 
-// 暴露方法给父组件
 defineExpose(expose)
 </script>
 

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -9,6 +9,7 @@ const props = withDefaults(defineProps<SenderProps>(), {
   mode: 'single',
   size: 'normal',
   submitType: 'enter',
+  enterkeyhint: 'send',
   extensions: () => [],
   autoSize: () => ({ minRows: 1, maxRows: 5 }),
 })

--- a/packages/components/src/sender/types/base.ts
+++ b/packages/components/src/sender/types/base.ts
@@ -20,6 +20,23 @@ export type InputMode = 'single' | 'multiple'
  */
 export type SubmitTrigger = 'enter' | 'ctrlEnter' | 'shiftEnter'
 
+/**
+ * 移动端虚拟键盘回车键提示
+ *
+ * 用于自定义移动端虚拟键盘上回车键的显示文本或图标
+ *
+ * - `enter`: 插入换行
+ * - `done`: 完成
+ * - `go`: 前往
+ * - `next`: 下一项
+ * - `previous`: 上一项
+ * - `search`: 搜索
+ * - `send`: 发送（推荐用于聊天场景）
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint
+ */
+export type EnterKeyHint = 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'
+
 // ============================================
 // 模板相关类型
 // ============================================


### PR DESCRIPTION
###  一、背景

在移动端使用组件时，键盘右下角的 enter 按键文字显示的 `换行`， 但实际是 `发送` 的行为

### 二、解决方案

提供 `enterkeyhint` 属性让用户可以自定义发送按键的类型文本

可参考 https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sender component adds an enterkeyhint prop to customize the mobile keyboard enter key. Supported values: 'enter', 'done', 'go', 'next', 'previous', 'search', 'send' (default: 'send').
  * Editor now applies and updates the enterkeyhint attribute dynamically as the prop changes.

* **Documentation**
  * Docs include the new EnterKeyHint type and enterkeyhint prop details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->