### PR TITLE
fix(ci): Remove env variable indirection for secrets in deploy-playground-to-cdn workflow

### DIFF
--- a/.github/workflows/deploy-playground-to-cdn.yml
+++ b/.github/workflows/deploy-playground-to-cdn.yml
@@ -148,18 +148,13 @@ jobs:
           sudo mv obsutil_linux_amd64_*/obsutil /usr/local/bin/obsutil
 
       - name: Configure and Upload to OBS
-        env:
-          HUAWEI_CLOUD_AK: ${{ secrets.HUAWEI_CLOUD_AK }}
-          HUAWEI_CLOUD_SK: ${{ secrets.HUAWEI_CLOUD_SK }}
-          HUAWEI_CLOUD_ENDPOINT: ${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
-          HUAWEI_CLOUD_BUCKET: ${{ secrets.HUAWEI_CLOUD_BUCKET }}
         run: |
-          obsutil config -i=$HUAWEI_CLOUD_AK \
-                         -k=$HUAWEI_CLOUD_SK \
-                         -e=$HUAWEI_CLOUD_ENDPOINT
+          obsutil config -i=${{ secrets.HUAWEI_CLOUD_AK }} \
+                         -k=${{ secrets.HUAWEI_CLOUD_SK }} \
+                         -e=${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
           # Upload to versioned path
           obsutil cp ./packages/playground/dist \
-                    obs://$HUAWEI_CLOUD_BUCKET/${{ needs.build.outputs.obs-path }} \
+                    obs://${{ secrets.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path }} \
                     -r -f -flat
 
           # If is_latest_release is true, also upload to latest path
@@ -168,9 +163,9 @@ jobs:
             find ./packages/playground/dist -type f \( -name "*.html" -o -name "*.js" -o -name "*.mjs" -o -name "*.css" \) \
               -exec sed -i "s|${{ needs.build.outputs.cdn-base }}|${{ needs.build.outputs.cdn-base-latest }}|g" {} +
             obsutil cp ./packages/playground/dist \
-                      obs://$HUAWEI_CLOUD_BUCKET/${{ needs.build.outputs.obs-path-latest }} \
+                      obs://${{ secrets.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path-latest }} \
                       -r -f -flat
           fi
 
-          echo "Uploaded to: obs://$HUAWEI_CLOUD_BUCKET/${{ needs.build.outputs.obs-path }}"
+          echo "Uploaded to: obs://${{ secrets.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path }}"
           echo "CDN URL: https://res-static.opentiny.design/${{ needs.build.outputs.obs-path }}"

--- a/.github/workflows/deploy-playground-to-cdn.yml
+++ b/.github/workflows/deploy-playground-to-cdn.yml
@@ -9,12 +9,6 @@ on:
         default: true
         type: boolean
 
-env:
-  HUAWEI_CLOUD_AK: ${{ secrets.HUAWEI_CLOUD_AK }}
-  HUAWEI_CLOUD_SK: ${{ secrets.HUAWEI_CLOUD_SK }}
-  HUAWEI_CLOUD_ENDPOINT: ${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
-  HUAWEI_CLOUD_BUCKET: ${{ secrets.HUAWEI_CLOUD_BUCKET }}
-
 jobs:
   check-secrets:
     runs-on: ubuntu-latest
@@ -154,13 +148,18 @@ jobs:
           sudo mv obsutil_linux_amd64_*/obsutil /usr/local/bin/obsutil
 
       - name: Configure and Upload to OBS
+        env:
+          HUAWEI_CLOUD_AK: ${{ secrets.HUAWEI_CLOUD_AK }}
+          HUAWEI_CLOUD_SK: ${{ secrets.HUAWEI_CLOUD_SK }}
+          HUAWEI_CLOUD_ENDPOINT: ${{ secrets.HUAWEI_CLOUD_ENDPOINT }}
+          HUAWEI_CLOUD_BUCKET: ${{ secrets.HUAWEI_CLOUD_BUCKET }}
         run: |
-          obsutil config -i=${{ env.HUAWEI_CLOUD_AK }} \
-                         -k=${{ env.HUAWEI_CLOUD_SK }} \
-                         -e=${{ env.HUAWEI_CLOUD_ENDPOINT }}
+          obsutil config -i=$HUAWEI_CLOUD_AK \
+                         -k=$HUAWEI_CLOUD_SK \
+                         -e=$HUAWEI_CLOUD_ENDPOINT
           # Upload to versioned path
           obsutil cp ./packages/playground/dist \
-                    obs://${{ env.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path }} \
+                    obs://$HUAWEI_CLOUD_BUCKET/${{ needs.build.outputs.obs-path }} \
                     -r -f -flat
 
           # If is_latest_release is true, also upload to latest path
@@ -169,9 +168,9 @@ jobs:
             find ./packages/playground/dist -type f \( -name "*.html" -o -name "*.js" -o -name "*.mjs" -o -name "*.css" \) \
               -exec sed -i "s|${{ needs.build.outputs.cdn-base }}|${{ needs.build.outputs.cdn-base-latest }}|g" {} +
             obsutil cp ./packages/playground/dist \
-                      obs://${{ env.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path-latest }} \
+                      obs://$HUAWEI_CLOUD_BUCKET/${{ needs.build.outputs.obs-path-latest }} \
                       -r -f -flat
           fi
 
-          echo "Uploaded to: obs://${{ env.HUAWEI_CLOUD_BUCKET }}/${{ needs.build.outputs.obs-path }}"
+          echo "Uploaded to: obs://$HUAWEI_CLOUD_BUCKET/${{ needs.build.outputs.obs-path }}"
           echo "CDN URL: https://res-static.opentiny.design/${{ needs.build.outputs.obs-path }}"


### PR DESCRIPTION
Huawei Cloud credentials (`AK`, `SK`, `ENDPOINT`, `BUCKET`) were being routed through `env:` blocks before use — first as workflow-level env, then as step-level env — adding unnecessary indirection and exposure surface.

## Changes

- Removed step-level `env:` block from "Configure and Upload to OBS"
- Secrets are now referenced directly via `${{ secrets.* }}` at the point of use

```yaml
# Before
env:
  HUAWEI_CLOUD_AK: ${{ secrets.HUAWEI_CLOUD_AK }}
  ...
run: |
  obsutil config -i=$HUAWEI_CLOUD_AK ...

# After
run: |
  obsutil config -i=${{ secrets.HUAWEI_CLOUD_AK }} ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored deployment workflow to enhance credential handling practices. Updated how sensitive authentication parameters are accessed during the build and upload process to maintain security best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->