### PR TITLE
fix(sender): keep consistent gap for sender action tooltips

### DIFF
--- a/docs/demos/sender/actions-config-basic.vue
+++ b/docs/demos/sender/actions-config-basic.vue
@@ -49,10 +49,3 @@ const handleSubmit = (text: string) => {
   color: #606266;
 }
 </style>
-
-<style>
-.tr-submit-button-tooltip-popper,
-.tr-action-button-tooltip-popper {
-  top: -10px !important;
-}
-</style>

--- a/docs/src/components/sender.md
+++ b/docs/src/components/sender.md
@@ -724,9 +724,14 @@ Sender 组件提供了丰富的 CSS 变量用于自定义样式。
 | -------------------------------- | ------------ |
 | `--tr-sender-button-size`        | 按钮尺寸     |
 | `--tr-sender-button-size-submit` | 提交按钮尺寸 |
+| `--tr-sender-tooltip-gap`        | 按钮 Tooltip 与触发按钮的间距 |
 
 :::tip 尺寸变体
 所有变量都支持通过 `size` 属性自动切换。当 `size="small"` 时，组件会使用对应的 `-small` 变体（如 `--tr-sender-font-size-small`）。
+:::
+
+:::tip Tooltip 间距
+Sender 按钮的 Tooltip 间距可通过 `--tr-sender-tooltip-gap` 全局自定义，默认值为 `8px`。由于 Tooltip 弹层通常挂载在全局层级，建议在 `:root` 或全局主题作用域下设置该变量。
 :::
 
 :::tip 使用示例
@@ -741,6 +746,11 @@ Sender 组件提供了丰富的 CSS 变量用于自定义样式。
 .my-sender {
   --tr-sender-button-size: 40px;
   --tr-sender-button-size-submit: 44px;
+}
+
+/* 全局调整 Sender 按钮 Tooltip 间距 */
+:root {
+  --tr-sender-tooltip-gap: 10px;
 }
 ```
 :::

--- a/packages/components/src/sender-actions/action-button/index.vue
+++ b/packages/components/src/sender-actions/action-button/index.vue
@@ -86,3 +86,11 @@ const sizeStyle = computed(() => {
   }
 }
 </style>
+
+<style lang="less">
+@import '../styles/tooltip.less';
+
+.tiny-tooltip.tiny-tooltip__popper.tr-action-button-tooltip-popper {
+  .tr-sender-tooltip-light-popper-mixin();
+}
+</style>

--- a/packages/components/src/sender-actions/clear-button/index.vue
+++ b/packages/components/src/sender-actions/clear-button/index.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue'
 import { useSenderContext } from '../../sender/context'
 import { IconClear } from '@opentiny/tiny-robot-svgs'
 import ActionButton from '../action-button/index.vue'
-import { normalizeTooltipContent } from '../utils/tooltip'
 
 // 从 Context 读取状态和配置
 const { hasContent, clearable, clear, loading, defaultActions } = useSenderContext()
@@ -18,7 +17,7 @@ const isDisabled = computed(() => {
   return false
 })
 
-const tooltipRenderFn = computed(() => normalizeTooltipContent(defaultActions.value?.clear?.tooltip))
+const tooltip = computed(() => defaultActions.value?.clear?.tooltip)
 
 const tooltipPlacement = computed(() => defaultActions.value?.clear?.tooltipPlacement ?? 'top')
 
@@ -46,7 +45,7 @@ const handleClick = () => {
     v-if="show"
     :icon="IconClear"
     :disabled="isDisabled"
-    :tooltip="tooltipRenderFn"
+    :tooltip="tooltip"
     :tooltip-placement="tooltipPlacement"
     @click="handleClick"
   />

--- a/packages/components/src/sender-actions/styles/tooltip.less
+++ b/packages/components/src/sender-actions/styles/tooltip.less
@@ -1,0 +1,59 @@
+.tr-sender-tooltip-gap-mixin() {
+  &[data-popper-placement^='top'],
+  &[x-placement^='top'],
+  &[data-placement^='top'] {
+    padding-bottom: var(--tr-sender-tooltip-gap, 8px);
+  }
+
+  &[data-popper-placement^='bottom'],
+  &[x-placement^='bottom'],
+  &[data-placement^='bottom'] {
+    padding-top: var(--tr-sender-tooltip-gap, 8px);
+  }
+
+  &[data-popper-placement^='left'],
+  &[x-placement^='left'],
+  &[data-placement^='left'] {
+    padding-right: var(--tr-sender-tooltip-gap, 8px);
+  }
+
+  &[data-popper-placement^='right'],
+  &[x-placement^='right'],
+  &[data-placement^='right'] {
+    padding-left: var(--tr-sender-tooltip-gap, 8px);
+  }
+}
+
+.tr-sender-tooltip-shell-mixin() {
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.tr-sender-tooltip-inner-base-mixin() {
+  display: block;
+  min-width: 10px;
+  max-width: 450px;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.tr-sender-tooltip-light-inner-mixin() {
+  .tr-sender-tooltip-inner {
+    .tr-sender-tooltip-inner-base-mixin();
+    padding: var(--tv-Tooltip-padding-y) var(--tv-Tooltip-padding-x);
+    color: var(--tv-Tooltip-popper-light-text-color);
+    font-size: var(--tv-Tooltip-popper-font-size);
+    line-height: var(--tv-Tooltip-popper-font-line-height);
+    background: var(--tv-Tooltip-popper-light-bg-color);
+    border-radius: var(--tv-Tooltip-popper-border-radius);
+    box-shadow: var(--tv-Tooltip-box-shadow);
+  }
+}
+
+.tr-sender-tooltip-light-popper-mixin() {
+  .tr-sender-tooltip-shell-mixin();
+  .tr-sender-tooltip-gap-mixin();
+  .tr-sender-tooltip-light-inner-mixin();
+}

--- a/packages/components/src/sender-actions/submit-button/index.vue
+++ b/packages/components/src/sender-actions/submit-button/index.vue
@@ -148,15 +148,10 @@ const handleClick = () => {
 </style>
 
 <style lang="less">
+@import '../styles/tooltip.less';
+
 /* 全局样式：自定义 TinyTooltip 样式 */
-.tr-submit-button-tooltip-popper {
-  .tiny-tooltip__popper {
-    padding: 6px 12px;
-    background-color: rgba(0, 0, 0, 0.85);
-    color: white;
-    border-radius: 4px;
-    font-size: 12px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  }
+.tiny-tooltip.tiny-tooltip__popper.tr-submit-button-tooltip-popper {
+  .tr-sender-tooltip-light-popper-mixin();
 }
 </style>

--- a/packages/components/src/sender-actions/utils/tooltip.ts
+++ b/packages/components/src/sender-actions/utils/tooltip.ts
@@ -1,4 +1,33 @@
+import { h, isVNode, type VNode } from 'vue'
 import type { TooltipContent } from '../types/tooltip'
+
+const TOOLTIP_INNER_CLASS = 'tr-sender-tooltip-inner'
+
+function hasTooltipInnerClass(value: unknown): boolean {
+  if (!value) return false
+
+  if (typeof value === 'string') {
+    return value.split(/\s+/).includes(TOOLTIP_INNER_CLASS)
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(hasTooltipInnerClass)
+  }
+
+  if (typeof value === 'object') {
+    return Boolean((value as Record<string, unknown>)[TOOLTIP_INNER_CLASS])
+  }
+
+  return false
+}
+
+function renderTooltipInner(content: string | VNode) {
+  if (isVNode(content) && hasTooltipInnerClass(content.props?.class)) {
+    return content
+  }
+
+  return h('div', { class: TOOLTIP_INNER_CLASS }, content)
+}
 
 /**
  * 将 TooltipContent 转换为 TinyTooltip 的 render-content 函数
@@ -7,8 +36,8 @@ export function normalizeTooltipContent(tooltip: TooltipContent | undefined) {
   if (!tooltip) return undefined
 
   if (typeof tooltip === 'string') {
-    return () => tooltip
+    return () => renderTooltipInner(tooltip)
   }
 
-  return tooltip
+  return () => renderTooltipInner(tooltip())
 }


### PR DESCRIPTION
## Background

Sender 的按钮 tooltip 在 `bottom` 场景下与触发按钮距离过近，部分情况下会出现 tooltip 贴住按钮的问题。  
根因是 demo 中通过全局样式直接修改了 popper 定位结果，导致不同按钮、不同 placement 下的表现不一致。

## What changed

- 移除 demo 中通过 `top: -10px !important` 修正 tooltip 位置的样式
- 将 Sender 按钮 tooltip 的 gap 逻辑统一收口到组件内部
- 按 `top / bottom / left / right` 处理固定方向间距
- 统一 `submit / clear / upload / voice` 的 tooltip 渲染结构
- 修复 `clear` 按钮 tooltip 的重复包装问题
- 增加 `--tr-sender-tooltip-gap` CSS 变量说明，支持全局样式定制

## Result

- `bottom` 方向下 tooltip 不再贴住按钮
- 各默认按钮和增强按钮的 tooltip 间距表现保持一致
- 不新增 JS API，仅提供 CSS 变量作为样式扩展能力

## Verification

- 检查 `submit / clear / upload / voice` 的 tooltip 展示
- 检查 `top / bottom / left / right` 下的间距表现
- 验证 docs demo 中不再依赖全局定位补丁


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new `--tr-sender-tooltip-gap` CSS variable, enabling tooltip spacing customization with an 8px default.

* **Style**
  * Refactored tooltip styling system for improved consistency and maintainability across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->