### PR TITLE
fix(sender): update submit event and template data clearing logic

### DIFF
--- a/packages/components/src/sender/composables/useKeyboardHandler.ts
+++ b/packages/components/src/sender/composables/useKeyboardHandler.ts
@@ -1,5 +1,5 @@
 import { ComputedRef, Ref } from 'vue'
-import type { SenderProps, SenderEmits, SpeechState, SubmitTrigger } from '../index.type'
+import type { SenderProps, SenderEmits, SpeechState, SubmitTrigger, UserItem } from '../index.type'
 
 /**
  * 键盘处理Hook
@@ -46,11 +46,19 @@ export function useKeyboardHandler(
   const triggerSubmit = () => {
     if (!canSubmit.value) return
 
+    const trimmedInputValue = inputValue.value.trim()
+    let templateForSubmit: UserItem[] = []
+
     if (isTemplateMode?.value) {
-      exitTemplateMode?.()
+      if (props.templateData && Array.isArray(props.templateData)) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        templateForSubmit = props.templateData.map(({ id, ...rest }) => rest)
+      }
     }
 
-    emit('submit', inputValue.value.trim())
+    emit('submit', trimmedInputValue, templateForSubmit)
+
+    exitTemplateMode?.()
   }
 
   /**

--- a/packages/components/src/sender/composables/useKeyboardHandler.ts
+++ b/packages/components/src/sender/composables/useKeyboardHandler.ts
@@ -1,5 +1,5 @@
 import { ComputedRef, Ref } from 'vue'
-import type { SenderProps, SenderEmits, SpeechState, SubmitTrigger, UserItem } from '../index.type'
+import type { SenderProps, SenderEmits, SpeechState, SubmitTrigger } from '../index.type'
 
 /**
  * 键盘处理Hook
@@ -47,18 +47,14 @@ export function useKeyboardHandler(
     if (!canSubmit.value) return
 
     const trimmedInputValue = inputValue.value.trim()
-    let templateForSubmit: UserItem[] = []
 
-    if (isTemplateMode?.value) {
-      if (props.templateData && Array.isArray(props.templateData)) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        templateForSubmit = props.templateData.map(({ id, ...rest }) => rest)
-      }
+    if (isTemplateMode?.value && Array.isArray(props.templateData)) {
+      const templateForSubmit = props.templateData.map(({ id: _, ...rest }) => rest)
+      emit('submit', trimmedInputValue, templateForSubmit)
+      exitTemplateMode?.()
+    } else {
+      emit('submit', trimmedInputValue)
     }
-
-    emit('submit', trimmedInputValue, templateForSubmit)
-
-    exitTemplateMode?.()
   }
 
   /**

--- a/packages/components/src/sender/index.type.ts
+++ b/packages/components/src/sender/index.type.ts
@@ -148,7 +148,7 @@ export interface ActionButtonsProps {
 export type SenderEmits = {
   (e: 'update:modelValue', value: string): void
   (e: 'update:templateData', value: UserItem[]): void
-  (e: 'submit', value: string): void
+  (e: 'submit', value: string, templateData?: UserItem[]): void
   (e: 'clear'): void
   (e: 'speech-start'): void
   (e: 'speech-end', transcript?: string): void


### PR DESCRIPTION
同步 v0.3.1-alpha3 优化模板清空逻辑

> 调整 模板数据 的清空时机，发送后再清空模板数据

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Sender now includes current template data when submitting in template mode, while non-template submissions remain unchanged.
  * Input is trimmed before submission.
  * Template mode exits at the correct time after template-mode submissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->