### PR TITLE
feat(playground): support hash sync when embedded in iframe

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,12 +1,9 @@
-import pkg from '@opentiny/tiny-robot/package.json' with { type: 'json' }
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import { fileURLToPath } from 'url'
 import { defineConfig } from 'vitepress'
 import { vitepressDemoPlugin } from 'vitepress-demo-plugin'
-import { SidebarBadgePlugin, MarkdownBadgePlugin } from './plugins/badge'
+import { MarkdownBadgePlugin, SidebarBadgePlugin } from './plugins/badge'
 import { themeConfig } from './themeConfig'
-
-const { version } = pkg
 
 const devAlias = {
   '@opentiny/tiny-robot': fileURLToPath(new URL('../../packages/components/src', import.meta.url)),
@@ -46,9 +43,6 @@ export default defineConfig({
       alias: {
         ...(process.env.VP_MODE === 'development' ? devAlias : prodAlias),
       },
-    },
-    define: {
-      __TINY_ROBOT_VERSION__: JSON.stringify(version),
     },
   },
   markdown: {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -10,7 +10,6 @@ declare global {
     __SW_REGISTERED__?: boolean
     __CODE_PLAYGROUND_LISTENED__?: boolean
   }
-  const __TINY_ROBOT_VERSION__: string
 }
 
 export default {
@@ -80,7 +79,7 @@ function listenCodePlaygroundEvent() {
       })
     }
 
-    const tinyRobotVersion = __TINY_ROBOT_VERSION__ || 'latest'
+    const tinyRobotVersion = 'latest'
     const defaultFiles = getDefaultFiles({ tinyRobotVersion })
     const cssFile = defaultFiles.find((file) => file.filename === 'src/index.css')
     if (cssFile) {

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -48,6 +48,37 @@ function triggerFullRecompile() {
   store.setFiles(store.getFiles(), store.mainFile)
 }
 
+// Listen for messages from the host app (useful when embedded in an iframe).
+const ALLOWED_ORIGINS = ['https://playground.opentiny.design'] as const
+
+function isAllowedMessageOrigin(origin: string): boolean {
+  // Allow local dev (any port) and the official playground domain.
+  if (!origin) return false
+  if (ALLOWED_ORIGINS.includes(origin as (typeof ALLOWED_ORIGINS)[number])) return true
+
+  try {
+    const url = new URL(origin)
+    const host = url.hostname.toLowerCase()
+    if (host === 'localhost' || host === '127.0.0.1') return true
+    return false
+  } catch {
+    return false
+  }
+}
+
+// 使用 document.referrer 推导父页面的 origin，在跨域场景下无法直接访问 window.parent.location
+function getParentOrigin(): string | null {
+  try {
+    const referrer = document.referrer
+    if (!referrer) return null
+    const url = new URL(referrer)
+    const origin = url.origin
+    return isAllowedMessageOrigin(origin) ? origin : null
+  } catch {
+    return null
+  }
+}
+
 if (location.hash) {
   try {
     store.deserialize(location.hash)
@@ -62,7 +93,13 @@ watchEffect(() => {
   const serialized = store.serialize()
   history.replaceState({}, '', serialized)
   if (window.self !== window.top) {
-    window.parent.postMessage({ type: 'playground-hash-change', url: window.location.href, hash: serialized }, '*')
+    const targetOrigin = getParentOrigin()
+    if (targetOrigin) {
+      window.parent.postMessage(
+        { type: 'playground-hash-change', url: window.location.href, hash: serialized },
+        targetOrigin,
+      )
+    }
   }
 })
 
@@ -103,24 +140,6 @@ onMounted(async () => {
     console.error('Failed to load TinyRobot versions:', error)
   }
 })
-
-// Listen for messages from the host app (useful when embedded in an iframe).
-const ALLOWED_ORIGINS = ['https://playground.opentiny.design'] as const
-
-function isAllowedMessageOrigin(origin: string): boolean {
-  // Allow local dev (any port) and the official playground domain.
-  if (!origin) return false
-  if (ALLOWED_ORIGINS.includes(origin as (typeof ALLOWED_ORIGINS)[number])) return true
-
-  try {
-    const url = new URL(origin)
-    const host = url.hostname.toLowerCase()
-    if (host === 'localhost' || host === '127.0.0.1') return true
-    return false
-  } catch {
-    return false
-  }
-}
 
 function onHostMessage(event: MessageEvent) {
   // Security: only accept messages from trusted origins.

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Repl } from '@vue/repl'
 import Monaco from '@vue/repl/monaco-editor'
-import { nextTick, onBeforeUnmount, onMounted, ref, watch, watchEffect } from 'vue'
+import { nextTick, onMounted, ref, watch, watchEffect } from 'vue'
 import Header from './Header.vue'
 import { generateImportMap, generateStore, getDefaultFiles, getVersions } from './utils'
 
@@ -139,38 +139,6 @@ onMounted(async () => {
   } catch (error) {
     console.error('Failed to load TinyRobot versions:', error)
   }
-})
-
-function onHostMessage(event: MessageEvent) {
-  // Security: only accept messages from trusted origins.
-  if (!isAllowedMessageOrigin(event.origin)) {
-    return
-  }
-
-  if (typeof event.data === 'object' && event.data?.type === 'playground-parent-url') {
-    const parentUrl = String(event.data?.url || '')
-
-    // Extract the hash, then `store.deserialize(hash)` and sync `tinyRobotVersion`.
-    try {
-      const url = new URL(parentUrl)
-      const hash = url.hash
-      if (hash) {
-        store.deserialize(hash)
-        syncTinyRobotVersionFromImportMap()
-        triggerFullRecompile()
-      }
-    } catch {
-      // Ignore invalid URLs.
-    }
-  }
-}
-
-onMounted(() => {
-  window.addEventListener('message', onHostMessage)
-})
-
-onBeforeUnmount(() => {
-  window.removeEventListener('message', onHostMessage)
 })
 </script>
 

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,29 +1,70 @@
 <script setup lang="ts">
-import { File, Repl } from '@vue/repl'
+import { Repl } from '@vue/repl'
 import Monaco from '@vue/repl/monaco-editor'
-import { nextTick, onMounted, ref, watch, watchEffect } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref, watch, watchEffect } from 'vue'
 import Header from './Header.vue'
 import { generateImportMap, generateStore, getDefaultFiles, getVersions } from './utils'
 
-declare global {
-  const __TINY_ROBOT_VERSION__: string
-}
-
-const tinyRobotVersion = ref(__TINY_ROBOT_VERSION__ || 'latest')
+const tinyRobotVersion = ref('latest')
 
 const tinyRobotVersions = ref<string[]>([tinyRobotVersion.value])
+const tinyRobotLatestVersion = ref<string | undefined>(undefined)
 
 const { store, builtinImportMap } = generateStore({
   tinyRobotVersion: tinyRobotVersion.value,
   files: location.hash ? [] : getDefaultFiles({ tinyRobotVersion: tinyRobotVersion.value }),
 })
 
-if (location.hash) {
-  store.deserialize(location.hash)
+// Extract TinyRobot version from import-map in store (e.g. from hash) and sync to tinyRobotVersion
+function syncTinyRobotVersionFromImportMap() {
+  type ImportMapShape = { imports?: Record<string, string> }
+  let importMap: ImportMapShape | null = null
+
+  const importMapFile = store.files['import-map.json']
+  if (importMapFile?.code) {
+    try {
+      importMap = JSON.parse(importMapFile.code) as ImportMapShape
+    } catch {
+      // ignore
+    }
+  }
+  const tinyRobotUrl = importMap?.imports?.['@opentiny/tiny-robot']
+  if (!tinyRobotUrl) return
+
+  // Match version in URL like .../tiny-robot@0.3.2/... or .../tiny-robot@latest/...
+  const match = tinyRobotUrl.match(/@opentiny\/tiny-robot@([^/]+)/)
+  const version = match?.[1]?.trim()
+  if (version) {
+    tinyRobotVersion.value = version
+  }
 }
 
-// persist state to URL hash
-watchEffect(() => history.replaceState({}, '', store.serialize()))
+/**
+ * Trigger a full recompile of all files in the store.
+ * Use this when file contents (e.g. src/index.css) are updated in-place so that the preview
+ * picks up the changes without needing to activate the corresponding tab.
+ */
+function triggerFullRecompile() {
+  store.setFiles(store.getFiles(), store.mainFile)
+}
+
+if (location.hash) {
+  try {
+    store.deserialize(location.hash)
+    syncTinyRobotVersionFromImportMap()
+  } catch {
+    // ignore
+  }
+}
+
+// Persist state to URL hash; when in an iframe, notify the parent so it can sync the URL.
+watchEffect(() => {
+  const serialized = store.serialize()
+  history.replaceState({}, '', serialized)
+  if (window.self !== window.top) {
+    window.parent.postMessage({ type: 'playground-hash-change', url: window.location.href, hash: serialized }, '*')
+  }
+})
 
 // Watch for TinyRobot version changes and update import map
 watch(tinyRobotVersion, async (newVersion) => {
@@ -43,28 +84,85 @@ watch(tinyRobotVersion, async (newVersion) => {
       `@opentiny/tiny-robot@${newVersion}/dist/style.css`,
     )
     if (indexCssFile.code !== updatedCss) {
-      store.addFile(new File('src/index.css', updatedCss))
+      indexCssFile.code = updatedCss
+      triggerFullRecompile()
     }
   }
 })
 
-// Load available Vue versions on component mount
+// Load available TinyRobot versions on component mount
 onMounted(async () => {
   try {
-    tinyRobotVersions.value = await getVersions('@opentiny/tiny-robot', {
+    const { versions, lastVersion } = await getVersions('@opentiny/tiny-robot', {
       includePrerelease: true,
-      includeLatest: false,
+      includeLatest: true,
     })
+    tinyRobotVersions.value = versions
+    tinyRobotLatestVersion.value = lastVersion
   } catch (error) {
-    console.error('Failed to load Vue versions:', error)
+    console.error('Failed to load TinyRobot versions:', error)
   }
+})
+
+// Listen for messages from the host app (useful when embedded in an iframe).
+const ALLOWED_ORIGINS = ['https://playground.opentiny.design'] as const
+
+function isAllowedMessageOrigin(origin: string): boolean {
+  // Allow local dev (any port) and the official playground domain.
+  if (!origin) return false
+  if (ALLOWED_ORIGINS.includes(origin as (typeof ALLOWED_ORIGINS)[number])) return true
+
+  try {
+    const url = new URL(origin)
+    const host = url.hostname.toLowerCase()
+    if (host === 'localhost' || host === '127.0.0.1') return true
+    return false
+  } catch {
+    return false
+  }
+}
+
+function onHostMessage(event: MessageEvent) {
+  // Security: only accept messages from trusted origins.
+  if (!isAllowedMessageOrigin(event.origin)) {
+    return
+  }
+
+  if (typeof event.data === 'object' && event.data?.type === 'playground-parent-url') {
+    const parentUrl = String(event.data?.url || '')
+
+    // Extract the hash, then `store.deserialize(hash)` and sync `tinyRobotVersion`.
+    try {
+      const url = new URL(parentUrl)
+      const hash = url.hash
+      if (hash) {
+        store.deserialize(hash)
+        syncTinyRobotVersionFromImportMap()
+        triggerFullRecompile()
+      }
+    } catch {
+      // Ignore invalid URLs.
+    }
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('message', onHostMessage)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('message', onHostMessage)
 })
 </script>
 
 <template>
   <div class="playground-container">
     <!-- Header with Vue version selector -->
-    <Header v-model:tiny-robot-version="tinyRobotVersion" :tiny-robot-versions="tinyRobotVersions" />
+    <Header
+      v-model:tiny-robot-version="tinyRobotVersion"
+      :tiny-robot-versions="tinyRobotVersions"
+      :tiny-robot-latest-version="tinyRobotLatestVersion"
+    />
 
     <!-- Main playground area -->
     <main class="playground-main">

--- a/packages/playground/src/Header.vue
+++ b/packages/playground/src/Header.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import IconGithub from './components/IconGithub.vue'
+import IconShare from './components/IconShare.vue'
+import { notify } from './utils/notify'
 
 // Define props interface for version data
 interface Props {
@@ -13,6 +15,51 @@ withDefaults(defineProps<Props>(), {
 })
 
 const tinyRobotVersion = defineModel<string>('tinyRobotVersion', { required: true })
+
+// Compute a shareable URL. When embedded in an iframe, prefer using the
+// full parent page URL (from document.referrer) but replace its hash with
+// the current playground hash, so the internal playground state is encoded
+// in the parent page URL.
+const getShareUrl = () => {
+  if (typeof window === 'undefined') return ''
+
+  const { location } = window
+  const currentHash = location.hash
+
+  try {
+    const referrer = typeof document !== 'undefined' ? document.referrer : ''
+    if (referrer) {
+      const url = new URL(referrer)
+      // When embedded in an iframe, always share the parent origin with a fixed
+      // playground path, and apply the current playground hash.
+      url.pathname = '/tiny-robot.html'
+      url.hash = currentHash
+      return url.toString()
+    }
+  } catch {
+    // Ignore errors and fall back to the current window URL.
+  }
+
+  // Fallback: use the playground's own URL as-is.
+  return location.href
+}
+
+// Handle click on the share URL button: copy the URL to clipboard or show it as a fallback.
+const handleShareClick = async () => {
+  const url = getShareUrl()
+  if (!url) return
+
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(url)
+      // Notify user that the URL has been copied successfully.
+      notify('链接已复制到剪贴板')
+      return
+    }
+  } catch {
+    // If clipboard access fails, fall back to showing the URL in a prompt.
+  }
+}
 </script>
 
 <template>
@@ -31,6 +78,9 @@ const tinyRobotVersion = defineModel<string>('tinyRobotVersion', { required: tru
             </option>
           </select>
         </div>
+        <button type="button" class="share-button" @click="handleShareClick" aria-label="Copy share URL">
+          <IconShare size="20" />
+        </button>
         <a
           class="github-button"
           href="https://github.com/opentiny/tiny-robot"
@@ -82,6 +132,27 @@ const tinyRobotVersion = defineModel<string>('tinyRobotVersion', { required: tru
   display: flex;
   align-items: center;
   gap: 1rem;
+}
+
+.share-button {
+  background: transparent;
+  border-radius: 999px;
+  color: #333;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.share-button:hover {
+  background-color: rgba(0, 0, 0, 0.04);
 }
 
 .version-selector {

--- a/packages/playground/src/Header.vue
+++ b/packages/playground/src/Header.vue
@@ -16,10 +16,9 @@ withDefaults(defineProps<Props>(), {
 
 const tinyRobotVersion = defineModel<string>('tinyRobotVersion', { required: true })
 
-// Compute a shareable URL. When embedded in an iframe, prefer using the
-// full parent page URL (from document.referrer) but replace its hash with
-// the current playground hash, so the internal playground state is encoded
-// in the parent page URL.
+// 获取分享链接
+// 1. 如果当前页面是 iframe，则使用 document.referrer 获取父页面 URL
+// 2. 如果当前页面不是 iframe，则使用当前页面 URL
 const getShareUrl = () => {
   if (typeof window === 'undefined') return ''
 
@@ -30,17 +29,13 @@ const getShareUrl = () => {
     const referrer = typeof document !== 'undefined' ? document.referrer : ''
     if (referrer) {
       const url = new URL(referrer)
-      // When embedded in an iframe, always share the parent origin with a fixed
-      // playground path, and apply the current playground hash.
+      // 这里写死 pathname。https://playground.opentiny.design/tiny-robot.html
       url.pathname = '/tiny-robot.html'
       url.hash = currentHash
       return url.toString()
     }
-  } catch {
-    // Ignore errors and fall back to the current window URL.
-  }
+  } catch {}
 
-  // Fallback: use the playground's own URL as-is.
   return location.href
 }
 
@@ -52,13 +47,9 @@ const handleShareClick = async () => {
   try {
     if (navigator.clipboard && navigator.clipboard.writeText) {
       await navigator.clipboard.writeText(url)
-      // Notify user that the URL has been copied successfully.
       notify('链接已复制到剪贴板')
-      return
     }
-  } catch {
-    // If clipboard access fails, fall back to showing the URL in a prompt.
-  }
+  } catch {}
 }
 </script>
 

--- a/packages/playground/src/Header.vue
+++ b/packages/playground/src/Header.vue
@@ -4,6 +4,7 @@ import IconGithub from './components/IconGithub.vue'
 // Define props interface for version data
 interface Props {
   tinyRobotVersions: string[]
+  tinyRobotLatestVersion?: string
 }
 
 // Define props with default values
@@ -26,7 +27,7 @@ const tinyRobotVersion = defineModel<string>('tinyRobotVersion', { required: tru
           <label for="tiny-robot-version" class="version-label">TinyRobot 版本:</label>
           <select id="tiny-robot-version" v-model="tinyRobotVersion" class="version-select">
             <option v-for="version in tinyRobotVersions" :key="version" :value="version">
-              {{ version }}
+              {{ version }}{{ version === 'latest' && tinyRobotLatestVersion ? ` (${tinyRobotLatestVersion})` : '' }}
             </option>
           </select>
         </div>
@@ -96,6 +97,7 @@ const tinyRobotVersion = defineModel<string>('tinyRobotVersion', { required: tru
 }
 
 .version-select {
+  min-width: 130px;
   padding: 0.375rem 0.75rem;
   border: 1px solid #ced4da;
   border-radius: 0.375rem;

--- a/packages/playground/src/components/IconShare.vue
+++ b/packages/playground/src/components/IconShare.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    size?: string | number
+  }>(),
+  {
+    size: 24,
+  },
+)
+</script>
+
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path d="M21 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h6" />
+    <path d="m21 3-9 9" />
+    <path d="M15 3h6v6" />
+  </svg>
+</template>

--- a/packages/playground/src/components/Notification.vue
+++ b/packages/playground/src/components/Notification.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+// Props for a simple top-centered notification
+const props = withDefaults(
+  defineProps<{
+    message: string
+    duration?: number
+  }>(),
+  {
+    duration: 2000,
+  },
+)
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const visible = ref(false)
+
+onMounted(() => {
+  // Show with a small delay to ensure transition works
+  requestAnimationFrame(() => {
+    visible.value = true
+  })
+
+  // Auto hide after specified duration
+  window.setTimeout(() => {
+    visible.value = false
+    // Give transition time before unmounting
+    window.setTimeout(() => emit('close'), 200)
+  }, props.duration)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <transition name="notification-fade">
+      <div v-if="visible" class="notification-root">
+        <div class="notification-content">
+          {{ message }}
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.notification-root {
+  position: fixed;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.notification-content {
+  pointer-events: auto;
+  background: #e7f1ff;
+  color: #084298;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+}
+
+.notification-fade-enter-active,
+.notification-fade-leave-active {
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.notification-fade-enter-from,
+.notification-fade-leave-to {
+  opacity: 0;
+  transform: translate(-50%, -6px);
+}
+
+.notification-fade-enter-to,
+.notification-fade-leave-from {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+</style>

--- a/packages/playground/src/components/Notification.vue
+++ b/packages/playground/src/components/Notification.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 
 // Props for a simple top-centered notification
 const props = withDefaults(
@@ -17,19 +17,37 @@ const emit = defineEmits<{
 }>()
 
 const visible = ref(false)
+let showFrameId: number | null = null
+let hideTimer: ReturnType<typeof setTimeout> | null = null
+let closeTimer: ReturnType<typeof setTimeout> | null = null
 
 onMounted(() => {
   // Show with a small delay to ensure transition works
-  requestAnimationFrame(() => {
+  showFrameId = requestAnimationFrame(() => {
     visible.value = true
   })
 
   // Auto hide after specified duration
-  window.setTimeout(() => {
+  hideTimer = setTimeout(() => {
     visible.value = false
     // Give transition time before unmounting
-    window.setTimeout(() => emit('close'), 200)
+    closeTimer = setTimeout(() => emit('close'), 200)
   }, props.duration)
+})
+
+onUnmounted(() => {
+  if (showFrameId !== null) {
+    cancelAnimationFrame(showFrameId)
+    showFrameId = null
+  }
+  if (hideTimer) {
+    clearTimeout(hideTimer)
+    hideTimer = null
+  }
+  if (closeTimer) {
+    clearTimeout(closeTimer)
+    closeTimer = null
+  }
 })
 </script>
 

--- a/packages/playground/src/utils/notify.ts
+++ b/packages/playground/src/utils/notify.ts
@@ -1,0 +1,38 @@
+import { createApp } from 'vue'
+import Notification from '../components/Notification.vue'
+
+export interface NotifyOptions {
+  message: string
+  duration?: number
+}
+
+/**
+ * Programmatically show a top-centered notification.
+ * This creates a one-off Vue app instance and unmounts it after closing.
+ */
+export function notify(options: NotifyOptions | string) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return
+
+  const props: NotifyOptions =
+    typeof options === 'string'
+      ? { message: options }
+      : {
+          message: options.message,
+          duration: options.duration,
+        }
+
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const app = createApp(Notification, {
+    ...props,
+    onClose: () => {
+      app.unmount()
+      if (container.parentNode) {
+        container.parentNode.removeChild(container)
+      }
+    },
+  })
+
+  app.mount(container)
+}

--- a/packages/playground/src/utils/versions.ts
+++ b/packages/playground/src/utils/versions.ts
@@ -4,16 +4,18 @@ interface GetVersionsOptions {
   includeLatest?: boolean // 是否包含 latest tag，默认为 true
 }
 
-const versionCache = new Map<string, string[]>()
+type VersionsResult = { versions: string[]; lastVersion: string | undefined }
+const versionCache = new Map<string, VersionsResult>()
 
-export async function getVersions(pkg: string, options: GetVersionsOptions = {}): Promise<string[]> {
+export async function getVersions(pkg: string, options: GetVersionsOptions = {}): Promise<VersionsResult> {
   const { includePrerelease = false, limit = 20, includeLatest = true } = options
   // 生成缓存键，处理 includePrerelease 可能是数组的情况
   const prereleaseKey = Array.isArray(includePrerelease) ? includePrerelease.join(',') : includePrerelease
   const cacheKey = `${pkg}-${prereleaseKey}-${limit}-${includeLatest}`
 
-  if (versionCache.has(cacheKey)) {
-    return versionCache.get(cacheKey)!
+  const cached = versionCache.get(cacheKey)
+  if (cached) {
+    return cached
   }
 
   try {
@@ -22,6 +24,7 @@ export async function getVersions(pkg: string, options: GetVersionsOptions = {})
     const data = await response.json()
 
     const time: Record<string, string> = data?.time || {}
+    const lastVersion = data['dist-tags']?.latest as string | undefined
     const allVersions = Object.entries(time)
       .filter(([key]) => key !== 'created' && key !== 'modified')
       .slice()
@@ -59,10 +62,11 @@ export async function getVersions(pkg: string, options: GetVersionsOptions = {})
       }
     }
 
-    versionCache.set(cacheKey, versions)
-    return versions
+    const result: VersionsResult = { versions, lastVersion }
+    versionCache.set(cacheKey, result)
+    return result
   } catch (error) {
     console.error(`Failed to fetch versions for ${pkg}:`, error)
-    return ['latest']
+    return { versions: ['latest'], lastVersion: undefined }
   }
 }

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,4 +1,3 @@
-import pkg from '@opentiny/tiny-robot/package.json' with { type: 'json' }
 import vue from '@vitejs/plugin-vue'
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
@@ -17,9 +16,6 @@ export default defineConfig(({ mode }) => {
       plugins: [vue()],
       optimizeDeps: {
         exclude: ['@vue/repl'],
-      },
-      define: {
-        __TINY_ROBOT_VERSION__: JSON.stringify(pkg.version),
       },
     }
   }


### PR DESCRIPTION
- Post playground-hash-change to parent when URL hash changes in iframe
- Listen for playground-parent-url from host to deserialize hash and sync state
- Sync TinyRobot version from import-map when loading from hash
- Restrict postMessage to allowed origins (localhost, playground.opentiny.design)
- Drop __TINY_ROBOT_VERSION__; use "latest" and derive version from hash/import-map
- getVersions returns lastVersion; header shows "latest (x.y.z)" when applicable

# PR：Playground iframe 下的 hash 同步能力

Related to opentiny/playground#21

## 功能概述

当 Playground 以 iframe 方式嵌入时，支持将自身的 URL hash 变化同步给父页面，保证地址栏状态与 iframe 内的示例状态尽量保持一致（便于分享与还原）。  

## 通信方式

- **通道**：浏览器 `postMessage`
- **方向**：**单向**（iframe → 父页面）
- **触发条件**：仅在 `window.self !== window.top`（运行在 iframe 中）时开启通信
- **安全约束**：根据 `document.referrer` 推导父页面 `origin`，并通过白名单校验，仅在受信任来源下发送消息

## 事件约定

### `playground-hash-change`（iframe → 父页面）

- **发送方**：Playground（iframe 内）
- **触发时机**：Playground 将当前状态序列化到自身 URL hash 时
- **主要字段**：
  - `type`: `'playground-hash-change'`
  - `url`: iframe 当前完整 URL
  - `hash`: 序列化后的 hash（如 `#code/...`）
- **父页面建议处理**：
  - 监听该事件后，使用 `history.replaceState` 或路由更新，将父页面地址栏同步为最新的 Playground 状态；
  - 也可以据此更新自身路由或记录埋点等。

## 安全策略

发送 `playground-hash-change` 事件前，会基于以下策略决定是否发送以及发送目标 `origin`：

- 通过 `document.referrer` 推导父页面 URL，并取其 `origin`
- 仅当该 `origin` 满足以下任一条件时才发送：
  - `https://playground.opentiny.design`
  - `localhost`（任意端口）
  - `127.0.0.1`（任意端口）
- 对于不在白名单内的来源，将 **跳过发送**，避免在恶意父页面中泄露 Playground 状态。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Share button to copy a permalink for embedded playgrounds.
  * In-app notifications for copy/feedback messages.

* **Improvements**
  * Secure parent-child messaging and URL/hash persistence when embedded.
  * Playground now shows the actual latest TinyRobot version in the selector and falls back to "latest" when unavailable.
  * CSS edits now trigger a full recompile so style changes apply reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->