### PR TITLE
test(sender): add e2e tests and selectors

### DIFF
--- a/packages/test/src/App.vue
+++ b/packages/test/src/App.vue
@@ -5,6 +5,7 @@
       <ul>
         <li><a href="/" @click.prevent="currentComponent = 'Home'">首页</a></li>
         <li><a href="/container" @click.prevent="currentComponent = 'Container'">Container 组件</a></li>
+        <li><a href="/sender" @click.prevent="currentComponent = 'Sender'">Sender 组件</a></li>
       </ul>
     </nav>
 
@@ -15,26 +16,23 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { Component } from 'vue'
 import Home from './home/index.vue'
 import ContainerDemo from './container/index.vue'
+import SenderDemo from './sender/index.vue'
 
-// 定义组件名称类型
-type ComponentName = 'Home' | 'Container'
+type ComponentName = 'Home' | 'Container' | 'Sender'
 
 const currentComponent = ref<ComponentName>('Home')
 
-// 定义组件映射对象
 const components: Record<ComponentName, Component> = {
   Home,
   Container: ContainerDemo,
+  Sender: SenderDemo,
 }
 
-// 计算属性确保类型安全
-const currentComponentInstance = computed(() => {
-  return components[currentComponent.value]
-})
+const currentComponentInstance = computed(() => components[currentComponent.value])
 </script>
 
 <style>

--- a/packages/test/src/home/index.vue
+++ b/packages/test/src/home/index.vue
@@ -1,26 +1,25 @@
 <template>
   <div class="home">
     <h2>欢迎使用 Tiny Robot E2E 测试应用</h2>
-    <p>这是一个用于测试 Tiny Robot 组件的演示应用。</p>
+    <p>这里会挂载组件的交互演示页，供 Playwright 用例直接操作和断言。</p>
 
     <div class="test-info">
-      <h3>可用测试组件：</h3>
+      <h3>可用测试组件</h3>
       <ul>
-        <li><strong>Container 组件</strong> - 测试容器组件的显示/隐藏、全屏切换、拖拽条等功能</li>
+        <li><strong>Container 组件</strong> - 验证容器组件的显示、隐藏、全屏切换等行为。</li>
+        <li><strong>Sender 组件</strong> - 验证输入、提交、Mention、Template、Suggestion 等行为。</li>
       </ul>
     </div>
 
     <div class="instructions">
-      <h3>测试说明：</h3>
-      <p>点击导航栏中的组件链接来查看和测试不同的组件。</p>
-      <p>每个组件页面都包含了相应的交互元素，用于 E2E 测试。</p>
+      <h3>测试说明</h3>
+      <p>点击上方导航可以切换到具体组件页面。</p>
+      <p>每个页面都会暴露稳定的测试按钮和 `data-testid`，便于 E2E 用例编写与维护。</p>
     </div>
   </div>
 </template>
 
-<script setup lang="ts">
-// 首页组件，用于显示测试应用的基本信息
-</script>
+<script setup lang="ts"></script>
 
 <style scoped>
 .home {

--- a/packages/test/src/sender/helpers/index.ts
+++ b/packages/test/src/sender/helpers/index.ts
@@ -15,6 +15,10 @@ export function createSenderTestHelper(page: Page) {
       return page.locator(selectors.sender)
     },
 
+    getEditorScroll() {
+      return page.locator(selectors.editorScroll)
+    },
+
     async typeContent(text: string) {
       await this.getEditor().click()
       await page.keyboard.type(text)
@@ -146,6 +150,23 @@ export function createSenderTestHelper(page: Page) {
 
     async expectResult(text: string) {
       await expect(page.locator(selectors.resultDisplay)).toContainText(text)
+    },
+
+    async expectResultExact(text: string) {
+      await expect(page.locator(selectors.resultDisplay)).toHaveText(text)
+    },
+
+    async expectMode(mode: 'single' | 'multiple') {
+      await expect(page.locator(selectors.modeDisplay)).toHaveText(mode)
+    },
+
+    async expectSubmitButtonDisabled(disabled: boolean) {
+      const submitBtn = page.locator(selectors.submitButton)
+      if (disabled) {
+        await expect(submitBtn).toHaveClass(/is-disabled/)
+      } else {
+        await expect(submitBtn).not.toHaveClass(/is-disabled/)
+      }
     },
 
     async expectFooterSlot() {

--- a/packages/test/src/sender/helpers/index.ts
+++ b/packages/test/src/sender/helpers/index.ts
@@ -1,0 +1,163 @@
+import { expect, type Page } from '@playwright/test'
+import { SENDER_SELECTORS } from '../selectors'
+
+export function createSenderTestHelper(page: Page) {
+  const selectors = SENDER_SELECTORS
+
+  return {
+    selectors,
+
+    getEditor() {
+      return page.locator(selectors.editor)
+    },
+
+    getSender() {
+      return page.locator(selectors.sender)
+    },
+
+    async typeContent(text: string) {
+      await this.getEditor().click()
+      await page.keyboard.type(text)
+    },
+
+    async clearContent() {
+      await this.getEditor().click()
+      await page.keyboard.press('Control+A')
+      await page.keyboard.press('Delete')
+      await page.waitForTimeout(50)
+    },
+
+    async clickSubmit() {
+      const submitBtn = page.locator(selectors.submitButton)
+      await expect(submitBtn).toBeVisible()
+      await submitBtn.click()
+    },
+
+    async clickClear() {
+      await page.locator(selectors.clearButton).click()
+    },
+
+    async toggleMode() {
+      await page.locator(selectors.toggleModeBtn).click()
+    },
+
+    async toggleClearable() {
+      await page.locator(selectors.toggleClearableBtn).click()
+    },
+
+    async toggleLoading() {
+      await page.locator(selectors.toggleLoadingBtn).click()
+    },
+
+    async toggleDisabled() {
+      await page.locator(selectors.toggleDisabledBtn).click()
+    },
+
+    async toggleWordLimit() {
+      await page.locator(selectors.toggleWordLimitBtn).click()
+    },
+
+    async toggleSize() {
+      await page.locator(selectors.toggleSizeBtn).click()
+    },
+
+    async setSubmitType(type: 'enter' | 'ctrlEnter' | 'shiftEnter') {
+      await page.locator(selectors.submitTypeSelect).selectOption(type)
+    },
+
+    async setMaxLength(length: number) {
+      await page.locator(selectors.maxLengthInput).fill(String(length))
+    },
+
+    async setPlaceholder(text: string) {
+      await page.locator(selectors.placeholderInput).fill(text)
+    },
+
+    async toggleMention() {
+      await page.locator(selectors.toggleMentionBtn).click()
+    },
+
+    async toggleTemplate() {
+      await page.locator(selectors.toggleTemplateBtn).click()
+    },
+
+    async toggleSuggestion() {
+      await page.locator(selectors.toggleSuggestionBtn).click()
+    },
+
+    async setContent() {
+      await page.locator(selectors.setContentBtn).click()
+    },
+
+    async getContent() {
+      await page.locator(selectors.getContentBtn).click()
+    },
+
+    async focusEditor() {
+      await page.locator(selectors.focusBtn).click()
+    },
+
+    async blurEditor() {
+      await page.locator(selectors.blurBtn).click()
+    },
+
+    async clearEditor() {
+      await page.locator(selectors.clearBtn).click()
+    },
+
+    async submitEditor() {
+      await page.locator(selectors.submitBtn).click()
+    },
+
+    async expectEditorContent(text: string) {
+      await expect(this.getEditor()).toContainText(text)
+    },
+
+    async expectEditorEmpty() {
+      const content = await this.getEditor().textContent()
+      const normalized = (content ?? '')
+        .replace(/\u200b/g, '')
+        .replace(/\u00a0/g, '')
+        .trim()
+      expect(normalized).toBe('')
+    },
+
+    async expectClearButtonVisible(visible: boolean) {
+      const clearBtn = page.locator(selectors.clearButton)
+      if (visible) {
+        await expect(clearBtn).toBeVisible()
+      } else {
+        await expect(clearBtn).toHaveCount(0)
+      }
+    },
+
+    async expectLoadingButtonVisible(visible: boolean) {
+      const loadingBtn = page.locator(selectors.loadingButton)
+      if (visible) {
+        await expect(loadingBtn).toBeVisible()
+      } else {
+        await expect(loadingBtn).toHaveCount(0)
+      }
+    },
+
+    async expectWordCounter(text: string) {
+      await expect(page.locator(selectors.wordCounter)).toContainText(text)
+    },
+
+    async expectResult(text: string) {
+      await expect(page.locator(selectors.resultDisplay)).toContainText(text)
+    },
+
+    async expectFooterSlot() {
+      await expect(page.locator(selectors.customFooterBtn)).toBeVisible()
+    },
+
+    async clickCustomFooterBtn() {
+      await page.locator(selectors.customFooterBtn).click()
+    },
+
+    async wait(ms: number) {
+      await page.waitForTimeout(ms)
+    },
+  }
+}

--- a/packages/test/src/sender/helpers/mention-helper.ts
+++ b/packages/test/src/sender/helpers/mention-helper.ts
@@ -1,0 +1,117 @@
+import { type Page, expect } from '@playwright/test'
+import { SENDER_SELECTORS } from '../selectors'
+
+export function createMentionHelper(page: Page) {
+  const selectors = SENDER_SELECTORS
+
+  return {
+    // 获取编辑器
+    getEditor() {
+      return page.locator(selectors.editor)
+    },
+
+    // 输入 @ 符号触发提及选择面板
+    async typeAtSymbol() {
+      await this.getEditor().click()
+      await page.keyboard.type('@')
+      // 等待面板出现
+      await expect(page.locator(selectors.mentionList)).toBeVisible()
+    },
+
+    // 输入查询文本进行过滤
+    async typeQuery(query: string) {
+      await page.keyboard.type(query)
+    },
+
+    // 按下键盘按键
+    async pressKey(key: string) {
+      await page.keyboard.press(key)
+    },
+
+    // 点击指定索引的提及项
+    async clickItem(index: number) {
+      const items = page.locator(selectors.mentionItem)
+      await items.nth(index).click()
+    },
+
+    // 鼠标悬停在指定索引的提及项上
+    async hoverItem(index: number) {
+      const items = page.locator(selectors.mentionItem)
+      await items.nth(index).hover()
+    },
+
+    // 验证提及选择面板可见
+    async expectMentionListVisible(visible: boolean = true) {
+      const list = page.locator(selectors.mentionList)
+      if (visible) {
+        await expect(list).toBeVisible()
+      } else {
+        await expect(list).not.toBeVisible()
+      }
+    },
+
+    // 验证提及选择面板中的项数量
+    async expectItemCount(count: number) {
+      const items = page.locator(selectors.mentionItem)
+      await expect(items).toHaveCount(count)
+    },
+
+    // 验证选中的项索引
+    async expectSelectedItemIndex(index: number) {
+      const selected = page.locator(selectors.mentionSelected)
+      const allItems = page.locator(selectors.mentionItem)
+      const selectedItem = allItems.nth(index)
+      await expect(selected).toHaveCount(1)
+      await expect(selectedItem).toHaveClass(/is-selected/)
+    },
+
+    // 验证编辑器中包含 mention 节点
+    async expectMentionExists(label: string) {
+      const mention = page.locator(selectors.mentionNode)
+      await expect(mention).toBeVisible()
+      await expect(mention).toContainText(label)
+    },
+
+    // 验证编辑器中 mention 节点数量
+    async expectMentionCount(count: number) {
+      const mentions = page.locator(selectors.mentionNode)
+      if (count === 0) {
+        await expect(mentions).toHaveCount(0)
+      } else {
+        await expect(mentions).toHaveCount(count)
+      }
+    },
+
+    // 验证提及列表中包含特定文本
+    async expectListContains(text: string) {
+      const items = page.locator(selectors.mentionItem)
+      const firstItem = items.first()
+      await expect(firstItem).toContainText(text)
+    },
+
+    // 删除 mention 节点（模拟 Backspace）
+    // 注意：mention 插入时会自动在后面添加空格，所以需要按两次 Backspace
+    // 第一次删除空格，第二次删除节点
+    async deleteMention() {
+      await page.keyboard.press('Backspace') // 删除空格
+      await page.keyboard.press('Backspace') // 删除节点
+    },
+
+    // 选择 mention 节点
+    async selectMention(label: string) {
+      const mention = page.locator(selectors.mentionNode).filter({ hasText: label })
+      await mention.click()
+    },
+
+    // 验证光标位置在技能块后面（通过输入测试）
+    async expectCursorAfterMention() {
+      // 输入一个空格看是否在技能块后面
+      await page.keyboard.type(' ')
+    },
+
+    // 等待
+    async wait(ms: number) {
+      await page.waitForTimeout(ms)
+    },
+  }
+}

--- a/packages/test/src/sender/helpers/mention-helper.ts
+++ b/packages/test/src/sender/helpers/mention-helper.ts
@@ -84,9 +84,8 @@ export function createMentionHelper(page: Page) {
 
     // 验证提及列表中包含特定文本
     async expectListContains(text: string) {
-      const items = page.locator(selectors.mentionItem)
-      const firstItem = items.first()
-      await expect(firstItem).toContainText(text)
+      const matchingItem = page.locator(selectors.mentionItem).filter({ hasText: text }).first()
+      await expect(matchingItem).toBeVisible()
     },
 
     // 删除 mention 节点（模拟 Backspace）

--- a/packages/test/src/sender/helpers/suggestion-helper.ts
+++ b/packages/test/src/sender/helpers/suggestion-helper.ts
@@ -1,0 +1,70 @@
+import { type Page, expect } from '@playwright/test'
+import { SENDER_SELECTORS } from '../selectors'
+
+export function createSuggestionHelper(page: Page) {
+  const selectors = SENDER_SELECTORS
+
+  return {
+    // 检查 Suggestion 列表是否可见
+    async expectSuggestionListVisible(visible: boolean) {
+      const list = page.locator(selectors.suggestionList)
+      if (visible) {
+        await expect(list).toBeVisible()
+      } else {
+        await expect(list).not.toBeVisible()
+      }
+    },
+
+    // 检查建议项数量
+    async expectSuggestionCount(count: number) {
+      await expect(page.locator(selectors.suggestionItem)).toHaveCount(count)
+    },
+
+    // 检查建议项内容
+    async expectSuggestionItemText(index: number, text: string) {
+      // 获取纯文本内容，忽略 HTML 标签
+      await expect(page.locator(selectors.suggestionItem).nth(index)).toContainText(text)
+    },
+
+    // 检查是否有高亮项
+    async expectHighlightedItem(index: number) {
+      const item = page.locator(selectors.suggestionItem).nth(index)
+      await expect(item).toHaveClass(/highlighted/)
+    },
+
+    // 点击建议项
+    async clickSuggestionItem(index: number) {
+      await page.locator(selectors.suggestionItem).nth(index).click()
+    },
+
+    // 按下 Enter
+    async pressEnter() {
+      await page.keyboard.press('Enter')
+    },
+
+    // 按下 Tab
+    async pressTab() {
+      await page.keyboard.press('Tab')
+    },
+
+    // 按下 ArrowDown
+    async pressArrowDown() {
+      await page.keyboard.press('ArrowDown')
+    },
+
+    // 按下 ArrowUp
+    async pressArrowUp() {
+      await page.keyboard.press('ArrowUp')
+    },
+
+    // 鼠标悬停到建议项
+    async hoverSuggestionItem(index: number) {
+      await page.locator(selectors.suggestionItem).nth(index).hover()
+    },
+
+    // 等待一段时间
+    async wait(ms: number) {
+      await page.waitForTimeout(ms)
+    },
+  }
+}

--- a/packages/test/src/sender/helpers/template-helper.ts
+++ b/packages/test/src/sender/helpers/template-helper.ts
@@ -1,0 +1,242 @@
+import { type Page, expect } from '@playwright/test'
+import { SENDER_SELECTORS } from '../selectors'
+
+/**
+ * 模板块测试辅助函数
+ */
+export function createTemplateTestHelper(page: Page) {
+  const selectors = SENDER_SELECTORS
+
+  return {
+    selectors,
+
+    /**
+     * 获取编辑器元素
+     */
+    getEditor() {
+      return page.locator(selectors.editor)
+    },
+
+    /**
+     * 获取所有模板块
+     */
+    getTemplates() {
+      return page.locator(selectors.template)
+    },
+
+    /**
+     * 根据索引获取模板块
+     */
+    getTemplate(index: number) {
+      return this.getTemplates().nth(index)
+    },
+
+    /**
+     * 获取模板块内的可编辑内容元素
+     */
+    getTemplateContent(index: number) {
+      return this.getTemplate(index).locator(selectors.templateContent)
+    },
+
+    /**
+     * 设置简单模板（一个模板块）
+     * 等同于：我是【张三】，来自
+     */
+    async setSimpleTemplate() {
+      await page.click(selectors.setTemplateSimpleBtn)
+      // 等待至少一个模板块出现
+      await expect(this.getTemplates().first()).toBeVisible()
+    },
+
+    /**
+     * 设置空模板块
+     * 等同于：我是【 】，来自
+     */
+    async setEmptyTemplate() {
+      await page.click(selectors.setTemplateEmptyBtn)
+      // 等待至少一个模板块出现
+      await expect(this.getTemplates().first()).toBeVisible()
+    },
+
+    /**
+     * 设置多个模板块
+     * 等同于：【姓名】【年龄】【城市】
+     */
+    async setMultipleTemplates() {
+      await page.click(selectors.setTemplateMultipleBtn)
+      // 等待至少3个模板块出现
+      await expect(this.getTemplates()).toHaveCount(3)
+    },
+
+    /**
+     * 清空模板
+     */
+    async clearTemplates() {
+      await page.click(selectors.clearTemplateBtn)
+      // 等待模板块数量归零
+      await expect(this.getTemplates()).toHaveCount(0)
+    },
+
+    /**
+     * 获取编辑器的文本内容（包括零宽字符）
+     */
+    async getEditorText() {
+      return await page.evaluate(() => {
+        const editor = document.querySelector('[data-testid="test-sender"] .ProseMirror')
+        return editor?.textContent || ''
+      })
+    },
+
+    /**
+     * 获取模板块数量
+     */
+    async getTemplateCount() {
+      return await this.getTemplates().count()
+    },
+
+    /**
+     * 获取指定模板块的文本内容
+     */
+    async getTemplateText(index: number) {
+      const block = this.getTemplate(index)
+      return await block.textContent()
+    },
+
+    /**
+     * 点击进入模板块编辑
+     */
+    async clickTemplate(index: number) {
+      const block = this.getTemplate(index)
+      await block.click()
+    },
+
+    /**
+     * 聚焦到模板块内容末尾
+     */
+    async focusTemplateEnd(index: number) {
+      await this.getTemplate(index).click()
+      // 移动光标到末尾
+      await page.keyboard.press('End')
+    },
+
+    /**
+     * 聚焦到模板块内容开头
+     */
+    async focusTemplateStart(index: number) {
+      await this.getTemplate(index).click()
+      // 移动光标到开头
+      await page.keyboard.press('Home')
+    },
+
+    /**
+     * 在模板块中输入文本
+     */
+    async typeInTemplate(index: number, text: string) {
+      await this.getTemplate(index).click()
+      await page.keyboard.type(text)
+    },
+
+    /**
+     * 按 Backspace 键
+     */
+    async pressBackspace(times: number = 1) {
+      for (let i = 0; i < times; i++) {
+        await page.keyboard.press('Backspace')
+        await page.waitForTimeout(50) // 等待 DOM 更新
+      }
+    },
+
+    /**
+     * 按 Delete 键
+     */
+    async pressDelete(times: number = 1) {
+      for (let i = 0; i < times; i++) {
+        await page.keyboard.press('Delete')
+        await page.waitForTimeout(50) // 等待 DOM 更新
+      }
+    },
+
+    /**
+     * 按 ArrowLeft 键
+     */
+    async pressArrowLeft(times: number = 1) {
+      for (let i = 0; i < times; i++) {
+        await page.keyboard.press('ArrowLeft')
+        await page.waitForTimeout(30)
+      }
+    },
+
+    /**
+     * 按 ArrowRight 键
+     */
+    async pressArrowRight(times: number = 1) {
+      for (let i = 0; i < times; i++) {
+        await page.keyboard.press('ArrowRight')
+        await page.waitForTimeout(30)
+      }
+    },
+
+    /**
+     * 选择编辑器中的文本
+     */
+    async selectText(range?: { from?: number; to?: number }) {
+      if (!range) {
+        // 全选
+        await page.keyboard.press('Control+A')
+      } else {
+        // TODO: 实现指定范围的选择
+        await page.keyboard.press('Control+A')
+      }
+    },
+
+    /**
+     * 验证模板块数量
+     */
+    async expectTemplateCount(count: number) {
+      await expect(this.getTemplates()).toHaveCount(count)
+    },
+
+    /**
+     * 验证模板块文本内容
+     */
+    async expectTemplateText(index: number, text: string) {
+      const block = this.getTemplate(index)
+      await expect(block).toContainText(text)
+    },
+
+    /**
+     * 验证编辑器包含文本
+     */
+    async expectEditorToContainText(text: string) {
+      await expect(this.getEditor()).toContainText(text)
+    },
+
+    /**
+     * 等待一段时间
+     */
+    async wait(ms: number) {
+      await page.waitForTimeout(ms)
+    },
+
+    /**
+     * 从后往前删除所有模板块的内容，并确保光标回到最前面
+     * @param backspaceCount 需要按 Backspace 的次数
+     */
+    async clearAllTemplatesContent(backspaceCount: number) {
+      // 聚焦到最后一个模板块末尾
+      const count = await this.getTemplateCount()
+      if (count > 0) {
+        await this.focusTemplateEnd(count - 1)
+        await this.pressBackspace(backspaceCount)
+      }
+    },
+
+    /**
+     * 从前往后删除空模板块
+     * @param deleteCount 需要按 Delete 的次数
+     */
+    async deleteEmptyTemplates(deleteCount: number) {
+      await this.pressDelete(deleteCount)
+    },
+  }
+}

--- a/packages/test/src/sender/helpers/template-helper.ts
+++ b/packages/test/src/sender/helpers/template-helper.ts
@@ -142,7 +142,6 @@ export function createTemplateTestHelper(page: Page) {
     async pressBackspace(times: number = 1) {
       for (let i = 0; i < times; i++) {
         await page.keyboard.press('Backspace')
-        await page.waitForTimeout(50) // 等待 DOM 更新
       }
     },
 
@@ -152,7 +151,6 @@ export function createTemplateTestHelper(page: Page) {
     async pressDelete(times: number = 1) {
       for (let i = 0; i < times; i++) {
         await page.keyboard.press('Delete')
-        await page.waitForTimeout(50) // 等待 DOM 更新
       }
     },
 
@@ -162,7 +160,6 @@ export function createTemplateTestHelper(page: Page) {
     async pressArrowLeft(times: number = 1) {
       for (let i = 0; i < times; i++) {
         await page.keyboard.press('ArrowLeft')
-        await page.waitForTimeout(30)
       }
     },
 
@@ -172,7 +169,6 @@ export function createTemplateTestHelper(page: Page) {
     async pressArrowRight(times: number = 1) {
       for (let i = 0; i < times; i++) {
         await page.keyboard.press('ArrowRight')
-        await page.waitForTimeout(30)
       }
     },
 
@@ -184,8 +180,7 @@ export function createTemplateTestHelper(page: Page) {
         // 全选
         await page.keyboard.press('Control+A')
       } else {
-        // TODO: 实现指定范围的选择
-        await page.keyboard.press('Control+A')
+        throw new Error('selectText(range) is not implemented yet')
       }
     },
 

--- a/packages/test/src/sender/index.vue
+++ b/packages/test/src/sender/index.vue
@@ -1,0 +1,334 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { TinySwitch } from '@opentiny/vue'
+import { Sender } from '@opentiny/tiny-robot'
+import type { MentionItem, TemplateItem, SenderSuggestionItem } from '@opentiny/tiny-robot'
+
+const senderRef = ref()
+const content = ref('')
+const result = ref('')
+
+const isMultipleMode = ref(false)
+const clearable = ref(false)
+const loading = ref(false)
+const disabled = ref(false)
+const showWordLimit = ref(true)
+const isSmallSize = ref(false)
+const submitType = ref<'enter' | 'ctrlEnter' | 'shiftEnter'>('enter')
+const maxLength = ref(100)
+const placeholder = ref('请输入内容...')
+
+const enableMention = ref(false)
+const enableTemplate = ref(false)
+const enableSuggestion = ref(false)
+const templateData = ref<TemplateItem[]>([])
+
+const mode = computed(() => (isMultipleMode.value ? 'multiple' : 'single'))
+const size = computed(() => (isSmallSize.value ? 'small' : 'normal'))
+
+const componentKey = computed(() => {
+  return `${enableMention.value}-${enableTemplate.value}-${enableSuggestion.value}`
+})
+
+const handleModeChange = () => {
+  result.value = `模式切换为: ${mode.value}`
+}
+
+const handleSizeChange = () => {
+  result.value = `尺寸切换为: ${size.value}`
+}
+
+const handleSubmit = (value: string) => {
+  result.value = `提交内容: ${value}`
+}
+
+const handleCancel = () => {
+  result.value = '取消操作'
+}
+
+const handleClear = () => {
+  result.value = '内容已清空'
+}
+
+const handleCustomAction = () => {
+  result.value = '自定义按钮被点击'
+}
+
+const handleSetContent = () => {
+  senderRef.value?.setContent('<p>测试内容</p>')
+  result.value = '已设置内容'
+}
+
+const handleGetContent = () => {
+  const current = senderRef.value?.getContent() ?? ''
+  result.value = `当前内容: ${current}`
+}
+
+const handleFocus = () => {
+  senderRef.value?.focus()
+  result.value = '调用 focus 方法'
+}
+
+const handleBlur = () => {
+  senderRef.value?.blur()
+  result.value = '调用 blur 方法'
+}
+
+const handleClearMethod = () => {
+  senderRef.value?.clear()
+  result.value = '调用 clear 方法'
+}
+
+const handleSubmitMethod = () => {
+  senderRef.value?.submit()
+  result.value = '调用 submit 方法'
+}
+
+const setTemplateSimple = () => {
+  templateData.value = [
+    { type: 'text', content: '我是' },
+    { type: 'block', content: '张三' },
+    { type: 'text', content: '，来自' },
+  ]
+  result.value = '已设置简单模板'
+}
+
+const setTemplateEmpty = () => {
+  templateData.value = [
+    { type: 'text', content: '我是' },
+    { type: 'block', content: '' },
+    { type: 'text', content: '，来自' },
+  ]
+  result.value = '已设置空模板块'
+}
+
+const setTemplateMultiple = () => {
+  templateData.value = [
+    { type: 'block', content: '姓名' },
+    { type: 'block', content: '年龄' },
+    { type: 'block', content: '城市' },
+  ]
+  result.value = '已设置多个模板块'
+}
+
+const clearTemplate = () => {
+  templateData.value = []
+  result.value = '已清空模板'
+}
+
+const mentions = ref<MentionItem[]>([
+  {
+    label: '小小画家',
+    value: '你是一个专业的绘画助手，擅长创作各种风格的艺术作品。',
+  },
+  {
+    label: '代码助手',
+    value: '你是一个专业的编码助手，精通多种编程语言和框架。',
+  },
+  {
+    label: '文案大师',
+    value: '你是一个专业的文案助手，能够创作吸引人的营销文案。',
+  },
+  {
+    label: '数据分析',
+    value: '你是一个专业的数据分析师，擅长从数据中提取有价值的信息。',
+  },
+])
+
+const suggestions = ref<SenderSuggestionItem[]>([
+  { content: 'Java' },
+  { content: 'JavaScript' },
+  { content: 'TypeScript' },
+  { content: 'Python' },
+  { content: 'C++' },
+  { content: 'Golang' },
+])
+
+const extensions = computed(() => {
+  const exts = []
+  if (enableMention.value) {
+    exts.push(Sender.mention(mentions))
+  }
+  if (enableTemplate.value) {
+    exts.push(Sender.template(templateData))
+  }
+  if (enableSuggestion.value) {
+    exts.push(Sender.suggestion(suggestions))
+  }
+  return exts
+})
+</script>
+
+<template>
+  <div class="sender-demo">
+    <h2>Sender 组件测试</h2>
+
+    <div class="control-panel">
+      <fieldset class="control-group">
+        <legend>基础属性</legend>
+        <div class="control-row">
+          <div class="control-item">
+            <label>mode:</label>
+            <tiny-switch
+              data-testid="toggle-mode-btn"
+              v-model="isMultipleMode"
+              @change="handleModeChange"
+            ></tiny-switch>
+            <span data-testid="mode-display">{{ mode }}</span>
+          </div>
+          <div class="control-item">
+            <label>clearable:</label>
+            <tiny-switch data-testid="toggle-clearable-btn" v-model="clearable"></tiny-switch>
+          </div>
+          <div class="control-item">
+            <label>loading:</label>
+            <tiny-switch data-testid="toggle-loading-btn" v-model="loading"></tiny-switch>
+          </div>
+          <div class="control-item">
+            <label>disabled:</label>
+            <tiny-switch data-testid="toggle-disabled-btn" v-model="disabled"></tiny-switch>
+          </div>
+          <div class="control-item">
+            <label>showWordLimit:</label>
+            <tiny-switch data-testid="toggle-word-limit-btn" v-model="showWordLimit"></tiny-switch>
+          </div>
+          <div class="control-item">
+            <label>size:</label>
+            <tiny-switch data-testid="toggle-size-btn" v-model="isSmallSize" @change="handleSizeChange"></tiny-switch>
+            <span>{{ size }}</span>
+          </div>
+          <div class="control-item">
+            <label>submitType:</label>
+            <select data-testid="submit-type-select" v-model="submitType">
+              <option value="enter">enter</option>
+              <option value="ctrlEnter">ctrlEnter</option>
+              <option value="shiftEnter">shiftEnter</option>
+            </select>
+          </div>
+          <div class="control-item">
+            <label>maxLength:</label>
+            <input data-testid="max-length-input" type="number" v-model.number="maxLength" />
+          </div>
+          <div class="control-item">
+            <label>placeholder:</label>
+            <input data-testid="placeholder-input" type="text" v-model="placeholder" />
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset class="control-group">
+        <legend>扩展开关</legend>
+        <div class="control-row">
+          <div class="control-item">
+            <label>mention:</label>
+            <tiny-switch data-testid="toggle-mention-btn" v-model="enableMention"></tiny-switch>
+          </div>
+          <div class="control-item">
+            <label>template:</label>
+            <tiny-switch data-testid="toggle-template-btn" v-model="enableTemplate"></tiny-switch>
+          </div>
+          <div class="control-item">
+            <label>suggestion:</label>
+            <tiny-switch data-testid="toggle-suggestion-btn" v-model="enableSuggestion"></tiny-switch>
+          </div>
+        </div>
+      </fieldset>
+
+      <fieldset class="control-group">
+        <legend>方法调用</legend>
+        <div class="button-row">
+          <button data-testid="set-content-btn" @click="handleSetContent">设置内容</button>
+          <button data-testid="get-content-btn" @click="handleGetContent">获取内容</button>
+          <button data-testid="focus-btn" @click="handleFocus">聚焦</button>
+          <button data-testid="blur-btn" @click="handleBlur">失焦</button>
+          <button data-testid="clear-btn" @click="handleClearMethod">清空</button>
+          <button data-testid="submit-btn" @click="handleSubmitMethod">提交</button>
+        </div>
+      </fieldset>
+
+      <fieldset class="control-group">
+        <legend>模板数据</legend>
+        <div class="button-row">
+          <button data-testid="set-template-simple-btn" @click="setTemplateSimple">简单模板</button>
+          <button data-testid="set-template-empty-btn" @click="setTemplateEmpty">空模板块</button>
+          <button data-testid="set-template-multiple-btn" @click="setTemplateMultiple">多模板块</button>
+          <button data-testid="clear-template-btn" @click="clearTemplate">清空模板</button>
+        </div>
+      </fieldset>
+
+      <p v-show="result" class="result-display" data-testid="result-display">
+        {{ result }}
+      </p>
+    </div>
+
+    <Sender
+      :key="componentKey"
+      ref="senderRef"
+      v-model="content"
+      data-testid="test-sender"
+      :mode="mode"
+      :size="size"
+      :clearable="clearable"
+      :loading="loading"
+      :disabled="disabled"
+      :extensions="extensions"
+      :max-length="maxLength"
+      :show-word-limit="showWordLimit"
+      :placeholder="placeholder"
+      :submit-type="submitType"
+      @submit="handleSubmit"
+      @cancel="handleCancel"
+      @clear="handleClear"
+    >
+      <template #footer>
+        <button data-testid="custom-footer-btn" @click="handleCustomAction">自定义按钮</button>
+      </template>
+    </Sender>
+  </div>
+</template>
+
+<style scoped>
+.sender-demo {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+}
+
+.control-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.control-group {
+  margin: 0;
+  padding: 8px;
+}
+
+.control-row,
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  align-items: center;
+}
+
+.control-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.control-item input,
+.control-item select {
+  min-width: 120px;
+}
+
+.button-row button {
+  padding: 4px 8px;
+}
+
+.result-display {
+  margin: 0;
+  word-break: break-all;
+}
+</style>

--- a/packages/test/src/sender/selectors.ts
+++ b/packages/test/src/sender/selectors.ts
@@ -1,0 +1,62 @@
+/**
+ * Sender 组件相关的选择器常量
+ */
+
+export const SENDER_SELECTORS = {
+  toggleModeBtn: '[data-testid="toggle-mode-btn"]',
+  toggleClearableBtn: '[data-testid="toggle-clearable-btn"]',
+  toggleLoadingBtn: '[data-testid="toggle-loading-btn"]',
+  toggleDisabledBtn: '[data-testid="toggle-disabled-btn"]',
+  toggleWordLimitBtn: '[data-testid="toggle-word-limit-btn"]',
+  toggleSizeBtn: '[data-testid="toggle-size-btn"]',
+  submitTypeSelect: '[data-testid="submit-type-select"]',
+  maxLengthInput: '[data-testid="max-length-input"]',
+  placeholderInput: '[data-testid="placeholder-input"]',
+
+  setContentBtn: '[data-testid="set-content-btn"]',
+  getContentBtn: '[data-testid="get-content-btn"]',
+  focusBtn: '[data-testid="focus-btn"]',
+  blurBtn: '[data-testid="blur-btn"]',
+  clearBtn: '[data-testid="clear-btn"]',
+  submitBtn: '[data-testid="submit-btn"]',
+
+  toggleMentionBtn: '[data-testid="toggle-mention-btn"]',
+  toggleTemplateBtn: '[data-testid="toggle-template-btn"]',
+  toggleSuggestionBtn: '[data-testid="toggle-suggestion-btn"]',
+
+  sender: '[data-testid="test-sender"]',
+  editor: '[data-testid="test-sender"] .ProseMirror',
+
+  submitButton: '.tr-sender-submit-button',
+  clearButton: '.tr-action-buttons-group .tr-action-button',
+  loadingButton: '.tr-sender-submit-button.is-loading',
+
+  wordCounter: '.tr-sender-word-counter',
+
+  footer: '.tr-sender-footer',
+  customFooterBtn: '[data-testid="custom-footer-btn"]',
+
+  resultDisplay: '[data-testid="result-display"]',
+  modeDisplay: '[data-testid="mode-display"]',
+
+  mentionList: '.mention-list',
+  mentionItem: '.mention-item',
+  mentionSelected: '.mention-item.is-selected',
+  mentionNode: '.mention',
+
+  template: '.template-block',
+  templateContent: '.template-block__content',
+
+  setTemplateSimpleBtn: '[data-testid="set-template-simple-btn"]',
+  setTemplateEmptyBtn: '[data-testid="set-template-empty-btn"]',
+  setTemplateMultipleBtn: '[data-testid="set-template-multiple-btn"]',
+  clearTemplateBtn: '[data-testid="clear-template-btn"]',
+
+  suggestionList: '.suggestion-list',
+  suggestionItem: '.suggestion-list__item',
+  suggestionHighlighted: '.suggestion-list__item.highlighted',
+} as const
+
+export type SenderSelectors = typeof SENDER_SELECTORS
+
+export const DEFAULT_SENDER_SELECTORS = SENDER_SELECTORS

--- a/packages/test/src/sender/selectors.ts
+++ b/packages/test/src/sender/selectors.ts
@@ -26,6 +26,7 @@ export const SENDER_SELECTORS = {
 
   sender: '[data-testid="test-sender"]',
   editor: '[data-testid="test-sender"] .ProseMirror',
+  editorScroll: '[data-testid="test-sender"] .tr-sender-editor-scroll',
 
   submitButton: '.tr-sender-submit-button',
   clearButton: '.tr-action-buttons-group .tr-action-button',

--- a/packages/test/src/sender/specs/basic.spec.ts
+++ b/packages/test/src/sender/specs/basic.spec.ts
@@ -1,4 +1,4 @@
-import { test, type Page } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 import { createSenderTestHelper } from '../helpers'
 
 test.describe('Sender 组件测试', () => {
@@ -80,7 +80,7 @@ test.describe('Sender 组件测试', () => {
     await helper.expectEditorContent('Enter提交')
     await helper.getEditor().click()
     await page.keyboard.press('Enter')
-    await helper.expectResult('提交内容: Enter提交')
+    await helper.expectResultExact('提交内容: Enter提交')
 
     await helper.clearContent()
     await helper.setSubmitType('ctrlEnter')
@@ -94,7 +94,7 @@ test.describe('Sender 组件测试', () => {
 
     await helper.getEditor().click()
     await page.keyboard.press('Control+Enter')
-    await helper.expectResult('提交内容')
+    await helper.expectResultExact('提交内容: Ctrl+Enter提交')
   })
 
   test('Props: size - 应该支持不同的组件尺寸', async () => {
@@ -105,12 +105,14 @@ test.describe('Sender 组件测试', () => {
     await helper.expectResult('尺寸切换为: normal')
   })
 
-  test('Props: maxLength - 应该正确限制输入长度', async () => {
+  test('Props: maxLength - 超出限制时应该标记超限并禁用提交', async () => {
     await helper.setMaxLength(10)
     await helper.wait(10)
 
     await helper.typeContent('这是一段超过十个字符的测试内容')
-    await helper.expectWordCounter('/')
+    await helper.expectWordCounter('15')
+    await helper.expectWordCounter('/10')
+    await helper.expectSubmitButtonDisabled(true)
   })
 
   test('Props: maxLength & showWordLimit - 应该显示字数统计', async () => {
@@ -199,31 +201,40 @@ test.describe('Sender 组件测试', () => {
 
   test('Props: autoSize - 应该在多行模式下自动调整高度', async () => {
     await helper.toggleMode()
-    await helper.wait(10)
+    await helper.expectMode('multiple')
+
+    const editor = helper.getEditor()
+    const initialHeight = await editor.evaluate((el) => el.getBoundingClientRect().height)
 
     await helper.typeContent('第一行')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Control+Enter')
     await page.keyboard.type('第二行')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Control+Enter')
     await page.keyboard.type('第三行')
 
     await helper.expectEditorContent('第一行')
     await helper.expectEditorContent('第二行')
     await helper.expectEditorContent('第三行')
+
+    await expect
+      .poll(async () => editor.evaluate((el) => el.getBoundingClientRect().height))
+      .toBeGreaterThan(initialHeight)
   })
 
   test('交互: 单行模式下按换行键应自动切换到多行模式', async () => {
+    await expect(helper.getSender()).toHaveClass(/tr-sender--single/)
+
     const modeDisplay = await page.locator(helper.selectors.modeDisplay).textContent()
     if (modeDisplay !== 'single') {
       await helper.toggleMode()
-      await helper.wait(10)
+      await helper.expectMode('single')
+      await expect(helper.getSender()).toHaveClass(/tr-sender--single/)
     }
 
     await helper.typeContent('测试自动切换')
     await page.keyboard.press('Control+Enter')
-    await helper.wait(200)
 
-    await page.locator(helper.selectors.modeDisplay).textContent()
+    await expect(helper.getSender()).toHaveClass(/tr-sender--multiple/)
   })
 
   test('边界: 快速连续输入和删除应该正常工作', async () => {

--- a/packages/test/src/sender/specs/basic.spec.ts
+++ b/packages/test/src/sender/specs/basic.spec.ts
@@ -1,0 +1,239 @@
+import { test, type Page } from '@playwright/test'
+import { createSenderTestHelper } from '../helpers'
+
+test.describe('Sender 组件测试', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let helper: ReturnType<typeof createSenderTestHelper>
+
+  test.beforeEach(async ({ page: currentPage }) => {
+    page = currentPage
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    helper = createSenderTestHelper(page)
+    await helper.clearContent()
+  })
+
+  test('基础功能: 应该能够输入和提交内容', async () => {
+    await helper.typeContent('测试内容')
+    await helper.expectEditorContent('测试内容')
+
+    await helper.clickSubmit()
+    await helper.expectResult('提交内容')
+  })
+
+  test('Props: clearable - 应该正确控制清空按钮显示', async () => {
+    await helper.typeContent('测试')
+    await helper.expectClearButtonVisible(false)
+
+    await helper.toggleClearable()
+    await helper.expectClearButtonVisible(true)
+
+    await helper.clickClear()
+    await helper.expectEditorEmpty()
+  })
+
+  test('Props: mode - 应该支持单行和多行模式切换', async () => {
+    await helper.toggleMode()
+    await helper.expectResult('模式切换为: multiple')
+
+    await helper.toggleMode()
+    await helper.expectResult('模式切换为: single')
+  })
+
+  test('Props: loading - 应该正确显示加载状态', async () => {
+    await helper.typeContent('测试内容')
+    await helper.toggleLoading()
+    await helper.wait(10)
+
+    await helper.expectLoadingButtonVisible(true)
+  })
+
+  test('Props: disabled - 应该正确控制禁用状态', async () => {
+    await helper.typeContent('测试内容')
+    await helper.expectEditorContent('测试内容')
+
+    await helper.toggleDisabled()
+    await helper.wait(10)
+    await helper.expectEditorContent('测试内容')
+
+    const sender = helper.getSender()
+    const isDisabled = await sender.evaluate((el) => el.classList.contains('is-disabled'))
+    if (!isDisabled) {
+      throw new Error('编辑器应该具有 is-disabled 类')
+    }
+
+    await helper.toggleDisabled()
+  })
+
+  test('Props: placeholder - 应该正确设置占位文本', async () => {
+    await helper.setPlaceholder('请输入新的内容...')
+    await helper.wait(10)
+
+    await helper.typeContent('测试')
+    await helper.expectEditorContent('测试')
+  })
+
+  test('Props: submitType - 应该支持不同的提交方式', async () => {
+    await helper.typeContent('Enter提交')
+    await helper.expectEditorContent('Enter提交')
+    await helper.getEditor().click()
+    await page.keyboard.press('Enter')
+    await helper.expectResult('提交内容: Enter提交')
+
+    await helper.clearContent()
+    await helper.setSubmitType('ctrlEnter')
+    await helper.wait(50)
+
+    await helper.typeContent('Ctrl+Enter提交')
+    await helper.expectEditorContent('Ctrl+Enter提交')
+    await helper.getEditor().click()
+    await page.keyboard.press('Enter')
+    await helper.expectResult('提交内容: Enter提交')
+
+    await helper.getEditor().click()
+    await page.keyboard.press('Control+Enter')
+    await helper.expectResult('提交内容')
+  })
+
+  test('Props: size - 应该支持不同的组件尺寸', async () => {
+    await helper.toggleSize()
+    await helper.expectResult('尺寸切换为: small')
+
+    await helper.toggleSize()
+    await helper.expectResult('尺寸切换为: normal')
+  })
+
+  test('Props: maxLength - 应该正确限制输入长度', async () => {
+    await helper.setMaxLength(10)
+    await helper.wait(10)
+
+    await helper.typeContent('这是一段超过十个字符的测试内容')
+    await helper.expectWordCounter('/')
+  })
+
+  test('Props: maxLength & showWordLimit - 应该显示字数统计', async () => {
+    await helper.toggleMode()
+    await helper.expectResult('模式切换为: multiple')
+
+    await helper.typeContent('测试')
+    await helper.expectWordCounter('/')
+  })
+
+  test('Methods: setContent - 应该能够通过方法设置内容', async () => {
+    await helper.setContent()
+    await helper.expectResult('已设置内容')
+    await helper.expectEditorContent('测试内容')
+  })
+
+  test('Methods: getContent - 应该能够通过方法获取内容', async () => {
+    await helper.typeContent('获取测试')
+    await helper.getContent()
+    await helper.expectResult('当前内容:')
+  })
+
+  test('Slots: footer - 应该正确显示底部插槽内容', async () => {
+    await helper.toggleMode()
+    await helper.expectFooterSlot()
+
+    await helper.clickCustomFooterBtn()
+    await helper.expectResult('自定义按钮被点击')
+  })
+
+  test('Emits: submit - 应该正确触发提交事件', async () => {
+    await helper.typeContent('提交测试')
+    await helper.clickSubmit()
+    await helper.expectResult('提交内容: 提交测试')
+  })
+
+  test('Emits: clear - 应该正确触发清空事件', async () => {
+    await helper.toggleClearable()
+    await helper.typeContent('清空测试')
+
+    await helper.clickClear()
+    await helper.expectResult('内容已清空')
+    await helper.expectEditorEmpty()
+  })
+
+  test('Emits: cancel - 应该在 loading 状态下触发取消事件', async () => {
+    await helper.typeContent('取消测试')
+    await helper.toggleLoading()
+    await helper.wait(10)
+
+    await page.locator(helper.selectors.loadingButton).click()
+    await helper.expectResult('取消操作')
+  })
+
+  test('Methods: focus - 应该能够通过方法聚焦编辑器', async () => {
+    await helper.focusEditor()
+    await helper.expectResult('调用 focus 方法')
+
+    await page.keyboard.type('聚焦测试')
+    await helper.expectEditorContent('聚焦测试')
+  })
+
+  test('Methods: blur - 应该能够通过方法失焦编辑器', async () => {
+    await helper.focusEditor()
+    await helper.wait(10)
+
+    await helper.blurEditor()
+    await helper.expectResult('调用 blur 方法')
+  })
+
+  test('Methods: clear - 应该能够通过方法清空内容', async () => {
+    await helper.typeContent('清空方法测试')
+    await helper.expectEditorContent('清空方法测试')
+
+    await helper.clearEditor()
+    await helper.expectResult('调用 clear 方法')
+    await helper.expectEditorEmpty()
+  })
+
+  test('Methods: submit - 应该能够通过方法提交内容', async () => {
+    await helper.typeContent('提交方法测试')
+
+    await helper.submitEditor()
+    await helper.expectResult('调用 submit 方法')
+  })
+
+  test('Props: autoSize - 应该在多行模式下自动调整高度', async () => {
+    await helper.toggleMode()
+    await helper.wait(10)
+
+    await helper.typeContent('第一行')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('第二行')
+    await page.keyboard.press('Enter')
+    await page.keyboard.type('第三行')
+
+    await helper.expectEditorContent('第一行')
+    await helper.expectEditorContent('第二行')
+    await helper.expectEditorContent('第三行')
+  })
+
+  test('交互: 单行模式下按换行键应自动切换到多行模式', async () => {
+    const modeDisplay = await page.locator(helper.selectors.modeDisplay).textContent()
+    if (modeDisplay !== 'single') {
+      await helper.toggleMode()
+      await helper.wait(10)
+    }
+
+    await helper.typeContent('测试自动切换')
+    await page.keyboard.press('Control+Enter')
+    await helper.wait(200)
+
+    await page.locator(helper.selectors.modeDisplay).textContent()
+  })
+
+  test('边界: 快速连续输入和删除应该正常工作', async () => {
+    await helper.typeContent('快速输入测试')
+    await helper.expectEditorContent('快速输入测试')
+
+    await helper.clearContent()
+    await helper.expectEditorEmpty()
+
+    await helper.typeContent('再次输入')
+    await helper.expectEditorContent('再次输入')
+  })
+})

--- a/packages/test/src/sender/specs/mention/atom.spec.ts
+++ b/packages/test/src/sender/specs/mention/atom.spec.ts
@@ -5,9 +5,9 @@ import { createSenderTestHelper } from '../../helpers'
 test.describe('Mention 功能 - Atom 节点行为', () => {
   test.describe.configure({ mode: 'serial' })
 
-  let page: Page
-  let mentionHelper: ReturnType<typeof createMentionHelper>
-  let basicHelper: ReturnType<typeof createSenderTestHelper>
+  let page: Page | undefined
+  let mentionHelper: ReturnType<typeof createMentionHelper> | undefined
+  let basicHelper: ReturnType<typeof createSenderTestHelper> | undefined
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
@@ -21,43 +21,45 @@ test.describe('Mention 功能 - Atom 节点行为', () => {
   })
 
   test.afterAll(async () => {
-    await basicHelper.toggleMention()
-    await page.close()
+    if (basicHelper) {
+      await basicHelper.toggleMention()
+    }
+    await page?.close()
   })
 
   test.beforeEach(async () => {
-    await basicHelper.clearContent()
+    await basicHelper!.clearContent()
   })
 
   test('TC-09: 选中提及项后应该插入 Atom 节点', async () => {
-    await mentionHelper.typeAtSymbol()
-    await mentionHelper.pressKey('Enter')
-    await mentionHelper.expectMentionExists('小小画家')
-    await mentionHelper.expectMentionListVisible(false)
+    await mentionHelper!.typeAtSymbol()
+    await mentionHelper!.pressKey('Enter')
+    await mentionHelper!.expectMentionExists('小小画家')
+    await mentionHelper!.expectMentionListVisible(false)
   })
 
   test('TC-10: 鼠标点击选中提及项应该插入 Atom 节点', async () => {
-    await mentionHelper.typeAtSymbol()
-    await mentionHelper.clickItem(1)
+    await mentionHelper!.typeAtSymbol()
+    await mentionHelper!.clickItem(1)
 
-    await mentionHelper.expectMentionExists('代码助手')
-    await mentionHelper.expectMentionListVisible(false)
+    await mentionHelper!.expectMentionExists('代码助手')
+    await mentionHelper!.expectMentionListVisible(false)
   })
 
   test('TC-11: Backspace 应该删除整个 Atom 节点', async () => {
-    await mentionHelper.typeAtSymbol()
-    await mentionHelper.pressKey('Enter')
-    await mentionHelper.expectMentionExists('小小画家')
+    await mentionHelper!.typeAtSymbol()
+    await mentionHelper!.pressKey('Enter')
+    await mentionHelper!.expectMentionExists('小小画家')
 
-    await mentionHelper.deleteMention()
-    await mentionHelper.expectMentionCount(0)
+    await mentionHelper!.deleteMention()
+    await mentionHelper!.expectMentionCount(0)
   })
 
   test('TC-12: 可以在 Atom 节点后继续输入', async () => {
-    await mentionHelper.typeAtSymbol()
-    await mentionHelper.pressKey('Enter')
+    await mentionHelper!.typeAtSymbol()
+    await mentionHelper!.pressKey('Enter')
 
-    await page.keyboard.type(' 帮我画画')
-    await basicHelper.expectEditorContent('小小画家 帮我画画')
+    await page!.keyboard.type(' 帮我画画')
+    await basicHelper!.expectEditorContent('小小画家 帮我画画')
   })
 })

--- a/packages/test/src/sender/specs/mention/atom.spec.ts
+++ b/packages/test/src/sender/specs/mention/atom.spec.ts
@@ -1,0 +1,63 @@
+import { test, type Page } from '@playwright/test'
+import { createMentionHelper } from '../../helpers/mention-helper'
+import { createSenderTestHelper } from '../../helpers'
+
+test.describe('Mention 功能 - Atom 节点行为', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let mentionHelper: ReturnType<typeof createMentionHelper>
+  let basicHelper: ReturnType<typeof createSenderTestHelper>
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    mentionHelper = createMentionHelper(page)
+    basicHelper = createSenderTestHelper(page)
+
+    await basicHelper.toggleMention()
+    await basicHelper.wait(300)
+  })
+
+  test.afterAll(async () => {
+    await basicHelper.toggleMention()
+    await page.close()
+  })
+
+  test.beforeEach(async () => {
+    await basicHelper.clearContent()
+  })
+
+  test('TC-09: 选中提及项后应该插入 Atom 节点', async () => {
+    await mentionHelper.typeAtSymbol()
+    await mentionHelper.pressKey('Enter')
+    await mentionHelper.expectMentionExists('小小画家')
+    await mentionHelper.expectMentionListVisible(false)
+  })
+
+  test('TC-10: 鼠标点击选中提及项应该插入 Atom 节点', async () => {
+    await mentionHelper.typeAtSymbol()
+    await mentionHelper.clickItem(1)
+
+    await mentionHelper.expectMentionExists('代码助手')
+    await mentionHelper.expectMentionListVisible(false)
+  })
+
+  test('TC-11: Backspace 应该删除整个 Atom 节点', async () => {
+    await mentionHelper.typeAtSymbol()
+    await mentionHelper.pressKey('Enter')
+    await mentionHelper.expectMentionExists('小小画家')
+
+    await mentionHelper.deleteMention()
+    await mentionHelper.expectMentionCount(0)
+  })
+
+  test('TC-12: 可以在 Atom 节点后继续输入', async () => {
+    await mentionHelper.typeAtSymbol()
+    await mentionHelper.pressKey('Enter')
+
+    await page.keyboard.type(' 帮我画画')
+    await basicHelper.expectEditorContent('小小画家 帮我画画')
+  })
+})

--- a/packages/test/src/sender/specs/mention/list.spec.ts
+++ b/packages/test/src/sender/specs/mention/list.spec.ts
@@ -1,0 +1,71 @@
+import { test, type Page } from '@playwright/test'
+import { createMentionHelper } from '../../helpers/mention-helper'
+import { createSenderTestHelper } from '../../helpers'
+
+test.describe('Mention 功能 - 列表交互', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let mentionHelper: ReturnType<typeof createMentionHelper>
+  let basicHelper: ReturnType<typeof createSenderTestHelper>
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    mentionHelper = createMentionHelper(page)
+    basicHelper = createSenderTestHelper(page)
+
+    await basicHelper.toggleMention()
+    await basicHelper.wait(300)
+  })
+
+  test.afterAll(async () => {
+    await basicHelper.toggleMention()
+    await page.close()
+  })
+
+  test.beforeEach(async () => {
+    await basicHelper.clearContent()
+  })
+
+  test('TC-05: 输入文本应该过滤提及项列表', async () => {
+    await mentionHelper.typeAtSymbol()
+    await mentionHelper.typeQuery('画')
+    await mentionHelper.expectItemCount(1)
+    await mentionHelper.expectListContains('小小画家')
+  })
+
+  test('TC-06: 键盘上下键应该导航列表', async () => {
+    await mentionHelper.typeAtSymbol()
+
+    await mentionHelper.expectSelectedItemIndex(0)
+
+    await mentionHelper.pressKey('ArrowDown')
+    await mentionHelper.expectSelectedItemIndex(1)
+
+    await mentionHelper.pressKey('ArrowUp')
+    await mentionHelper.expectSelectedItemIndex(0)
+  })
+
+  test('TC-07: 边界导航不应该越界', async () => {
+    await mentionHelper.typeAtSymbol()
+
+    await mentionHelper.expectSelectedItemIndex(0)
+    await mentionHelper.pressKey('ArrowUp')
+    await mentionHelper.expectSelectedItemIndex(0)
+
+    await mentionHelper.pressKey('ArrowDown')
+    await mentionHelper.pressKey('ArrowDown')
+    await mentionHelper.pressKey('ArrowDown')
+    await mentionHelper.expectSelectedItemIndex(3)
+
+    await mentionHelper.pressKey('ArrowDown')
+    await mentionHelper.expectSelectedItemIndex(3)
+  })
+
+  test('TC-08: 鼠标悬停应该高亮选项', async () => {
+    await mentionHelper.typeAtSymbol()
+    await mentionHelper.hoverItem(2)
+  })
+})

--- a/packages/test/src/sender/specs/mention/list.spec.ts
+++ b/packages/test/src/sender/specs/mention/list.spec.ts
@@ -5,9 +5,9 @@ import { createSenderTestHelper } from '../../helpers'
 test.describe('Mention 功能 - 列表交互', () => {
   test.describe.configure({ mode: 'serial' })
 
-  let page: Page
-  let mentionHelper: ReturnType<typeof createMentionHelper>
-  let basicHelper: ReturnType<typeof createSenderTestHelper>
+  let page: Page | undefined
+  let mentionHelper: ReturnType<typeof createMentionHelper> | undefined
+  let basicHelper: ReturnType<typeof createSenderTestHelper> | undefined
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
@@ -21,51 +21,54 @@ test.describe('Mention 功能 - 列表交互', () => {
   })
 
   test.afterAll(async () => {
-    await basicHelper.toggleMention()
-    await page.close()
+    if (basicHelper) {
+      await basicHelper.toggleMention()
+    }
+    await page?.close()
   })
 
   test.beforeEach(async () => {
-    await basicHelper.clearContent()
+    await basicHelper!.clearContent()
   })
 
   test('TC-05: 输入文本应该过滤提及项列表', async () => {
-    await mentionHelper.typeAtSymbol()
-    await mentionHelper.typeQuery('画')
-    await mentionHelper.expectItemCount(1)
-    await mentionHelper.expectListContains('小小画家')
+    await mentionHelper!.typeAtSymbol()
+    await mentionHelper!.typeQuery('画')
+    await mentionHelper!.expectItemCount(1)
+    await mentionHelper!.expectListContains('小小画家')
   })
 
   test('TC-06: 键盘上下键应该导航列表', async () => {
-    await mentionHelper.typeAtSymbol()
+    await mentionHelper!.typeAtSymbol()
 
-    await mentionHelper.expectSelectedItemIndex(0)
+    await mentionHelper!.expectSelectedItemIndex(0)
 
-    await mentionHelper.pressKey('ArrowDown')
-    await mentionHelper.expectSelectedItemIndex(1)
+    await mentionHelper!.pressKey('ArrowDown')
+    await mentionHelper!.expectSelectedItemIndex(1)
 
-    await mentionHelper.pressKey('ArrowUp')
-    await mentionHelper.expectSelectedItemIndex(0)
+    await mentionHelper!.pressKey('ArrowUp')
+    await mentionHelper!.expectSelectedItemIndex(0)
   })
 
   test('TC-07: 边界导航不应该越界', async () => {
-    await mentionHelper.typeAtSymbol()
+    await mentionHelper!.typeAtSymbol()
 
-    await mentionHelper.expectSelectedItemIndex(0)
-    await mentionHelper.pressKey('ArrowUp')
-    await mentionHelper.expectSelectedItemIndex(0)
+    await mentionHelper!.expectSelectedItemIndex(0)
+    await mentionHelper!.pressKey('ArrowUp')
+    await mentionHelper!.expectSelectedItemIndex(0)
 
-    await mentionHelper.pressKey('ArrowDown')
-    await mentionHelper.pressKey('ArrowDown')
-    await mentionHelper.pressKey('ArrowDown')
-    await mentionHelper.expectSelectedItemIndex(3)
+    await mentionHelper!.pressKey('ArrowDown')
+    await mentionHelper!.pressKey('ArrowDown')
+    await mentionHelper!.pressKey('ArrowDown')
+    await mentionHelper!.expectSelectedItemIndex(3)
 
-    await mentionHelper.pressKey('ArrowDown')
-    await mentionHelper.expectSelectedItemIndex(3)
+    await mentionHelper!.pressKey('ArrowDown')
+    await mentionHelper!.expectSelectedItemIndex(3)
   })
 
   test('TC-08: 鼠标悬停应该高亮选项', async () => {
-    await mentionHelper.typeAtSymbol()
-    await mentionHelper.hoverItem(2)
+    await mentionHelper!.typeAtSymbol()
+    await mentionHelper!.hoverItem(2)
+    await mentionHelper!.expectSelectedItemIndex(2)
   })
 })

--- a/packages/test/src/sender/specs/mention/trigger.spec.ts
+++ b/packages/test/src/sender/specs/mention/trigger.spec.ts
@@ -1,0 +1,56 @@
+import { test, type Page } from '@playwright/test'
+import { createMentionHelper } from '../../helpers/mention-helper'
+import { createSenderTestHelper } from '../../helpers'
+
+test.describe('Mention 功能 - 触发机制', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let mentionHelper: ReturnType<typeof createMentionHelper>
+  let basicHelper: ReturnType<typeof createSenderTestHelper>
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    mentionHelper = createMentionHelper(page)
+    basicHelper = createSenderTestHelper(page)
+
+    await basicHelper.toggleMention()
+    await basicHelper.wait(300)
+  })
+
+  test.afterAll(async () => {
+    await basicHelper.toggleMention()
+    await page.close()
+  })
+
+  test.beforeEach(async () => {
+    await basicHelper.clearContent()
+  })
+
+  test('TC-01: 输入 @ 符号应该触发提及面板', async () => {
+    await mentionHelper.typeAtSymbol()
+    await mentionHelper.expectMentionListVisible(true)
+    await mentionHelper.expectItemCount(4)
+  })
+
+  test('TC-02: 输入普通文本不应该触发提及面板', async () => {
+    await basicHelper.typeContent('Hello')
+    await mentionHelper.expectMentionListVisible(false)
+  })
+
+  test('TC-03: 在已有文本后输入 @ 应该触发面板', async () => {
+    await basicHelper.typeContent('Hello ')
+    await mentionHelper.typeAtSymbol()
+    await mentionHelper.expectMentionListVisible(true)
+  })
+
+  test('TC-04: 删除 @ 符号应该关闭面板', async () => {
+    await mentionHelper.typeAtSymbol()
+    await mentionHelper.expectMentionListVisible(true)
+
+    await mentionHelper.pressKey('Backspace')
+    await mentionHelper.expectMentionListVisible(false)
+  })
+})

--- a/packages/test/src/sender/specs/mention/trigger.spec.ts
+++ b/packages/test/src/sender/specs/mention/trigger.spec.ts
@@ -5,9 +5,9 @@ import { createSenderTestHelper } from '../../helpers'
 test.describe('Mention 功能 - 触发机制', () => {
   test.describe.configure({ mode: 'serial' })
 
-  let page: Page
-  let mentionHelper: ReturnType<typeof createMentionHelper>
-  let basicHelper: ReturnType<typeof createSenderTestHelper>
+  let page: Page | undefined
+  let mentionHelper: ReturnType<typeof createMentionHelper> | undefined
+  let basicHelper: ReturnType<typeof createSenderTestHelper> | undefined
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
@@ -21,36 +21,38 @@ test.describe('Mention 功能 - 触发机制', () => {
   })
 
   test.afterAll(async () => {
-    await basicHelper.toggleMention()
-    await page.close()
+    if (basicHelper) {
+      await basicHelper.toggleMention()
+    }
+    await page?.close()
   })
 
   test.beforeEach(async () => {
-    await basicHelper.clearContent()
+    await basicHelper!.clearContent()
   })
 
   test('TC-01: 输入 @ 符号应该触发提及面板', async () => {
-    await mentionHelper.typeAtSymbol()
-    await mentionHelper.expectMentionListVisible(true)
-    await mentionHelper.expectItemCount(4)
+    await mentionHelper!.typeAtSymbol()
+    await mentionHelper!.expectMentionListVisible(true)
+    await mentionHelper!.expectItemCount(4)
   })
 
   test('TC-02: 输入普通文本不应该触发提及面板', async () => {
-    await basicHelper.typeContent('Hello')
-    await mentionHelper.expectMentionListVisible(false)
+    await basicHelper!.typeContent('Hello')
+    await mentionHelper!.expectMentionListVisible(false)
   })
 
   test('TC-03: 在已有文本后输入 @ 应该触发面板', async () => {
-    await basicHelper.typeContent('Hello ')
-    await mentionHelper.typeAtSymbol()
-    await mentionHelper.expectMentionListVisible(true)
+    await basicHelper!.typeContent('Hello ')
+    await mentionHelper!.typeAtSymbol()
+    await mentionHelper!.expectMentionListVisible(true)
   })
 
   test('TC-04: 删除 @ 符号应该关闭面板', async () => {
-    await mentionHelper.typeAtSymbol()
-    await mentionHelper.expectMentionListVisible(true)
+    await mentionHelper!.typeAtSymbol()
+    await mentionHelper!.expectMentionListVisible(true)
 
-    await mentionHelper.pressKey('Backspace')
-    await mentionHelper.expectMentionListVisible(false)
+    await mentionHelper!.pressKey('Backspace')
+    await mentionHelper!.expectMentionListVisible(false)
   })
 })

--- a/packages/test/src/sender/specs/suggestion/basic.spec.ts
+++ b/packages/test/src/sender/specs/suggestion/basic.spec.ts
@@ -1,0 +1,70 @@
+import { test, type Page } from '@playwright/test'
+import { createSenderTestHelper } from '../../helpers'
+import { createSuggestionHelper } from '../../helpers/suggestion-helper'
+
+test.describe('Sender Suggestion', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let helper: ReturnType<typeof createSenderTestHelper>
+  let suggestionHelper: ReturnType<typeof createSuggestionHelper>
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    helper = createSenderTestHelper(page)
+    suggestionHelper = createSuggestionHelper(page)
+
+    await helper.toggleSuggestion()
+    await helper.wait(300)
+  })
+
+  test.afterAll(async () => {
+    await helper.toggleSuggestion()
+    await page.close()
+  })
+
+  test.beforeEach(async () => {
+    await helper.clearContent()
+  })
+
+  test('TC-SUG-01: 输入任意字符应显示所有建议项', async () => {
+    await helper.typeContent('J')
+
+    await suggestionHelper.expectSuggestionListVisible(true)
+    await suggestionHelper.expectSuggestionCount(6)
+    await suggestionHelper.expectSuggestionItemText(0, 'Java')
+    await suggestionHelper.expectHighlightedItem(0)
+  })
+
+  test('TC-SUG-02: 键盘导航建议列表', async () => {
+    await helper.typeContent('J')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await suggestionHelper.pressArrowDown()
+    await suggestionHelper.expectHighlightedItem(1)
+    await suggestionHelper.expectSuggestionItemText(1, 'JavaScript')
+
+    await suggestionHelper.pressArrowUp()
+    await suggestionHelper.expectHighlightedItem(0)
+  })
+
+  test('TC-SUG-03: 按 Enter 键选中建议项', async () => {
+    await helper.typeContent('J')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await suggestionHelper.pressEnter()
+    await helper.expectEditorContent('Java')
+    await suggestionHelper.expectSuggestionListVisible(false)
+  })
+
+  test('TC-SUG-04: 点击选中建议项', async () => {
+    await helper.typeContent('T')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await suggestionHelper.clickSuggestionItem(2)
+    await helper.expectEditorContent('TypeScript')
+    await suggestionHelper.expectSuggestionListVisible(false)
+  })
+})

--- a/packages/test/src/sender/specs/suggestion/basic.spec.ts
+++ b/packages/test/src/sender/specs/suggestion/basic.spec.ts
@@ -5,9 +5,9 @@ import { createSuggestionHelper } from '../../helpers/suggestion-helper'
 test.describe('Sender Suggestion', () => {
   test.describe.configure({ mode: 'serial' })
 
-  let page: Page
-  let helper: ReturnType<typeof createSenderTestHelper>
-  let suggestionHelper: ReturnType<typeof createSuggestionHelper>
+  let page: Page | undefined
+  let helper: ReturnType<typeof createSenderTestHelper> | undefined
+  let suggestionHelper: ReturnType<typeof createSuggestionHelper> | undefined
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
@@ -21,50 +21,52 @@ test.describe('Sender Suggestion', () => {
   })
 
   test.afterAll(async () => {
-    await helper.toggleSuggestion()
-    await page.close()
+    if (helper) {
+      await helper.toggleSuggestion()
+    }
+    await page?.close()
   })
 
   test.beforeEach(async () => {
-    await helper.clearContent()
+    await helper!.clearContent()
   })
 
   test('TC-SUG-01: 输入任意字符应显示所有建议项', async () => {
-    await helper.typeContent('J')
+    await helper!.typeContent('J')
 
-    await suggestionHelper.expectSuggestionListVisible(true)
-    await suggestionHelper.expectSuggestionCount(6)
-    await suggestionHelper.expectSuggestionItemText(0, 'Java')
-    await suggestionHelper.expectHighlightedItem(0)
+    await suggestionHelper!.expectSuggestionListVisible(true)
+    await suggestionHelper!.expectSuggestionCount(6)
+    await suggestionHelper!.expectSuggestionItemText(0, 'Java')
+    await suggestionHelper!.expectHighlightedItem(0)
   })
 
   test('TC-SUG-02: 键盘导航建议列表', async () => {
-    await helper.typeContent('J')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('J')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await suggestionHelper.pressArrowDown()
-    await suggestionHelper.expectHighlightedItem(1)
-    await suggestionHelper.expectSuggestionItemText(1, 'JavaScript')
+    await suggestionHelper!.pressArrowDown()
+    await suggestionHelper!.expectHighlightedItem(1)
+    await suggestionHelper!.expectSuggestionItemText(1, 'JavaScript')
 
-    await suggestionHelper.pressArrowUp()
-    await suggestionHelper.expectHighlightedItem(0)
+    await suggestionHelper!.pressArrowUp()
+    await suggestionHelper!.expectHighlightedItem(0)
   })
 
   test('TC-SUG-03: 按 Enter 键选中建议项', async () => {
-    await helper.typeContent('J')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('J')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await suggestionHelper.pressEnter()
-    await helper.expectEditorContent('Java')
-    await suggestionHelper.expectSuggestionListVisible(false)
+    await suggestionHelper!.pressEnter()
+    await helper!.expectEditorContent('Java')
+    await suggestionHelper!.expectSuggestionListVisible(false)
   })
 
   test('TC-SUG-04: 点击选中建议项', async () => {
-    await helper.typeContent('T')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('T')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await suggestionHelper.clickSuggestionItem(2)
-    await helper.expectEditorContent('TypeScript')
-    await suggestionHelper.expectSuggestionListVisible(false)
+    await suggestionHelper!.clickSuggestionItem(2)
+    await helper!.expectEditorContent('TypeScript')
+    await suggestionHelper!.expectSuggestionListVisible(false)
   })
 })

--- a/packages/test/src/sender/specs/suggestion/keyboard.spec.ts
+++ b/packages/test/src/sender/specs/suggestion/keyboard.spec.ts
@@ -5,9 +5,9 @@ import { createSuggestionHelper } from '../../helpers/suggestion-helper'
 test.describe('Sender Suggestion - 键盘交互', () => {
   test.describe.configure({ mode: 'serial' })
 
-  let page: Page
-  let helper: ReturnType<typeof createSenderTestHelper>
-  let suggestionHelper: ReturnType<typeof createSuggestionHelper>
+  let page: Page | undefined
+  let helper: ReturnType<typeof createSenderTestHelper> | undefined
+  let suggestionHelper: ReturnType<typeof createSuggestionHelper> | undefined
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
@@ -21,74 +21,76 @@ test.describe('Sender Suggestion - 键盘交互', () => {
   })
 
   test.afterAll(async () => {
-    await helper.toggleSuggestion()
-    await page.close()
+    if (helper) {
+      await helper.toggleSuggestion()
+    }
+    await page?.close()
   })
 
   test.beforeEach(async () => {
-    await helper.clearContent()
+    await helper!.clearContent()
   })
 
   test('TC-SUG-KB-01: 按 Tab 键应用自动补全', async () => {
-    await helper.typeContent('Ja')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('Ja')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await suggestionHelper.pressTab()
-    await helper.expectEditorContent('Java')
-    await suggestionHelper.expectSuggestionListVisible(false)
+    await suggestionHelper!.pressTab()
+    await helper!.expectEditorContent('Java')
+    await suggestionHelper!.expectSuggestionListVisible(false)
   })
 
   test('TC-SUG-KB-02: 按 Esc 键关闭建议列表', async () => {
-    await helper.typeContent('P')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('P')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await page.keyboard.press('Escape')
-    await suggestionHelper.expectSuggestionListVisible(false)
-    await helper.expectEditorContent('P')
+    await page!.keyboard.press('Escape')
+    await suggestionHelper!.expectSuggestionListVisible(false)
+    await helper!.expectEditorContent('P')
   })
 
   test('TC-SUG-KB-03: 向下导航到最后一项后应循环到第一项', async () => {
-    await helper.typeContent('G')
-    await suggestionHelper.expectSuggestionListVisible(true)
-    await suggestionHelper.expectSuggestionCount(6)
+    await helper!.typeContent('G')
+    await suggestionHelper!.expectSuggestionListVisible(true)
+    await suggestionHelper!.expectSuggestionCount(6)
 
     for (let i = 0; i < 6; i++) {
-      await suggestionHelper.pressArrowDown()
+      await suggestionHelper!.pressArrowDown()
     }
 
-    await suggestionHelper.expectHighlightedItem(0)
+    await suggestionHelper!.expectHighlightedItem(0)
   })
 
   test('TC-SUG-KB-04: 向上导航到第一项后应循环到最后一项', async () => {
-    await helper.typeContent('C')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('C')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await suggestionHelper.pressArrowUp()
-    await suggestionHelper.expectHighlightedItem(5)
+    await suggestionHelper!.pressArrowUp()
+    await suggestionHelper!.expectHighlightedItem(5)
   })
 
   test('TC-SUG-KB-05: 导航后按 Enter 应选中当前高亮项', async () => {
-    await helper.typeContent('T')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('T')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await suggestionHelper.pressArrowDown()
-    await suggestionHelper.pressArrowDown()
-    await suggestionHelper.pressEnter()
+    await suggestionHelper!.pressArrowDown()
+    await suggestionHelper!.pressArrowDown()
+    await suggestionHelper!.pressEnter()
 
-    await helper.expectEditorContent('TypeScript')
-    await suggestionHelper.expectSuggestionListVisible(false)
+    await helper!.expectEditorContent('TypeScript')
+    await suggestionHelper!.expectSuggestionListVisible(false)
   })
 
   test('TC-SUG-KB-06: 导航后按 Tab 应应用当前项的自动补全', async () => {
-    await helper.typeContent('P')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('P')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await suggestionHelper.pressArrowDown()
-    await suggestionHelper.pressArrowDown()
-    await suggestionHelper.pressArrowDown()
-    await suggestionHelper.pressTab()
+    await suggestionHelper!.pressArrowDown()
+    await suggestionHelper!.pressArrowDown()
+    await suggestionHelper!.pressArrowDown()
+    await suggestionHelper!.pressTab()
 
-    await helper.expectEditorContent('Python')
-    await suggestionHelper.expectSuggestionListVisible(false)
+    await helper!.expectEditorContent('Python')
+    await suggestionHelper!.expectSuggestionListVisible(false)
   })
 })

--- a/packages/test/src/sender/specs/suggestion/keyboard.spec.ts
+++ b/packages/test/src/sender/specs/suggestion/keyboard.spec.ts
@@ -1,0 +1,94 @@
+import { test, type Page } from '@playwright/test'
+import { createSenderTestHelper } from '../../helpers'
+import { createSuggestionHelper } from '../../helpers/suggestion-helper'
+
+test.describe('Sender Suggestion - 键盘交互', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let helper: ReturnType<typeof createSenderTestHelper>
+  let suggestionHelper: ReturnType<typeof createSuggestionHelper>
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    helper = createSenderTestHelper(page)
+    suggestionHelper = createSuggestionHelper(page)
+
+    await helper.toggleSuggestion()
+    await helper.wait(300)
+  })
+
+  test.afterAll(async () => {
+    await helper.toggleSuggestion()
+    await page.close()
+  })
+
+  test.beforeEach(async () => {
+    await helper.clearContent()
+  })
+
+  test('TC-SUG-KB-01: 按 Tab 键应用自动补全', async () => {
+    await helper.typeContent('Ja')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await suggestionHelper.pressTab()
+    await helper.expectEditorContent('Java')
+    await suggestionHelper.expectSuggestionListVisible(false)
+  })
+
+  test('TC-SUG-KB-02: 按 Esc 键关闭建议列表', async () => {
+    await helper.typeContent('P')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await page.keyboard.press('Escape')
+    await suggestionHelper.expectSuggestionListVisible(false)
+    await helper.expectEditorContent('P')
+  })
+
+  test('TC-SUG-KB-03: 向下导航到最后一项后应循环到第一项', async () => {
+    await helper.typeContent('G')
+    await suggestionHelper.expectSuggestionListVisible(true)
+    await suggestionHelper.expectSuggestionCount(6)
+
+    for (let i = 0; i < 6; i++) {
+      await suggestionHelper.pressArrowDown()
+    }
+
+    await suggestionHelper.expectHighlightedItem(0)
+  })
+
+  test('TC-SUG-KB-04: 向上导航到第一项后应循环到最后一项', async () => {
+    await helper.typeContent('C')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await suggestionHelper.pressArrowUp()
+    await suggestionHelper.expectHighlightedItem(5)
+  })
+
+  test('TC-SUG-KB-05: 导航后按 Enter 应选中当前高亮项', async () => {
+    await helper.typeContent('T')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await suggestionHelper.pressArrowDown()
+    await suggestionHelper.pressArrowDown()
+    await suggestionHelper.pressEnter()
+
+    await helper.expectEditorContent('TypeScript')
+    await suggestionHelper.expectSuggestionListVisible(false)
+  })
+
+  test('TC-SUG-KB-06: 导航后按 Tab 应应用当前项的自动补全', async () => {
+    await helper.typeContent('P')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await suggestionHelper.pressArrowDown()
+    await suggestionHelper.pressArrowDown()
+    await suggestionHelper.pressArrowDown()
+    await suggestionHelper.pressTab()
+
+    await helper.expectEditorContent('Python')
+    await suggestionHelper.expectSuggestionListVisible(false)
+  })
+})

--- a/packages/test/src/sender/specs/suggestion/list.spec.ts
+++ b/packages/test/src/sender/specs/suggestion/list.spec.ts
@@ -1,0 +1,82 @@
+import { test, type Page } from '@playwright/test'
+import { createSenderTestHelper } from '../../helpers'
+import { createSuggestionHelper } from '../../helpers/suggestion-helper'
+
+test.describe('Sender Suggestion - 列表显示', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let helper: ReturnType<typeof createSenderTestHelper>
+  let suggestionHelper: ReturnType<typeof createSuggestionHelper>
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    helper = createSenderTestHelper(page)
+    suggestionHelper = createSuggestionHelper(page)
+
+    await helper.toggleSuggestion()
+    await helper.wait(300)
+  })
+
+  test.afterAll(async () => {
+    await helper.toggleSuggestion()
+    await page.close()
+  })
+
+  test.beforeEach(async () => {
+    await helper.clearContent()
+  })
+
+  test('TC-SUG-LIST-01: 空内容时不应显示建议列表', async () => {
+    await helper.expectEditorEmpty()
+    await suggestionHelper.expectSuggestionListVisible(false)
+  })
+
+  test('TC-SUG-LIST-02: 输入内容后应显示建议列表', async () => {
+    await helper.typeContent('J')
+
+    await suggestionHelper.expectSuggestionListVisible(true)
+    await suggestionHelper.expectSuggestionCount(6)
+  })
+
+  test('TC-SUG-LIST-03: 清空内容后应关闭建议列表', async () => {
+    await helper.typeContent('Java')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await helper.clearContent()
+    await suggestionHelper.expectSuggestionListVisible(false)
+  })
+
+  test('TC-SUG-LIST-04: 选中建议项后应关闭列表', async () => {
+    await helper.typeContent('C')
+    await suggestionHelper.expectSuggestionListVisible(true)
+
+    await suggestionHelper.pressEnter()
+    await suggestionHelper.expectSuggestionListVisible(false)
+  })
+
+  test('TC-SUG-LIST-05: 选中后再次输入应重新显示列表', async () => {
+    await helper.typeContent('J')
+    await suggestionHelper.pressEnter()
+    await suggestionHelper.expectSuggestionListVisible(false)
+
+    await helper.clearContent()
+    await helper.typeContent('P')
+    await suggestionHelper.expectSuggestionListVisible(true)
+  })
+
+  test('TC-SUG-LIST-06: 建议列表应显示所有建议项', async () => {
+    await helper.typeContent('test')
+
+    await suggestionHelper.expectSuggestionListVisible(true)
+    await suggestionHelper.expectSuggestionCount(6)
+    await suggestionHelper.expectSuggestionItemText(0, 'Java')
+    await suggestionHelper.expectSuggestionItemText(1, 'JavaScript')
+    await suggestionHelper.expectSuggestionItemText(2, 'TypeScript')
+    await suggestionHelper.expectSuggestionItemText(3, 'Python')
+    await suggestionHelper.expectSuggestionItemText(4, 'C++')
+    await suggestionHelper.expectSuggestionItemText(5, 'Golang')
+  })
+})

--- a/packages/test/src/sender/specs/suggestion/list.spec.ts
+++ b/packages/test/src/sender/specs/suggestion/list.spec.ts
@@ -5,9 +5,9 @@ import { createSuggestionHelper } from '../../helpers/suggestion-helper'
 test.describe('Sender Suggestion - 列表显示', () => {
   test.describe.configure({ mode: 'serial' })
 
-  let page: Page
-  let helper: ReturnType<typeof createSenderTestHelper>
-  let suggestionHelper: ReturnType<typeof createSuggestionHelper>
+  let page: Page | undefined
+  let helper: ReturnType<typeof createSenderTestHelper> | undefined
+  let suggestionHelper: ReturnType<typeof createSuggestionHelper> | undefined
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
@@ -21,62 +21,64 @@ test.describe('Sender Suggestion - 列表显示', () => {
   })
 
   test.afterAll(async () => {
-    await helper.toggleSuggestion()
-    await page.close()
+    if (helper) {
+      await helper.toggleSuggestion()
+    }
+    await page?.close()
   })
 
   test.beforeEach(async () => {
-    await helper.clearContent()
+    await helper!.clearContent()
   })
 
   test('TC-SUG-LIST-01: 空内容时不应显示建议列表', async () => {
-    await helper.expectEditorEmpty()
-    await suggestionHelper.expectSuggestionListVisible(false)
+    await helper!.expectEditorEmpty()
+    await suggestionHelper!.expectSuggestionListVisible(false)
   })
 
   test('TC-SUG-LIST-02: 输入内容后应显示建议列表', async () => {
-    await helper.typeContent('J')
+    await helper!.typeContent('J')
 
-    await suggestionHelper.expectSuggestionListVisible(true)
-    await suggestionHelper.expectSuggestionCount(6)
+    await suggestionHelper!.expectSuggestionListVisible(true)
+    await suggestionHelper!.expectSuggestionCount(6)
   })
 
   test('TC-SUG-LIST-03: 清空内容后应关闭建议列表', async () => {
-    await helper.typeContent('Java')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('Java')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await helper.clearContent()
-    await suggestionHelper.expectSuggestionListVisible(false)
+    await helper!.clearContent()
+    await suggestionHelper!.expectSuggestionListVisible(false)
   })
 
   test('TC-SUG-LIST-04: 选中建议项后应关闭列表', async () => {
-    await helper.typeContent('C')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.typeContent('C')
+    await suggestionHelper!.expectSuggestionListVisible(true)
 
-    await suggestionHelper.pressEnter()
-    await suggestionHelper.expectSuggestionListVisible(false)
+    await suggestionHelper!.pressEnter()
+    await suggestionHelper!.expectSuggestionListVisible(false)
   })
 
   test('TC-SUG-LIST-05: 选中后再次输入应重新显示列表', async () => {
-    await helper.typeContent('J')
-    await suggestionHelper.pressEnter()
-    await suggestionHelper.expectSuggestionListVisible(false)
+    await helper!.typeContent('J')
+    await suggestionHelper!.pressEnter()
+    await suggestionHelper!.expectSuggestionListVisible(false)
 
-    await helper.clearContent()
-    await helper.typeContent('P')
-    await suggestionHelper.expectSuggestionListVisible(true)
+    await helper!.clearContent()
+    await helper!.typeContent('P')
+    await suggestionHelper!.expectSuggestionListVisible(true)
   })
 
   test('TC-SUG-LIST-06: 建议列表应显示所有建议项', async () => {
-    await helper.typeContent('test')
+    await helper!.typeContent('test')
 
-    await suggestionHelper.expectSuggestionListVisible(true)
-    await suggestionHelper.expectSuggestionCount(6)
-    await suggestionHelper.expectSuggestionItemText(0, 'Java')
-    await suggestionHelper.expectSuggestionItemText(1, 'JavaScript')
-    await suggestionHelper.expectSuggestionItemText(2, 'TypeScript')
-    await suggestionHelper.expectSuggestionItemText(3, 'Python')
-    await suggestionHelper.expectSuggestionItemText(4, 'C++')
-    await suggestionHelper.expectSuggestionItemText(5, 'Golang')
+    await suggestionHelper!.expectSuggestionListVisible(true)
+    await suggestionHelper!.expectSuggestionCount(6)
+    await suggestionHelper!.expectSuggestionItemText(0, 'Java')
+    await suggestionHelper!.expectSuggestionItemText(1, 'JavaScript')
+    await suggestionHelper!.expectSuggestionItemText(2, 'TypeScript')
+    await suggestionHelper!.expectSuggestionItemText(3, 'Python')
+    await suggestionHelper!.expectSuggestionItemText(4, 'C++')
+    await suggestionHelper!.expectSuggestionItemText(5, 'Golang')
   })
 })

--- a/packages/test/src/sender/specs/template/backspace.spec.ts
+++ b/packages/test/src/sender/specs/template/backspace.spec.ts
@@ -1,0 +1,95 @@
+import { test, type Page } from '@playwright/test'
+import { createSenderTestHelper } from '../../helpers'
+import { createTemplateTestHelper } from '../../helpers/template-helper'
+
+test.describe('Template Block - Backspace 删除逻辑', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let helper: ReturnType<typeof createSenderTestHelper>
+  let templateHelper: ReturnType<typeof createTemplateTestHelper>
+
+  test.beforeEach(async ({ page: currentPage }) => {
+    page = currentPage
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    helper = createSenderTestHelper(page)
+    templateHelper = createTemplateTestHelper(page)
+
+    await helper.toggleTemplate()
+    await helper.wait(300)
+    await helper.clearContent()
+    await templateHelper.clearTemplates()
+  })
+
+  test('TC-BS-01: 应该能够删除模板块内的字符', async () => {
+    await templateHelper.setSimpleTemplate()
+    await templateHelper.focusTemplateEnd(0)
+    await templateHelper.pressBackspace()
+    await templateHelper.expectTemplateText(0, '张')
+  })
+
+  test('TC-BS-02: 删除最后一个字符时应该保留模板块', async () => {
+    await templateHelper.setSimpleTemplate()
+    await templateHelper.focusTemplateEnd(0)
+    await templateHelper.pressBackspace()
+    await templateHelper.pressBackspace()
+    await templateHelper.expectTemplateCount(1)
+  })
+
+  test('TC-BS-03: 空模板块内按 Backspace 应该跳出模板块', async () => {
+    await templateHelper.setEmptyTemplate()
+    await templateHelper.clickTemplate(0)
+    await templateHelper.wait(100)
+    await templateHelper.pressBackspace()
+    await templateHelper.expectTemplateCount(1)
+  })
+
+  test('TC-BS-04: 模板块开头按 Backspace 应该跳出且不吸入文本', async () => {
+    await templateHelper.setSimpleTemplate()
+    await templateHelper.focusTemplateStart(0)
+    await templateHelper.pressBackspace()
+    await templateHelper.expectEditorToContainText('我是')
+    await templateHelper.expectTemplateCount(1)
+  })
+
+  test('TC-BS-05: 从模板块右侧按 Backspace 应该进入模板块', async () => {
+    await templateHelper.setSimpleTemplate()
+    await helper.getEditor().click()
+    await templateHelper.wait(100)
+    await helper.getEditor().press('End')
+    await templateHelper.pressArrowLeft(3)
+    await templateHelper.pressBackspace()
+
+    await templateHelper.expectTemplateCount(1)
+    await templateHelper.expectTemplateText(0, '张三')
+  })
+
+  test('TC-BS-06: 从右侧删除空模板块需要多次操作', async () => {
+    await templateHelper.setEmptyTemplate()
+    await templateHelper.clickTemplate(0)
+    await templateHelper.wait(100)
+    await templateHelper.pressArrowRight()
+    await templateHelper.wait(50)
+
+    for (let i = 0; i < 4; i++) {
+      if ((await templateHelper.getTemplateCount()) === 0) {
+        break
+      }
+      await templateHelper.pressBackspace()
+      await templateHelper.wait(100)
+    }
+
+    await templateHelper.expectTemplateCount(0)
+  })
+
+  test('TC-BS-07: 选区删除应该包含模板块', async () => {
+    await templateHelper.setSimpleTemplate()
+    await helper.getEditor().click()
+    await templateHelper.selectText()
+    await templateHelper.pressBackspace()
+
+    await helper.expectEditorEmpty()
+    await templateHelper.expectTemplateCount(0)
+  })
+})

--- a/packages/test/src/sender/specs/template/boundary.spec.ts
+++ b/packages/test/src/sender/specs/template/boundary.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect, type Page } from '@playwright/test'
+import { createSenderTestHelper } from '../../helpers'
+import { createTemplateTestHelper } from '../../helpers/template-helper'
+
+test.describe('Template Block - 边界情况测试', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let helper: ReturnType<typeof createSenderTestHelper>
+  let templateHelper: ReturnType<typeof createTemplateTestHelper>
+
+  test.beforeEach(async ({ page: currentPage }) => {
+    page = currentPage
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    helper = createSenderTestHelper(page)
+    templateHelper = createTemplateTestHelper(page)
+
+    await helper.toggleTemplate()
+    await helper.wait(300)
+    await helper.clearContent()
+    await templateHelper.clearTemplates()
+  })
+
+  test('TC-BD-01: 连续模板块清空后应保留空块结构', async () => {
+    await templateHelper.setMultipleTemplates()
+    await templateHelper.expectTemplateCount(3)
+
+    await templateHelper.clearAllTemplatesContent(15)
+    await templateHelper.expectTemplateCount(3)
+    await templateHelper.expectTemplateText(0, '')
+    await templateHelper.expectTemplateText(1, '')
+    await templateHelper.expectTemplateText(2, '')
+  })
+
+  test('TC-BD-02: 模板块与文本粘连检测', async () => {
+    await templateHelper.setSimpleTemplate()
+
+    await templateHelper.expectEditorToContainText('我是')
+    await templateHelper.expectEditorToContainText('张三')
+    await templateHelper.expectEditorToContainText('来自')
+    await templateHelper.expectTemplateCount(1)
+  })
+
+  test('TC-BD-03: 应该能够在模板块内编辑内容', async () => {
+    await templateHelper.setSimpleTemplate()
+    await templateHelper.focusTemplateEnd(0)
+    await templateHelper.pressBackspace(2)
+    await templateHelper.typeInTemplate(0, '李四')
+    await templateHelper.wait(100)
+
+    await templateHelper.expectTemplateText(0, '李四')
+  })
+
+  test('TC-BD-04: 应该能够处理连续的多个模板块', async () => {
+    await templateHelper.setMultipleTemplates()
+
+    await templateHelper.expectTemplateCount(3)
+    await templateHelper.expectTemplateText(0, '姓名')
+    await templateHelper.expectTemplateText(1, '年龄')
+    await templateHelper.expectTemplateText(2, '城市')
+  })
+
+  test('TC-BD-05: 模板块前后的空格应该保留', async () => {
+    await templateHelper.setSimpleTemplate()
+    const text = await templateHelper.getEditorText()
+
+    expect(text).toContain('我是')
+    expect(text).toContain('张三')
+    expect(text).toContain('来自')
+  })
+})

--- a/packages/test/src/sender/specs/template/boundary.spec.ts
+++ b/packages/test/src/sender/specs/template/boundary.spec.ts
@@ -64,9 +64,11 @@ test.describe('Template Block - 边界情况测试', () => {
   test('TC-BD-05: 模板块前后的空格应该保留', async () => {
     await templateHelper.setSimpleTemplate()
     const text = await templateHelper.getEditorText()
+    const normalizedText = text
+      .replace(/\u200b/g, '')
+      .replace(/\u00a0/g, ' ')
+      .trim()
 
-    expect(text).toContain('我是')
-    expect(text).toContain('张三')
-    expect(text).toContain('来自')
+    expect(normalizedText).toBe('我是 张三 ，来自')
   })
 })

--- a/packages/test/src/sender/specs/template/delete.spec.ts
+++ b/packages/test/src/sender/specs/template/delete.spec.ts
@@ -1,0 +1,101 @@
+import { test, type Page } from '@playwright/test'
+import { createSenderTestHelper } from '../../helpers'
+import { createTemplateTestHelper } from '../../helpers/template-helper'
+
+test.describe('Template Block - Delete 删除逻辑', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let helper: ReturnType<typeof createSenderTestHelper>
+  let templateHelper: ReturnType<typeof createTemplateTestHelper>
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    helper = createSenderTestHelper(page)
+    templateHelper = createTemplateTestHelper(page)
+
+    await helper.toggleTemplate()
+    await helper.wait(300)
+  })
+
+  test.afterAll(async () => {
+    await helper.toggleTemplate()
+    await page.close()
+  })
+
+  test.beforeEach(async () => {
+    await helper.clearContent()
+    await templateHelper.clearTemplates()
+  })
+
+  test('TC-DL-01: 应该能够删除模板块内的字符', async () => {
+    await templateHelper.setSimpleTemplate()
+    await templateHelper.focusTemplateStart(0)
+    await templateHelper.pressDelete()
+    await templateHelper.expectTemplateText(0, '三')
+  })
+
+  test('TC-DL-02: 删除最后一个字符时应该保留模板块', async () => {
+    await templateHelper.setSimpleTemplate()
+    await templateHelper.focusTemplateStart(0)
+    await templateHelper.pressDelete()
+    await templateHelper.pressDelete()
+    await templateHelper.expectTemplateCount(1)
+  })
+
+  test('TC-DL-03: 空模板块内按 Delete 应该跳出模板块', async () => {
+    await templateHelper.setEmptyTemplate()
+    await templateHelper.clickTemplate(0)
+    await templateHelper.wait(100)
+    await templateHelper.pressDelete()
+    await templateHelper.expectTemplateCount(1)
+  })
+
+  test('TC-DL-04: 模板块末尾按 Delete 应该跳出且不吸入文本', async () => {
+    await templateHelper.setSimpleTemplate()
+    await templateHelper.focusTemplateEnd(0)
+    await templateHelper.pressDelete()
+
+    await templateHelper.expectEditorToContainText('，来自')
+    await templateHelper.expectTemplateCount(1)
+  })
+
+  test('TC-DL-05: 从模板块左侧按 Delete 应该进入模板块', async () => {
+    await templateHelper.setSimpleTemplate()
+    await helper.getEditor().click()
+    await templateHelper.wait(100)
+    await helper.getEditor().press('Home')
+    await templateHelper.pressArrowRight(2)
+    await templateHelper.pressDelete()
+
+    await templateHelper.expectTemplateCount(1)
+    await templateHelper.expectTemplateText(0, '张三')
+  })
+
+  test('TC-DL-06: 从左侧删除空模板块需要多次操作', async () => {
+    await templateHelper.setEmptyTemplate()
+    await helper.getEditor().click()
+    await helper.getEditor().press('Home')
+    await templateHelper.pressArrowRight(2)
+
+    await templateHelper.pressDelete()
+    await templateHelper.wait(50)
+    await templateHelper.pressDelete()
+    await templateHelper.wait(50)
+    await templateHelper.pressArrowLeft(1)
+    await templateHelper.pressBackspace()
+    await templateHelper.wait(100)
+  })
+
+  test('TC-DL-07: 选区删除应该包含模板块', async () => {
+    await templateHelper.setSimpleTemplate()
+    await helper.getEditor().click()
+    await templateHelper.selectText()
+    await templateHelper.pressDelete()
+
+    await helper.expectEditorEmpty()
+    await templateHelper.expectTemplateCount(0)
+  })
+})

--- a/packages/test/src/sender/specs/template/delete.spec.ts
+++ b/packages/test/src/sender/specs/template/delete.spec.ts
@@ -5,9 +5,9 @@ import { createTemplateTestHelper } from '../../helpers/template-helper'
 test.describe('Template Block - Delete 删除逻辑', () => {
   test.describe.configure({ mode: 'serial' })
 
-  let page: Page
-  let helper: ReturnType<typeof createSenderTestHelper>
-  let templateHelper: ReturnType<typeof createTemplateTestHelper>
+  let page: Page | undefined
+  let helper: ReturnType<typeof createSenderTestHelper> | undefined
+  let templateHelper: ReturnType<typeof createTemplateTestHelper> | undefined
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
@@ -21,81 +21,92 @@ test.describe('Template Block - Delete 删除逻辑', () => {
   })
 
   test.afterAll(async () => {
-    await helper.toggleTemplate()
-    await page.close()
+    if (helper) {
+      await helper.toggleTemplate()
+    }
+    await page?.close()
   })
 
   test.beforeEach(async () => {
-    await helper.clearContent()
-    await templateHelper.clearTemplates()
+    await helper!.clearContent()
+    await templateHelper!.clearTemplates()
   })
 
   test('TC-DL-01: 应该能够删除模板块内的字符', async () => {
-    await templateHelper.setSimpleTemplate()
-    await templateHelper.focusTemplateStart(0)
-    await templateHelper.pressDelete()
-    await templateHelper.expectTemplateText(0, '三')
+    await templateHelper!.setSimpleTemplate()
+    await templateHelper!.focusTemplateStart(0)
+    await templateHelper!.pressDelete()
+    await templateHelper!.expectTemplateText(0, '三')
   })
 
   test('TC-DL-02: 删除最后一个字符时应该保留模板块', async () => {
-    await templateHelper.setSimpleTemplate()
-    await templateHelper.focusTemplateStart(0)
-    await templateHelper.pressDelete()
-    await templateHelper.pressDelete()
-    await templateHelper.expectTemplateCount(1)
+    await templateHelper!.setSimpleTemplate()
+    await templateHelper!.focusTemplateStart(0)
+    await templateHelper!.pressDelete()
+    await templateHelper!.pressDelete()
+    await templateHelper!.expectTemplateCount(1)
   })
 
   test('TC-DL-03: 空模板块内按 Delete 应该跳出模板块', async () => {
-    await templateHelper.setEmptyTemplate()
-    await templateHelper.clickTemplate(0)
-    await templateHelper.wait(100)
-    await templateHelper.pressDelete()
-    await templateHelper.expectTemplateCount(1)
+    await templateHelper!.setEmptyTemplate()
+    await templateHelper!.clickTemplate(0)
+    await templateHelper!.wait(100)
+    await templateHelper!.pressDelete()
+    await templateHelper!.expectTemplateCount(1)
   })
 
   test('TC-DL-04: 模板块末尾按 Delete 应该跳出且不吸入文本', async () => {
-    await templateHelper.setSimpleTemplate()
-    await templateHelper.focusTemplateEnd(0)
-    await templateHelper.pressDelete()
+    await templateHelper!.setSimpleTemplate()
+    await templateHelper!.focusTemplateEnd(0)
+    await templateHelper!.pressDelete()
 
-    await templateHelper.expectEditorToContainText('，来自')
-    await templateHelper.expectTemplateCount(1)
+    await templateHelper!.expectEditorToContainText('，来自')
+    await templateHelper!.expectTemplateCount(1)
   })
 
   test('TC-DL-05: 从模板块左侧按 Delete 应该进入模板块', async () => {
-    await templateHelper.setSimpleTemplate()
-    await helper.getEditor().click()
-    await templateHelper.wait(100)
-    await helper.getEditor().press('Home')
-    await templateHelper.pressArrowRight(2)
-    await templateHelper.pressDelete()
+    await templateHelper!.setSimpleTemplate()
+    await helper!.getEditor().click()
+    await templateHelper!.wait(100)
+    await helper!.getEditor().press('Home')
+    await templateHelper!.pressArrowRight(2)
+    await templateHelper!.pressDelete()
 
-    await templateHelper.expectTemplateCount(1)
-    await templateHelper.expectTemplateText(0, '张三')
+    await templateHelper!.expectTemplateCount(1)
+    await templateHelper!.expectTemplateText(0, '张三')
   })
 
   test('TC-DL-06: 从左侧删除空模板块需要多次操作', async () => {
-    await templateHelper.setEmptyTemplate()
-    await helper.getEditor().click()
-    await helper.getEditor().press('Home')
-    await templateHelper.pressArrowRight(2)
+    await templateHelper!.setEmptyTemplate()
+    await helper!.getEditor().click()
+    await helper!.getEditor().press('Home')
+    await templateHelper!.pressArrowRight(2)
 
-    await templateHelper.pressDelete()
-    await templateHelper.wait(50)
-    await templateHelper.pressDelete()
-    await templateHelper.wait(50)
-    await templateHelper.pressArrowLeft(1)
-    await templateHelper.pressBackspace()
-    await templateHelper.wait(100)
+    for (let i = 0; i < 4; i++) {
+      if ((await templateHelper!.getTemplateCount()) === 0) {
+        break
+      }
+      await templateHelper!.pressDelete()
+      await templateHelper!.wait(100)
+    }
+
+    if ((await templateHelper!.getTemplateCount()) > 0) {
+      await templateHelper!.pressArrowLeft(1)
+      await templateHelper!.pressBackspace()
+      await templateHelper!.wait(100)
+    }
+
+    await templateHelper!.expectTemplateCount(0)
+    await templateHelper!.expectEditorToContainText('，来自')
   })
 
   test('TC-DL-07: 选区删除应该包含模板块', async () => {
-    await templateHelper.setSimpleTemplate()
-    await helper.getEditor().click()
-    await templateHelper.selectText()
-    await templateHelper.pressDelete()
+    await templateHelper!.setSimpleTemplate()
+    await helper!.getEditor().click()
+    await templateHelper!.selectText()
+    await templateHelper!.pressDelete()
 
-    await helper.expectEditorEmpty()
-    await templateHelper.expectTemplateCount(0)
+    await helper!.expectEditorEmpty()
+    await templateHelper!.expectTemplateCount(0)
   })
 })


### PR DESCRIPTION
**PR 概述**

主要在 `packages/test` 中为 `Sender` 组件补充完整的 Playwright E2E 测试能力。

**测试案例范围**
- 基础能力覆盖 23 条用例，验证输入与提交、`clearable`、`mode` 单多行切换、`loading`、`disabled`、`placeholder`、`submitType`、`size`、`maxLength`、字数统计、footer 插槽、自定义按钮、`submit/clear/cancel` 事件，以及 `setContent/getContent/focus/blur/clear/submit` 等实例方法，同时补充了自动高度、连续输入删除等基础交互边界。
- Mention 覆盖 12 条用例，验证 `@` 触发机制、普通文本不触发、已有文本后继续触发、删除触发符后关闭面板、列表过滤、上下键导航、边界导航不越界、鼠标悬停高亮、键盘/鼠标选择插入 Atom 节点、Backspace 删除整个 mention 节点，以及插入 mention 后继续输入文本的行为。
- Suggestion 覆盖 16 条用例，验证输入后建议列表展示、空内容不展示、清空后关闭、选择后关闭并可再次触发、列表项完整展示，以及 `ArrowUp/ArrowDown/Enter/Tab/Esc` 的键盘交互，包括高亮切换、首尾循环、回车确认和 Tab 自动补全。
- Template 覆盖 19 条用例，重点验证模板块的编辑与删除语义，包括块内字符删除、最后一个字符删除后保留空块、空模板块的跳出行为、块左右边界的 `Backspace/Delete` 处理、从块外进入块内删除、整段选区删除、多个连续模板块、模板与普通文本拼接，以及模板内容清空后的结构保持。

**验证脚本**

```bash
pnpm -F tiny-robot-test test -- src/sender/specs
```

**测试结果截图**

<img width="687" height="212" alt="image" src="https://github.com/user-attachments/assets/524859d6-6d0f-451d-8094-3203c2e4854e" />

<img width="1010" height="610" alt="image" src="https://github.com/user-attachments/assets/a856eac8-e8bf-4d8e-8a1b-f7fb67ebdd13" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Sender demo page with interactive controls and presets for testing editor modes and behaviors
  * Added comprehensive test helpers and selector constants to drive sender interactions

* **Tests**
  * Added extensive Playwright test suites covering basic flows, mention, suggestion, and template behaviors (keyboard, list, boundary, delete/backspace, and integration cases)

* **Documentation**
  * Updated home/testing instructions to reference the Sender demo and top-nav component switching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->