### PR TITLE
fix(sender-e2e): stabilize template delete e2e case

### DIFF
--- a/packages/test/src/sender/helpers/template-helper.ts
+++ b/packages/test/src/sender/helpers/template-helper.ts
@@ -6,6 +6,18 @@ import { SENDER_SELECTORS } from '../selectors'
  */
 export function createTemplateTestHelper(page: Page) {
   const selectors = SENDER_SELECTORS
+  const normalizeEditorText = async () => {
+    const text = await page.evaluate(() => {
+      const editor = document.querySelector('[data-testid="test-sender"] .ProseMirror')
+      return editor?.textContent || ''
+    })
+
+    return text
+      .replace(/\u200b/g, '')
+      .replace(/\u00a0/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
 
   return {
     selectors,
@@ -111,6 +123,17 @@ export function createTemplateTestHelper(page: Page) {
     },
 
     /**
+     * 从模板块左侧触发 Delete，避免依赖外层键盘时序
+     */
+    async pressDeleteBeforeTemplate(index: number) {
+      const handled = await page.evaluate((templateIndex) => {
+        return window.__senderTestApi?.pressDeleteBeforeTemplate(templateIndex) ?? false
+      }, index)
+
+      expect(handled).toBe(true)
+    },
+
+    /**
      * 聚焦到模板块内容末尾
      */
     async focusTemplateEnd(index: number) {
@@ -204,6 +227,13 @@ export function createTemplateTestHelper(page: Page) {
      */
     async expectEditorToContainText(text: string) {
       await expect(this.getEditor()).toContainText(text)
+    },
+
+    /**
+     * 验证去除零宽字符后的编辑器文本完全匹配
+     */
+    async expectNormalizedEditorText(text: string) {
+      await expect.poll(async () => normalizeEditorText()).toBe(text)
     },
 
     /**

--- a/packages/test/src/sender/index.vue
+++ b/packages/test/src/sender/index.vue
@@ -1,8 +1,17 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { TinySwitch } from '@opentiny/vue'
 import { Sender } from '@opentiny/tiny-robot'
 import type { MentionItem, TemplateItem, SenderSuggestionItem } from '@opentiny/tiny-robot'
+
+declare global {
+  interface Window {
+    __senderTestApi?: {
+      moveCursorBeforeTemplate: (index: number) => boolean
+      pressDeleteBeforeTemplate: (index: number) => boolean
+    }
+  }
+}
 
 const senderRef = ref()
 const content = ref('')
@@ -156,6 +165,58 @@ const extensions = computed(() => {
     exts.push(Sender.suggestion(suggestions))
   }
   return exts
+})
+
+const moveCursorBeforeTemplate = (index: number) => {
+  const exposedEditor = senderRef.value?.editor
+  const editor = exposedEditor?.value ?? exposedEditor
+  if (!editor) return false
+
+  let currentIndex = 0
+  let templatePosition: number | null = null
+
+  editor.state.doc.descendants((node: { type: { name: string } }, pos: number) => {
+    if (node.type.name === 'templateBlock') {
+      if (currentIndex === index) {
+        templatePosition = pos
+        return false
+      }
+      currentIndex += 1
+    }
+    return true
+  })
+
+  if (templatePosition === null) return false
+
+  editor.commands.setTextSelection(templatePosition)
+  editor.commands.focus(templatePosition)
+
+  return editor.state.selection.$from.nodeAfter?.type?.name === 'templateBlock'
+}
+
+const pressDeleteBeforeTemplate = (index: number) => {
+  const exposedEditor = senderRef.value?.editor
+  const editor = exposedEditor?.value ?? exposedEditor
+  if (!editor || !moveCursorBeforeTemplate(index)) return false
+
+  const deleteEvent = new KeyboardEvent('keydown', {
+    key: 'Delete',
+    bubbles: true,
+    cancelable: true,
+  })
+
+  return editor.view.dom.dispatchEvent(deleteEvent) === false
+}
+
+onMounted(() => {
+  window.__senderTestApi = {
+    moveCursorBeforeTemplate,
+    pressDeleteBeforeTemplate,
+  }
+})
+
+onBeforeUnmount(() => {
+  delete window.__senderTestApi
 })
 </script>
 

--- a/packages/test/src/sender/specs/template/delete.spec.ts
+++ b/packages/test/src/sender/specs/template/delete.spec.ts
@@ -66,14 +66,18 @@ test.describe('Template Block - Delete 删除逻辑', () => {
 
   test('TC-DL-05: 从模板块左侧按 Delete 应该进入模板块', async () => {
     await templateHelper!.setSimpleTemplate()
-    await helper!.getEditor().click()
-    await templateHelper!.wait(100)
-    await helper!.getEditor().press('Home')
-    await templateHelper!.pressArrowRight(2)
-    await templateHelper!.pressDelete()
+    await templateHelper!.pressDeleteBeforeTemplate(0)
 
     await templateHelper!.expectTemplateCount(1)
     await templateHelper!.expectTemplateText(0, '张三')
+  })
+
+  test('TC-DL-06: 从左侧按 Delete 应稳定删除空模板块', async () => {
+    await templateHelper!.setEmptyTemplate()
+    await templateHelper!.pressDeleteBeforeTemplate(0)
+
+    await templateHelper!.expectTemplateCount(0)
+    await templateHelper!.expectNormalizedEditorText('我是，来自')
   })
 
   test('TC-DL-07: 选区删除应该包含模板块', async () => {

--- a/packages/test/src/sender/specs/template/delete.spec.ts
+++ b/packages/test/src/sender/specs/template/delete.spec.ts
@@ -76,7 +76,7 @@ test.describe('Template Block - Delete 删除逻辑', () => {
     await templateHelper!.expectTemplateText(0, '张三')
   })
 
-  test('TC-DL-06: 选区删除应该包含模板块', async () => {
+  test('TC-DL-07: 选区删除应该包含模板块', async () => {
     await templateHelper!.setSimpleTemplate()
     await helper!.getEditor().click()
     await templateHelper!.selectText()

--- a/packages/test/src/sender/specs/template/delete.spec.ts
+++ b/packages/test/src/sender/specs/template/delete.spec.ts
@@ -76,31 +76,7 @@ test.describe('Template Block - Delete 删除逻辑', () => {
     await templateHelper!.expectTemplateText(0, '张三')
   })
 
-  test('TC-DL-06: 从左侧删除空模板块需要多次操作', async () => {
-    await templateHelper!.setEmptyTemplate()
-    await helper!.getEditor().click()
-    await helper!.getEditor().press('Home')
-    await templateHelper!.pressArrowRight(2)
-
-    for (let i = 0; i < 4; i++) {
-      if ((await templateHelper!.getTemplateCount()) === 0) {
-        break
-      }
-      await templateHelper!.pressDelete()
-      await templateHelper!.wait(100)
-    }
-
-    if ((await templateHelper!.getTemplateCount()) > 0) {
-      await templateHelper!.pressArrowLeft(1)
-      await templateHelper!.pressBackspace()
-      await templateHelper!.wait(100)
-    }
-
-    await templateHelper!.expectTemplateCount(0)
-    await templateHelper!.expectEditorToContainText('，来自')
-  })
-
-  test('TC-DL-07: 选区删除应该包含模板块', async () => {
+  test('TC-DL-06: 选区删除应该包含模板块', async () => {
     await templateHelper!.setSimpleTemplate()
     await helper!.getEditor().click()
     await templateHelper!.selectText()


### PR DESCRIPTION
### 一、问题背景
Sender 模板块删除场景中的 TC-DL-06 在 CI 环境下存在偶发失败。根因是该用例原先依赖 Home + ArrowRight 这类键盘步进方式来定位光标，再通过外层键盘事件触发 Delete，对浏览器选区行为和执行时序较为敏感，在不同环境下容易出现光标未准确落位的问题，从而导致未命中预期的模板块删除逻辑。

<img width="948" height="446" alt="image" src="https://github.com/user-attachments/assets/21fe477a-8eb1-4469-8bac-48c7459537ad" />

### 二、 优化方向
本次优化将“光标定位 + Delete 触发”收敛为基于 Sender 内部 editor 的浏览器侧原子操作，不再依赖外层键盘步进来猜测光标位置。这样可以更稳定地命中模板块左侧删除场景，降低 ProseMirror/Tiptap 选区差异带来的 flaky 风险，同时保留该测试场景的覆盖。

**变更内容**
- 优化模板块左侧 `Delete` 场景的测试实现，不再依赖 `Home + ArrowRight` 这类对浏览器选区行为敏感的键盘步进。
- 在 Sender 测试页中补充基于 editor 的稳定删除桥接能力，将“光标定位 + Delete 触发”收敛为浏览器侧原子操作。
- 在 `template-helper` 中补充对应的稳定辅助方法和文本断言能力，用于提升模板块边界场景下的断言可靠性。
- 调整 `TC-DL-05`、恢复并稳定 `TC-DL-06` 的实现，使其更贴近模板块删除逻辑的真实触发路径。

### 三、 当前现状
**验证情况**
- `pnpm -F tiny-robot-test test -- --workers=1 src/sender/specs/template/delete.spec.ts`
- `CI=1`、单 worker 模式下连续运行 5 轮 `template/delete.spec.ts`，均通过
- `CI=1`、单 worker 模式下运行 `src/sender/specs`，`70 passed`

- `pnpm -F tiny-robot-test test` , `79 passed`

**运行截图**

【git-action】

<img width="651" height="321" alt="image" src="https://github.com/user-attachments/assets/2f483889-64e7-4175-86b9-3a9a9b0d0147" />

【本地】

**整体测试**
<img width="635" height="217" alt="image" src="https://github.com/user-attachments/assets/6212a859-2634-45da-933f-0f215502d52e" />

**相关测试**
<img width="990" height="220" alt="image" src="https://github.com/user-attachments/assets/e0a3d83f-6325-494b-8072-7b09d10f8380" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Playwright specs to use a new helper for removing empty template blocks, simplifying steps and improving reliability.
  * Improved editor-text normalization in assertions to reduce flakiness with invisible/whitespace characters.
  * Adjusted test assertions accordingly to reflect normalized text comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->