### PR TITLE
fix(docs): remove hardcoded VitePress brand color override

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -9,7 +9,6 @@ body,
   --rainbow-prev: #009ff7;
   --rainbow-next: #c76dd1;
   --vp-c-brand-soft: rgba(25, 25, 52, 0.1);
-  --vp-c-brand-1: #191919;
   --vp-home-hero-name-color: transparent;
   --vp-home-hero-name-background: -webkit-linear-gradient(120deg, var(--rainbow-prev) 30%, var(--rainbow-next));
   --vp-home-hero-image-background-image: linear-gradient(-45deg, var(--rainbow-prev) 30%, var(--rainbow-next));


### PR DESCRIPTION
问题处理：

修复了文档站点在暗色模式下侧边栏悬浮标题时颜色不可见的问题。

具体处理方式是移除 VitePress 主题中对 `--vp-c-brand-1: #191919` 的硬编码覆盖，让默认的暗色模式品牌色变量重新生效。

修改前：
<img width="1116" height="225" alt="image" src="https://github.com/user-attachments/assets/bc81d120-d207-4d19-9f13-4193e7b3f99b" />



修改后：
<img width="1108" height="222" alt="image" src="https://github.com/user-attachments/assets/40192771-b217-449c-acf0-8cdc3b869b64" />
