### PR TITLE
feat(bubble): integrate content navigation in BubbleList and add related composables

### DIFF
--- a/docs/src/components/bubble.md
+++ b/docs/src/components/bubble.md
@@ -388,12 +388,14 @@ Bubble 组件支持通过 `state` 属性存储 UI 相关的数据，并通过 `s
 | `contentRenderMode` | `'single' \| 'split'`                                         | -                              | 内容渲染模式                                                                                                                                                                                                                            |
 | `contentResolver`   | `(message: BubbleMessage) => ChatMessageContent \| undefined` | `(message) => message.content` | 内容解析函数，用于解析消息内容                                                                                                                                                                                                          |
 | `autoScroll`        | `boolean`                                                     | `false`                        | 是否自动滚动到底部。需要满足以下条件：<br/>- BubbleList 是可滚动容器（需要 scrollHeight > clientHeight）<br/>- 滚动容器接近底部                                                                                                         |
+| `contentNav`        | `boolean \| BubbleListContentNavOptions`                      | `false`                        | 是否启用最小版内容导航集成。开启后，`BubbleList` 会基于分组结果生成可供 `getContentNavSource()` 读取的导航源                                                                                                                          |
 
 **BubbleList Expose**
 
 | 方法             | 签名                                           | 说明                                                                                  |
 | ---------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `scrollToBottom` | `(behavior?: ScrollBehavior) => Promise<void>` | 滚动到底部。传入 `'smooth'` 可平滑滚动。若未启用 `autoScroll`，调用后无实际滚动效果。 |
+| `getContentNavSource` | `() => ContentNavSource \| undefined`        | 返回当前导航源。目录项基于 `messageGroups` 生成，目标 DOM 直接绑定在真实的 `.tr-bubble` 根节点上。 |
 
 **BubbleProviderProps** - 气泡提供者组件的属性配置
 

--- a/packages/components/src/bubble/BubbleList.vue
+++ b/packages/components/src/bubble/BubbleList.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, nextTick, provide, ref, watch } from 'vue'
+import { computed, nextTick, provide, ref, toRefs, watch } from 'vue'
 import { useAutoScroll } from '../shared/composables'
 import BubbleItem from './BubbleItem.vue'
 import { setupBubbleStore, useCopyCleanup } from './composables'
+import { useBubbleContentNav } from './composables/useBubbleContentNav'
 import { BUBBLE_LIST_CONTEXT_KEY } from './constants'
 import type { BubbleListProps, BubbleListSlots, BubbleMessage, BubbleMessageGroup } from './index.type'
 
@@ -169,8 +170,21 @@ const messageGroups = computed<BubbleMessageGroup[]>(() => {
   }
 })
 
+const { contentNav, contentResolver, dividerRole, fallbackRole } = toRefs(props)
+
+const { contentNavEntries, contentNavSource, bindGroupTarget } = useBubbleContentNav({
+  contentNav,
+  messageGroups,
+  dividerRole,
+  fallbackRole,
+  contentResolver,
+})
+
+const getContentNavSourceFn = () => contentNavSource.value
+
 defineExpose({
   scrollToBottom: scrollToBottomFn,
+  getContentNavSource: getContentNavSourceFn,
 })
 </script>
 
@@ -179,6 +193,8 @@ defineExpose({
     <BubbleItem
       v-for="(group, index) in messageGroups"
       :key="index"
+      :ref="bindGroupTarget(contentNavEntries[index]?.id)"
+      :data-content-nav-id="contentNavEntries[index]?.id || undefined"
       :role="group.role || props.fallbackRole"
       :role-config="props.roleConfigs?.[group.role || props.fallbackRole]"
       :message-group="group"

--- a/packages/components/src/bubble/composables/useBubbleContentNav.ts
+++ b/packages/components/src/bubble/composables/useBubbleContentNav.ts
@@ -1,0 +1,193 @@
+import { computed, toValue, watch, type MaybeRefOrGetter } from 'vue'
+import { useTargetRegistry, type TargetBinder } from '../../shared/composables'
+import type { ContentNavItem, ContentNavSource } from '../../shared/content-nav.type'
+import { createContentResolver } from './useContentResolver'
+import type { BubbleListContentNavOptions, BubbleMessage, BubbleMessageGroup, BubbleProps } from '../index.type'
+
+type BubbleContentNavEntry = {
+  id: string
+  item: ContentNavItem
+}
+
+function normalizeText(value: string) {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function extractResolvedContentText(message: BubbleMessage, resolveContent: ReturnType<typeof createContentResolver>) {
+  const parts: string[] = []
+  const content = resolveContent(message)
+
+  if (typeof content === 'string') {
+    parts.push(content)
+  } else if (Array.isArray(content)) {
+    content.forEach((item) => {
+      if (typeof item?.text === 'string') {
+        parts.push(item.text)
+      } else if (typeof item?.title === 'string') {
+        parts.push(item.title)
+      } else if (typeof item?.alt === 'string') {
+        parts.push(item.alt)
+      }
+    })
+  }
+
+  return normalizeText(parts.join(' '))
+}
+
+function extractMessageText(message: BubbleMessage, resolveContent: ReturnType<typeof createContentResolver>) {
+  const parts: string[] = []
+  const resolvedContentText = extractResolvedContentText(message, resolveContent)
+
+  if (resolvedContentText) {
+    parts.push(resolvedContentText)
+  }
+
+  if (typeof message.reasoning_content === 'string') {
+    parts.push(message.reasoning_content)
+  }
+
+  if (Array.isArray(message.tool_calls)) {
+    message.tool_calls.forEach((toolCall) => {
+      if (toolCall.function?.name) {
+        parts.push(toolCall.function.name)
+      }
+    })
+  }
+
+  return normalizeText(parts.join(' '))
+}
+
+function resolveGroupTexts(group: BubbleMessageGroup, resolveContent: ReturnType<typeof createContentResolver>) {
+  const messageTexts: string[] = []
+  let firstMessageText = ''
+
+  group.messages.forEach((message) => {
+    const text = extractMessageText(message, resolveContent)
+    if (!text) {
+      return
+    }
+
+    if (!firstMessageText) {
+      firstMessageText = text
+    }
+
+    messageTexts.push(text)
+  })
+
+  return {
+    firstMessageText,
+    groupMessagesText: normalizeText(messageTexts.join(' ')),
+  }
+}
+
+function resolveDefaultContentNavItem(
+  group: BubbleMessageGroup,
+  groupIndex: number,
+  fallbackRole: string,
+  resolveContent: ReturnType<typeof createContentResolver>,
+): ContentNavItem {
+  const groupRole = group.role || fallbackRole
+  const { firstMessageText, groupMessagesText } = resolveGroupTexts(group, resolveContent)
+  const label = firstMessageText || groupMessagesText || `${groupRole} ${groupIndex + 1}`
+  const id = group.messages.find((message) => message.id)?.id || `bubble-group-${group.startIndex}`
+
+  return {
+    id,
+    label,
+    searchText: groupMessagesText || label,
+    tooltipText: label,
+    meta: {
+      role: groupRole,
+      groupIndex,
+      startIndex: group.startIndex,
+      messageIndexes: [...group.messageIndexes],
+    },
+  }
+}
+
+export function useBubbleContentNav(options: {
+  contentNav: MaybeRefOrGetter<boolean | BubbleListContentNavOptions | undefined>
+  messageGroups: MaybeRefOrGetter<BubbleMessageGroup[]>
+  dividerRole: MaybeRefOrGetter<string>
+  fallbackRole: MaybeRefOrGetter<string>
+  contentResolver?: MaybeRefOrGetter<BubbleProps['contentResolver'] | undefined>
+}) {
+  const resolvedContentNavOptions = computed<BubbleListContentNavOptions | undefined>(() => {
+    const contentNav = toValue(options.contentNav)
+    if (!contentNav) {
+      return undefined
+    }
+
+    return contentNav === true ? {} : contentNav
+  })
+
+  const isContentNavEnabled = computed(() => Boolean(resolvedContentNavOptions.value))
+  const resolveContent = createContentResolver(options.contentResolver)
+  const registry = useTargetRegistry()
+  const noopGroupTargetBinder: TargetBinder = () => {}
+
+  const contentNavEntries = computed<Array<BubbleContentNavEntry | undefined>>(() => {
+    const groups = toValue(options.messageGroups)
+    if (!isContentNavEnabled.value) {
+      return groups.map(() => undefined)
+    }
+
+    const dividerRole = toValue(options.dividerRole)
+    const fallbackRole = toValue(options.fallbackRole)
+    const contentNavOptions = resolvedContentNavOptions.value
+
+    return groups.map((group, groupIndex) => {
+      const resolvedItem =
+        contentNavOptions?.itemResolver?.({
+          group,
+          groupIndex,
+          dividerRole,
+        }) ?? resolveDefaultContentNavItem(group, groupIndex, fallbackRole, resolveContent)
+
+      if (!resolvedItem || !resolvedItem.id) {
+        return undefined
+      }
+
+      return {
+        id: resolvedItem.id,
+        item: resolvedItem,
+      }
+    })
+  })
+
+  const contentNavItems = computed(() =>
+    contentNavEntries.value.flatMap((entry) => {
+      return entry ? [entry.item] : []
+    }),
+  )
+
+  const internalContentNavSource: ContentNavSource = {
+    items: contentNavItems,
+    resolveTarget: registry.get,
+    revision: registry.version,
+  }
+
+  watch(
+    () => contentNavItems.value.map((item) => item.id),
+    (activeIds) => {
+      registry.prune(activeIds)
+    },
+    { immediate: true },
+  )
+
+  const contentNavSource = computed(() => (isContentNavEnabled.value ? internalContentNavSource : undefined))
+
+  function bindGroupTarget(id: string | undefined) {
+    if (!isContentNavEnabled.value || !id) {
+      return noopGroupTargetBinder
+    }
+
+    return registry.bindTarget(id)
+  }
+
+  return {
+    contentNavEntries,
+    contentNavSource,
+    bindGroupTarget,
+  }
+}

--- a/packages/components/src/bubble/composables/useContentResolver.ts
+++ b/packages/components/src/bubble/composables/useContentResolver.ts
@@ -1,11 +1,21 @@
-import { inject, MaybeRefOrGetter, provide, toValue } from 'vue'
+import { inject, type MaybeRefOrGetter, provide, toValue } from 'vue'
 import type { BubbleMessage, BubbleProps } from '../index.type'
 
 const BUBBLE_CONTENT_RESOLVER_KEY = Symbol('BUBBLE_CONTENT_RESOLVER_KEY')
 
 type Resolver = BubbleProps['contentResolver']
+type ResolverSource = MaybeRefOrGetter<Resolver | undefined>
 
-export const useContentResolver = (contentResolver?: MaybeRefOrGetter<Resolver>) => {
+export const createContentResolver = (source?: ResolverSource) => {
+  return source
+    ? (message: BubbleMessage) => {
+        const fn = toValue(source)
+        return fn?.(message)
+      }
+    : (message: BubbleMessage) => message.content
+}
+
+export const useContentResolver = (contentResolver?: ResolverSource) => {
   const injected = inject<MaybeRefOrGetter<Resolver> | undefined>(BUBBLE_CONTENT_RESOLVER_KEY, undefined)
 
   const source = injected ?? contentResolver
@@ -19,12 +29,5 @@ export const useContentResolver = (contentResolver?: MaybeRefOrGetter<Resolver>)
    * 统一返回「可直接调用」的函数
    * 内部按需 toValue，保证始终取到最新值
    */
-  const resolveContent = source
-    ? (message: BubbleMessage) => {
-        const fn = toValue(source)
-        return fn?.(message)
-      }
-    : (message: BubbleMessage) => message.content
-
-  return resolveContent
+  return createContentResolver(source)
 }

--- a/packages/components/src/bubble/index.type.ts
+++ b/packages/components/src/bubble/index.type.ts
@@ -1,4 +1,5 @@
 import { Component, VNode } from 'vue'
+import type { ContentNavItem } from '../shared/content-nav.type'
 
 /**
  * 工具调用接口（支持 OpenAI 格式）
@@ -127,6 +128,14 @@ export type BubbleRoleConfig = Pick<
  */
 type BubbleGroupFunction = (messages: BubbleMessage[], dividerRole?: string) => BubbleMessageGroup[]
 
+export interface BubbleListContentNavOptions {
+  itemResolver?: (context: {
+    group: BubbleMessageGroup
+    groupIndex: number
+    dividerRole: string
+  }) => ContentNavItem | false
+}
+
 export interface BubbleListProps {
   messages: BubbleMessage[]
   /**
@@ -164,6 +173,7 @@ export interface BubbleListProps {
    * @default false
    */
   autoScroll?: boolean
+  contentNav?: boolean | BubbleListContentNavOptions
 }
 
 export interface BubbleProviderProps {

--- a/packages/components/src/shared/composables/index.ts
+++ b/packages/components/src/shared/composables/index.ts
@@ -1,4 +1,5 @@
 export * from './createTeleport'
+export * from './useTargetRegistry'
 export * from './useAutoScroll'
 export * from './useSlotRefs'
 export * from './useTeleportTarget'

--- a/packages/components/src/shared/composables/useTargetRegistry.ts
+++ b/packages/components/src/shared/composables/useTargetRegistry.ts
@@ -1,0 +1,113 @@
+import { type MaybeElement, unrefElement } from '@vueuse/core'
+import { ref, type ComponentPublicInstance, type Ref } from 'vue'
+
+export interface TargetRegistryEntry {
+  id: string
+  el: HTMLElement
+}
+
+export type TargetBinder = (target: Element | ComponentPublicInstance | null) => void
+
+export interface TargetRegistry {
+  version: Readonly<Ref<number>>
+  register: (id: string, el: HTMLElement | null) => void
+  unregister: (id: string) => void
+  get: (id: string) => HTMLElement | null
+  getAll: () => TargetRegistryEntry[]
+  bindTarget: (id: string) => TargetBinder
+  prune: (activeIds: Iterable<string>) => void
+}
+
+export function useTargetRegistry(): TargetRegistry {
+  const registry = new Map<string, HTMLElement>()
+  const targetBinders = new Map<string, TargetBinder>()
+  const version = ref(0)
+  const noopTargetBinder: TargetBinder = () => {}
+
+  const touch = () => {
+    version.value += 1
+  }
+
+  function register(id: string, el: HTMLElement | null) {
+    if (!id) {
+      return
+    }
+
+    if (!el) {
+      if (registry.delete(id)) {
+        touch()
+      }
+      return
+    }
+
+    const current = registry.get(id)
+    if (current !== el) {
+      registry.set(id, el)
+      touch()
+    }
+  }
+
+  function unregister(id: string) {
+    if (registry.delete(id)) {
+      touch()
+    }
+  }
+
+  function get(id: string) {
+    return registry.get(id) ?? null
+  }
+
+  function getAll() {
+    return Array.from(registry.entries()).map(([id, el]) => ({ id, el }))
+  }
+
+  function bindTarget(id: string) {
+    if (!id) {
+      return noopTargetBinder
+    }
+
+    const cachedBinder = targetBinders.get(id)
+    if (cachedBinder) {
+      return cachedBinder
+    }
+
+    const binder: TargetBinder = (target) => {
+      const el = unrefElement(target as MaybeElement)
+      if (!(el instanceof HTMLElement)) {
+        unregister(id)
+        return
+      }
+
+      register(id, el)
+    }
+
+    targetBinders.set(id, binder)
+    return binder
+  }
+
+  function prune(activeIds: Iterable<string>) {
+    const activeIdSet = new Set(activeIds)
+
+    getAll().forEach(({ id }) => {
+      if (!activeIdSet.has(id)) {
+        unregister(id)
+      }
+    })
+
+    for (const id of targetBinders.keys()) {
+      if (!activeIdSet.has(id)) {
+        targetBinders.delete(id)
+      }
+    }
+  }
+
+  return {
+    version,
+    register,
+    unregister,
+    get,
+    getAll,
+    bindTarget,
+    prune,
+  }
+}

--- a/packages/components/src/shared/content-nav.type.ts
+++ b/packages/components/src/shared/content-nav.type.ts
@@ -1,0 +1,15 @@
+import type { Ref } from 'vue'
+
+export interface ContentNavItem {
+  id: string
+  label: string
+  searchText?: string
+  tooltipText?: string
+  meta?: Record<string, unknown>
+}
+
+export interface ContentNavSource {
+  items: Readonly<Ref<ContentNavItem[]>>
+  resolveTarget: (id: string) => HTMLElement | null
+  revision: Readonly<Ref<number>>
+}


### PR DESCRIPTION
# BubbleList 与 ContentNav 集成说明

## 背景

当前分支在 `BubbleList` 上新增了一套最小版的内容导航接入能力。目标不是让 `BubbleList` 直接内置一个目录 UI，而是让它能够**向外暴露一份标准化的导航数据源**，供 `TrContentNav` 或其他导航消费者使用。

这套设计的核心结论是：

- `BubbleList` 负责把原始 `messages` 转成最终展示的 `messageGroups`
- `useBubbleContentNav` 负责把 `messageGroups` 转成 `ContentNavSource`
- `ContentNav` 负责消费 `ContentNavSource`，完成目录渲染、过滤、点击跳转和滚动激活态同步

也就是说，这次新增的能力本质上是：

**Bubble 生产导航源，ContentNav 消费导航源**

而不是：

**Bubble 内置 ContentNav**

## 为什么需要由 BubbleList 提供导航源

如果只看原始 `messages`，外部很难可靠地构造目录项，原因有几个：

1. `BubbleList` 最终展示的是 `messageGroups`，不是原始 message 列表
2. 连续同角色消息会合并为一个视觉分组
3. hidden 角色会影响最终分组结果
4. `fallbackRole`、`dividerRole`、`groupStrategy` 都会影响最终展示结构
5. `contentResolver` 可能让最终渲染内容与原始 `message.content` 不一致

因此，如果让使用方在外部自己基于 `messages` 再拼一份目录数据，往往会遇到下面这些问题：

- 一个视觉 bubble 对应多个目录项
- 目录项指向了隐藏内容
- 目录标签与实际展示内容不一致
- 点击目录后无法准确滚动到真正的 bubble DOM

所以导航源最适合在 `BubbleList` 内部生成，因为只有它掌握“最终展示结果”。

## 新增的公开能力

### 1. BubbleListProps 新增 `contentNav`

文件：

- `packages/components/src/bubble/index.type.ts`

新增：

```ts
export interface BubbleListContentNavOptions {
  itemResolver?: (context: {
    group: BubbleMessageGroup
    groupIndex: number
    dividerRole: string
  }) => ContentNavItem | false
}
```

以及：

```ts
contentNav?: boolean | BubbleListContentNavOptions
```

语义如下：

- `false` 或未传：不启用导航源
- `true`：启用默认导航项生成逻辑
- 对象：启用导航源，并允许通过 `itemResolver` 自定义每个 group 的导航项

### 2. BubbleList Expose 新增 `getContentNavSource`

文件：

- `packages/components/src/bubble/BubbleList.vue`
- `docs/src/components/bubble.md`

新增 expose：

```ts
getContentNavSource: () => ContentNavSource | undefined
```

这个方法的意义是：

- `BubbleList` 不直接渲染目录
- 上层页面可以通过 ref 读取导航源
- `TrContentNav` 或其他消费者可以自行决定如何展示目录

这是一种低耦合的设计：

- Bubble 负责“产出导航数据”
- 外部负责“如何使用导航数据”

## 共享契约：ContentNavItem 与 ContentNavSource

文件：

- `packages/components/src/shared/content-nav.type.ts`

新增：

```ts
export interface ContentNavItem {
  id: string
  label: string
  searchText?: string
  tooltipText?: string
  meta?: Record<string, unknown>
}

export interface ContentNavSource {
  items: Readonly<Ref<ContentNavItem[]>>
  resolveTarget: (id: string) => HTMLElement | null
  revision: Readonly<Ref<number>>
}
```

这里的关键是：`ContentNav` 真正需要的不是一组静态目录文字，而是一份完整的 source。

这份 source 至少要回答三个问题：

1. 当前有哪些导航项
2. 每个导航项对应哪个真实 DOM
3. 这些 DOM 绑定关系什么时候变了

因此：

- `items` 用于渲染目录
- `resolveTarget(id)` 用于点击跳转和滚动定位
- `revision` 用于通知消费者重新同步目标元素

## useBubbleContentNav 的职责

文件：

- `packages/components/src/bubble/composables/useBubbleContentNav.ts`

这个 composable 是 Bubble 与 ContentNav 之间的桥接层。它不负责渲染目录，也不负责计算 Bubble 分组，而是负责：

1. 解析 `contentNav` 配置
2. 将 `messageGroups` 转成 `ContentNavItem[]`
3. 为每个导航项建立 `id -> HTMLElement` 的目标映射
4. 组装标准 `ContentNavSource`

### 输入

```ts
{
  contentNav,
  messageGroups,
  dividerRole,
  fallbackRole,
  contentResolver,
}
```

### 输出

```ts
{
  contentNavEntries,
  contentNavSource,
  bindGroupTarget,
}
```

含义如下：

- `contentNavEntries`：保留 `id + item` 结构的中间态结果
- `contentNavSource`：标准导航源
- `bindGroupTarget(id)`：返回一个函数型 ref，用来把该 id 绑定到真实 Bubble DOM

## useBubbleContentNav 的详细处理流程

### 第一步：解析 contentNav 配置

```ts
const resolvedContentNavOptions = computed(() => {
  const contentNav = toValue(options.contentNav)
  if (!contentNav) return undefined
  return contentNav === true ? {} : contentNav
})
```

语义：

- 未启用时返回 `undefined`
- `true` 时表示“使用默认规则”
- 对象时表示“启用并读取自定义规则”

### 第二步：建立内容解析器

```ts
const resolveContent = createContentResolver(options.contentResolver)
```

这里使用 `createContentResolver()` 的原因是：

- `Bubble` 正文可能经过 `contentResolver` 改写
- 默认目录项的 `label/searchText/tooltipText` 也应尽量与最终渲染保持一致

如果目录项仍然只看原始 `message.content`，就会出现“页面显示 A，目录显示 B”的问题。

### 第三步：从每条 message 提取用于导航的文本

内部会按顺序提取：

- `contentResolver(message)` 解析后的正文
- `reasoning_content`
- `tool_calls[].function.name`

最后统一走空白归一化：

```ts
value.replace(/\s+/g, ' ').trim()
```

目的是：

- `label` 尽量简洁
- `searchText` 尽量完整
- 默认搜索可以命中更多内容

### 第四步：按 group 汇总文本

每个 `BubbleMessageGroup` 会产出两份文本：

- `firstMessageText`
- `groupMessagesText`

其中：

- `firstMessageText` 更适合作为 label
- `groupMessagesText` 更适合作为 searchText

### 第五步：生成默认导航项

默认项结构：

```ts
{
  id,
  label,
  searchText,
  tooltipText,
  meta: {
    role,
    groupIndex,
    startIndex,
    messageIndexes,
  },
}
```

默认 id 规则：

- 优先取该 group 中第一条带 id 的 message
- 否则回退到 `bubble-group-${group.startIndex}`

默认文本规则：

- `label = firstMessageText || groupMessagesText || "${role} ${index + 1}"`
- `searchText = groupMessagesText || label`
- `tooltipText = label`

### 第六步：处理 itemResolver

如果外部提供了 `itemResolver`：

- 返回 `ContentNavItem`：使用自定义项
- 返回 `undefined/null`：回退到默认项
- 返回 `false`：显式跳过该 group

这允许使用方：

- 完全自定义导航项
- 只自定义部分 group
- 明确忽略某些 group

## 为什么需要把 item id 绑定到真实 Bubble DOM

目录数据如果只有 `items`，还不够完成跳转。因为 `ContentNav` 点击某个导航项时，最终需要知道：

**这个 item id 对应的真实目标元素在哪里。**

所以还需要一套 `id -> HTMLElement` 的映射机制。

## 目标绑定机制

### BubbleList 模板层

文件：

- `packages/components/src/bubble/BubbleList.vue`

关键代码：

```vue
<BubbleItem
  v-for="(group, index) in messageGroups"
  :key="index"
  :ref="bindGroupTarget(contentNavEntries[index]?.id)"
  :data-content-nav-id="contentNavEntries[index]?.id || undefined"
/>
```

这里有两个点：

- `:ref="bindGroupTarget(...)"` 是核心绑定逻辑
- `:data-content-nav-id="..."` 不是核心机制，主要用于调试、观察和测试

也就是说，真正重要的是函数型 ref，不是 `data-*` 属性。

### 什么是函数型 ref

可以把函数型 ref 理解成：

不是把节点“放进一个变量”，而是“告诉 Vue：当这个节点或组件挂载/卸载时，请调用这个函数”。

例如：

```vue
<div :ref="bind('a')" />
```

等价于：

- 渲染时先得到一个函数
- 挂载时 Vue 自动调用这个函数，并把真实节点传进去
- 卸载时 Vue 再调用一次，并传 `null`

所以当前这句：

```vue
:ref="bindGroupTarget(contentNavEntries[index]?.id)"
```

含义是：

- 为当前 group 的导航项 id 生成一个专属 ref 回调
- 当对应 `BubbleItem` 挂载时，把这个组件实例交给回调处理

### registry 层如何接收这个回调

文件：

- `packages/components/src/shared/composables/useTargetRegistry.ts`

`bindTarget(id)` 会返回一个 binder：

```ts
const binder: TargetBinder = (target) => {
  const el = unrefElement(target as MaybeElement)
  if (!(el instanceof HTMLElement)) {
    unregister(id)
    return
  }

  register(id, el)
}
```

这里使用 VueUse 的 `unrefElement` 有两个原因：

1. 模板 ref 拿到的可能是 DOM，也可能是组件实例
2. 最终 registry 需要的必须是真实 `HTMLElement`

所以它会把各种可能的 target 统一解成实际 DOM。

### 最终绑定结果是什么

假设某个 group 目录项 id 为 `turn-101`，那么在组件挂载后，registry 内部大致会形成：

```ts
Map {
  'turn-101' => <div class="tr-bubble" ...>,
  'assistant-101-1' => <div class="tr-bubble" ...>,
}
```

后续 `ContentNav` 只要调用：

```ts
source.resolveTarget('turn-101')
```

就能拿到对应的 bubble DOM。

## 为什么还需要 revision

`BubbleList` 的内容是动态的：

- 消息可能增删
- 分组可能变化
- 某些 group 可能被过滤或重建

所以除了 `items` 和 `resolveTarget` 外，还需要一个版本号，告诉消费者：

**目标元素的映射关系刚刚变了，需要重新同步。**

这就是 `revision` 的作用。

在 `useTargetRegistry()` 内部：

- `register()` 时会更新 version
- `unregister()` 时会更新 version

而在 `useBubbleContentNav()` 内部，还会根据当前有效 item ids 调用 `prune(activeIds)`，清掉已经失效的旧绑定。

## 一个真实业务示例

假设页面上有如下原始消息：

```ts
const messages = [
  {
    id: 'turn-1',
    role: 'user',
    content: '帮我总结一下昨天项目例会的结论',
  },
  {
    id: 'assistant-1',
    role: 'assistant',
    content: '先给结论：本周先完成联调和灰度准备',
  },
  {
    id: 'assistant-2',
    role: 'assistant',
    content: '补充风险：发布窗口、依赖团队排期、权限审批还没收口',
    reasoning_content: '需要先明确 blocker 再给正式计划',
    tool_calls: [{ type: 'function', id: 'tool-1', function: { name: 'query_release_calendar', arguments: '{}' } }],
  },
  {
    id: 'turn-2',
    role: 'user',
    content: '再列一下负责人和时间点',
  },
]
```

并且配置：

```ts
groupStrategy = 'divider'
dividerRole = 'user'
contentNav = true
contentResolver = (message) => {
  if (message.role === 'user') return `提问：${message.content}`
  if (message.role === 'assistant') return `回复：${message.content}`
  return message.content
}
```

### 1. BubbleList 先计算 messageGroups

结果可能是：

```ts
[
  {
    role: 'user',
    startIndex: 0,
    messageIndexes: [0],
    messages: [{ id: 'turn-1', role: 'user', content: '帮我总结一下昨天项目例会的结论' }],
  },
  {
    role: 'assistant',
    startIndex: 1,
    messageIndexes: [1, 2],
    messages: [
      { id: 'assistant-1', role: 'assistant', content: '先给结论：本周先完成联调和灰度准备' },
      { id: 'assistant-2', role: 'assistant', content: '补充风险：发布窗口、依赖团队排期、权限审批还没收口' },
    ],
  },
  {
    role: 'user',
    startIndex: 3,
    messageIndexes: [3],
    messages: [{ id: 'turn-2', role: 'user', content: '再列一下负责人和时间点' }],
  },
]
```

### 2. useBubbleContentNav 生成默认导航项

结果可能是：

```ts
[
  {
    id: 'turn-1',
    label: '提问：帮我总结一下昨天项目例会的结论',
    searchText: '提问：帮我总结一下昨天项目例会的结论',
    tooltipText: '提问：帮我总结一下昨天项目例会的结论',
    meta: { role: 'user', groupIndex: 0, startIndex: 0, messageIndexes: [0] },
  },
  {
    id: 'assistant-1',
    label: '回复：先给结论：本周先完成联调和灰度准备',
    searchText:
      '回复：先给结论：本周先完成联调和灰度准备 回复：补充风险：发布窗口、依赖团队排期、权限审批还没收口 需要先明确 blocker 再给正式计划 query_release_calendar',
    tooltipText: '回复：先给结论：本周先完成联调和灰度准备',
    meta: { role: 'assistant', groupIndex: 1, startIndex: 1, messageIndexes: [1, 2] },
  },
  {
    id: 'turn-2',
    label: '提问：再列一下负责人和时间点',
    searchText: '提问：再列一下负责人和时间点',
    tooltipText: '提问：再列一下负责人和时间点',
    meta: { role: 'user', groupIndex: 2, startIndex: 3, messageIndexes: [3] },
  },
]
```

### 3. 模板渲染时绑定目标 DOM

每个 group 渲染一个 `BubbleItem`，并调用：

```vue
:ref="bindGroupTarget(contentNavEntries[index]?.id)"
```

于是会注册：

```ts
'turn-1' -> 第一个 user bubble DOM
'assistant-1' -> assistant group 对应的 bubble DOM
'turn-2' -> 第二个 user bubble DOM
```

### 4. 外部通过 expose 读取 source

```ts
const source = bubbleListRef.value?.getContentNavSource()
```

拿到的就是：

```ts
{
  items,
  resolveTarget,
  revision,
}
```

### 5. ContentNav 使用这份 source

后续目录组件就可以：

- 用 `items` 渲染目录
- 用 `searchText` 做过滤
- 点击目录时用 `resolveTarget(id)` 跳转
- 监听 `revision` 在绑定变化时重新同步 scroll spy

## 为什么需要 createContentResolver

文件：

- `packages/components/src/bubble/composables/useContentResolver.ts`

改动点：

- 抽出 `createContentResolver()`
- `useContentResolver()` 改为内部复用 `createContentResolver()`

这样拆分的原因是：

- `useContentResolver()` 带有 `inject/provide` 语义，适合渲染链
- `useBubbleContentNav()` 只是纯数据派生逻辑，不应带入上下文副作用

因此：

- `Bubble.vue` 继续使用 `useContentResolver()`
- `useBubbleContentNav.ts` 使用 `createContentResolver()`

这样既复用了相同的解析规则，又避免在非渲染场景里引入多余副作用。

## 为什么需要 useTargetRegistry

这不是 Bubble 专属实现，而是一层可复用的通用能力。

它解决的问题是：

- 如何把一组逻辑 id 映射到真实 DOM
- 如何在目标挂载/卸载时自动更新映射
- 如何在目标集合变化时进行清理

所以它被放在：

- `packages/components/src/shared/composables/useTargetRegistry.ts`

同时在：

- `packages/components/src/shared/composables/index.ts`

中对外导出。

## 如何理解

可以把这次设计理解为两层：

### 第一层：Bubble 作为导航源生产者

BubbleList 新增的不是“目录 UI”，而是“目录数据生产能力”。

### 第二层：ContentNav 作为导航源消费者

ContentNav 不需要关心 Bubble 如何分组，只需要消费标准 `ContentNavSource` 即可。

这使得两边职责清晰：

- Bubble 负责“数据源正确”
- ContentNav 负责“导航行为正确”