### PR TITLE
fix: handle empty reasoning_content from non-standard APIs

### DIFF
--- a/packages/components/src/bubble/renderers/defaultRenderers.ts
+++ b/packages/components/src/bubble/renderers/defaultRenderers.ts
@@ -25,7 +25,7 @@ export const defaultContentRendererMatches: Array<BubbleContentRendererMatch> = 
     priority: BubbleRendererMatchPriority.LOADING,
   },
   {
-    find: (message) => typeof message.reasoning_content === 'string',
+    find: (message) => typeof message.reasoning_content === 'string' && message.reasoning_content.trim() !== '',
     renderer: markRaw(Reasoning),
     priority: BubbleRendererMatchPriority.NORMAL,
   },


### PR DESCRIPTION
Some non-standard APIs may return an empty string for `reasoning_content` even when the model does not support deep reasoning. This change improves compatibility by tolerating that response shape.

非标准 API 中，不支持深度思考，仍然可能返回空字符串的 `reasoning_content` 。导致渲染了没有内容的“思考过程”
修改前：
<img width="322" height="131" alt="image" src="https://github.com/user-attachments/assets/acf1b583-441a-4eb0-8e6b-7864c4c986f2" />
修改后：
<img width="330" height="73" alt="image" src="https://github.com/user-attachments/assets/ebc815e6-edf4-4cf2-a4fb-473fd2542097" />
