### PR TITLE
feat(bubble): add provider-level box and content attributes

### DIFF
--- a/docs/demos/bubble/RecursiveReasoningRenderer.vue
+++ b/docs/demos/bubble/RecursiveReasoningRenderer.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { type BubbleContentRendererProps, useBubbleContentRenderer, useOmitMessageFields } from '@opentiny/tiny-robot'
+import { computed } from 'vue'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = defineProps<BubbleContentRendererProps>()
+
+const { restMessage, restProps } = useOmitMessageFields(props, ['reasoning_content'])
+const renderer = useBubbleContentRenderer(restMessage, props.contentIndex)
+
+const recursiveProps = computed(() => ({
+  ...renderer.value.attributes,
+  ...restProps.value,
+}))
+</script>
+
+<template>
+  <section class="custom-reasoning" data-type="custom-reasoning" v-bind="$attrs">
+    <div class="custom-reasoning__title">自定义推理过程</div>
+    <p class="custom-reasoning__content">{{ props.message.reasoning_content }}</p>
+  </section>
+  <component :is="renderer.renderer" v-bind="recursiveProps" />
+</template>
+
+<style scoped>
+.custom-reasoning {
+  margin-bottom: 8px;
+  padding-left: 10px;
+  border-left: 2px solid #8b5cf6;
+  color: #666;
+}
+
+.custom-reasoning__title {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.custom-reasoning__content {
+  margin: 4px 0 0;
+  font-size: 13px;
+  line-height: 20px;
+  white-space: pre-wrap;
+}
+</style>

--- a/docs/demos/bubble/custom-composite-renderer.vue
+++ b/docs/demos/bubble/custom-composite-renderer.vue
@@ -1,0 +1,44 @@
+<template>
+  <tr-bubble-provider :content-renderer-matches="contentRendererMatches" :content-attributes="contentAttributes">
+    <tr-bubble
+      content="最终答案：1 + 1 在二进制中等于 10。"
+      reasoning_content="先按十进制理解 1 + 1 = 2，再把 2 转成二进制，结果是 10。"
+      :avatar="aiAvatar"
+    ></tr-bubble>
+  </tr-bubble-provider>
+</template>
+
+<script setup lang="ts">
+import {
+  BubbleRendererMatchPriority,
+  type BubbleContentAttributesConfig,
+  type BubbleContentRendererMatch,
+  TrBubble,
+  TrBubbleProvider,
+} from '@opentiny/tiny-robot'
+import { IconAi } from '@opentiny/tiny-robot-svgs'
+import { h, markRaw } from 'vue'
+import RecursiveReasoningRenderer from './RecursiveReasoningRenderer.vue'
+
+const aiAvatar = h(IconAi, { style: { fontSize: '32px' } })
+
+const contentRendererMatches: BubbleContentRendererMatch[] = [
+  {
+    find: (message) => typeof message.reasoning_content === 'string',
+    renderer: markRaw(RecursiveReasoningRenderer),
+    priority: BubbleRendererMatchPriority.NORMAL - 1,
+    attributes: { 'data-renderer': 'custom-recursive-reasoning' },
+  },
+]
+
+const contentAttributes: BubbleContentAttributesConfig = (message, content, contentIndex) => {
+  const isReasoning = typeof message.reasoning_content === 'string' && message.reasoning_content
+
+  return {
+    'data-demo-kind': isReasoning ? 'reasoning' : 'content',
+    'data-role': message.role || 'assistant',
+    'data-content-type': content.type,
+    'data-content-index': contentIndex,
+  }
+}
+</script>

--- a/docs/demos/bubble/provider-attributes.vue
+++ b/docs/demos/bubble/provider-attributes.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="demo">
+    <p class="desc">
+      外层气泡容器是 Box，里面的每一段内容是 Content。点击下方任意 Box 或 Content，可查看该 DOM 节点上的真实 data-*
+      属性。
+    </p>
+
+    <div class="preview" @click="handleInspect">
+      <tr-bubble-provider :box-attributes="boxAttributes" :content-attributes="contentAttributes">
+        <tr-bubble-list :messages="messages" :role-configs="roleConfigs" content-render-mode="split"></tr-bubble-list>
+      </tr-bubble-provider>
+    </div>
+
+    <pre class="output">{{ output }}</pre>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type {
+  BubbleBoxAttributesConfig,
+  BubbleContentAttributesConfig,
+  BubbleMessage,
+  BubbleRoleConfig,
+} from '@opentiny/tiny-robot'
+import { TrBubbleList, TrBubbleProvider } from '@opentiny/tiny-robot'
+import { IconAi, IconUser } from '@opentiny/tiny-robot-svgs'
+import { h, ref } from 'vue'
+
+const messages: BubbleMessage[] = [
+  { role: 'user', content: '请总结今天会议。' },
+  {
+    role: 'assistant',
+    content: [
+      { type: 'text', text: '重点一：支持 BubbleProvider 统一注入 attributes。' },
+      { type: 'text', text: '重点二：支持按消息上下文动态生成 attributes。' },
+    ],
+  },
+]
+
+const roleConfigs: Record<string, BubbleRoleConfig> = {
+  assistant: {
+    avatar: h(IconAi, { style: { fontSize: '28px' } }),
+  },
+  user: {
+    avatar: h(IconUser, { style: { fontSize: '28px' } }),
+    placement: 'end',
+  },
+}
+
+const boxAttributes: BubbleBoxAttributesConfig = (messages, content, contentIndex) => ({
+  'data-demo-kind': 'box',
+  'data-role': messages[0]?.role || 'unknown',
+  'data-message-count': messages.length,
+  'data-content-type': content?.type || 'unknown',
+  'data-content-index': contentIndex ?? 'unknown',
+})
+
+const contentAttributes: BubbleContentAttributesConfig = (message, content, contentIndex) => ({
+  'data-demo-kind': 'content',
+  'data-role': message.role || 'unknown',
+  'data-content-type': content.type,
+  'data-content-index': contentIndex,
+})
+
+const output = ref('点击预览区域中的节点后，这里会显示该节点上的 data-* 属性。')
+
+const handleInspect = (event: MouseEvent) => {
+  const target = event.target as HTMLElement | null
+  const element = target?.closest('[data-demo-kind]') as HTMLElement | null
+
+  if (!element) {
+    return
+  }
+
+  const dataAttributes = Object.fromEntries(
+    element
+      .getAttributeNames()
+      .filter((name) => name.startsWith('data-') && !name.startsWith('data-v-'))
+      .map((name) => [name, element.getAttribute(name)]),
+  )
+
+  output.value = JSON.stringify(dataAttributes, null, 2)
+}
+</script>
+
+<style scoped>
+.demo {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.desc {
+  margin: 0;
+  font-size: 12px;
+  color: #666;
+}
+
+.preview {
+  padding: 12px;
+  border: 1px solid var(--vp-c-divider, #ddd);
+  background: var(--vp-c-bg-soft, #f6f6f7);
+}
+
+.preview :deep([data-demo-kind]) {
+  cursor: pointer;
+}
+
+.preview :deep([data-demo-kind='box']) {
+  outline: 1px dashed #f59e0b;
+}
+
+.preview :deep([data-demo-kind='content']) {
+  outline: 1px solid #60a5fa;
+}
+
+.output {
+  margin: 0;
+  padding: 12px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--vp-c-text-1, #213547);
+  background: var(--vp-c-bg-soft, #f5f5f5);
+  border: 1px solid var(--vp-c-divider, #ddd);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+</style>

--- a/docs/src/components/bubble.md
+++ b/docs/src/components/bubble.md
@@ -1,5 +1,5 @@
 ---
-outline: [1, 3]
+outline: [1, 4]
 ---
 
 # Bubble 气泡组件
@@ -210,6 +210,20 @@ Bubble 组件采用渲染器架构，支持灵活的内容渲染和自定义扩�
 
 <demo vue="../../demos/bubble/provider-renderer.vue" />
 
+#### 通过 BubbleProvider 统一注入 attributes
+
+除了配置渲染器，`BubbleProvider` 还支持通过 `box-attributes` 和 `content-attributes` 为 Box / Content 统一注入 attributes。
+
+- `box-attributes` 的作用域是一个 Box，对应参数为 `(messages, content, contentIndex)`
+- `content-attributes` 的作用域是单个 Content，对应参数为 `(message, content, contentIndex)`
+- 两个属性都支持传入静态对象，或返回 attributes 的函数
+
+适合用于统一添加 `data-*` 标记、埋点字段、测试选择器等通用属性，而不需要依赖所有消息都匹配某个自定义渲染器。
+
+<demo vue="../../demos/bubble/provider-attributes.vue" />
+
+> `BubbleProvider` 注入的 attributes 会在对应的 Box / Content 上统一生效；如果某个匹配规则本身也配置了 `attributes`，会在 Provider attributes 的基础上继续合并。
+
 #### 渲染器匹配优先级
 
 匹配规则可以使用 `priority` 属性来设置优先级，值越小优先级越高。系统提供了以下优先级常量：
@@ -401,6 +415,8 @@ Bubble 组件支持通过 `state` 属性存储 UI 相关的数据，并通过 `s
 | ------------------------- | --------------------------------------- | ------ | ---------------------------------------------------------- |
 | `boxRendererMatches`      | `BubbleBoxRendererMatch[]`              | -      | Box 渲染器匹配规则数组                                     |
 | `contentRendererMatches`  | `BubbleContentRendererMatch[]`          | -      | 内容渲染器匹配规则数组                                     |
+| `boxAttributes`           | `BubbleBoxAttributesConfig`             | -      | 统一注入到 Box 的 attributes，支持静态对象或 resolver 函数 |
+| `contentAttributes`       | `BubbleContentAttributesConfig`         | -      | 统一注入到 Content 的 attributes，支持静态对象或 resolver 函数 |
 | `fallbackBoxRenderer`     | `Component<BubbleBoxRendererProps>`     | -      | 默认 box 渲染器（当无法匹配到合适的渲染器时使用）          |
 | `fallbackContentRenderer` | `Component<BubbleContentRendererProps>` | -      | 默认内容渲染器（当无法匹配到合适的渲染器时使用）           |
 | `store`                   | `Record<string, unknown>`               | -      | 全局状态存储，用于在 BubbleList 和 Bubble 组件之间共享数据 |

--- a/docs/src/components/bubble.md
+++ b/docs/src/components/bubble.md
@@ -266,44 +266,35 @@ Bubble 组件采用渲染器架构，支持灵活的内容渲染和自定义扩�
 
 #### 实现自定义渲染器
 
-**Content 渲染器示例**
+**Content 渲染器**
 
-Content 渲染器接收 `BubbleContentRendererProps` 作为 props，包含 `message` 和可选的 `contentIndex`。
-
-```vue
-<script setup lang="ts">
-import type { BubbleContentRendererProps } from '@opentiny/tiny-robot'
-import { defineComponent, markRaw, h } from 'vue'
-
-// 方式一：使用 defineComponent
-const CustomContentRenderer = defineComponent({
-  props: {
-    message: { type: Object, required: true },
-    contentIndex: Number,
-  },
-  setup(props: BubbleContentRendererProps) {
-    return () => h('div', { class: 'custom-content' }, props.message.content)
-  },
-})
-</script>
-```
-
-或者使用 `.vue` 文件：
+Content 渲染器接收 `BubbleContentRendererProps` 作为 props，包含 `message` 和 `contentIndex`。最简单的渲染器只需要消费当前消息内容，并把外部传入的 attributes 绑定到自己的根节点上。
 
 ```vue
-<!-- CustomRenderer.vue -->
-<template>
-  <div class="custom-content">
-    {{ message.content }}
-  </div>
-</template>
-
+<!-- CustomContentRenderer.vue -->
 <script setup lang="ts">
 import type { BubbleContentRendererProps } from '@opentiny/tiny-robot'
 
 defineProps<BubbleContentRendererProps>()
 </script>
+
+<template>
+  <div class="custom-content" v-bind="$attrs">
+    {{ message.content }}
+  </div>
+</template>
 ```
+
+当一个渲染器会拆出部分字段单独渲染，同时还要继续渲染剩余内容时，可以实现为复合渲染器。典型场景是 `reasoning_content + content` 或 `tool_calls + content`：
+
+- 使用 `useOmitMessageFields(props, fields)` 从消息中剥离已经消费的字段，避免递归时再次命中同一个渲染器
+- 使用 `useBubbleContentRenderer(restMessage, contentIndex)` 为剩余消息重新选择渲染器
+- 内部递归渲染时传入 `renderer.attributes`，保证 `BubbleProvider` / match 注入的 attributes 不丢失
+- 多根节点组件需要 `inheritAttrs: false`，并把 `$attrs` 显式绑定到当前渲染器真正代表的 DOM 节点上
+
+下方示例中，`contentAttributes` 使用函数形式，并根据 `message.reasoning_content` 分发不同属性；match 的 `attributes` 会落到自定义推理块上，递归渲染普通 `content` 时会重新计算并传递新的 `contentAttributes`。
+
+<demo vue="../../demos/bubble/custom-composite-renderer.vue" :vueFiles="['../../demos/bubble/custom-composite-renderer.vue', '../../demos/bubble/RecursiveReasoningRenderer.vue']" />
 
 **Box 渲染器示例**
 
@@ -342,21 +333,7 @@ defineProps<BubbleBoxRendererProps>()
 - Box 渲染器的 `find` 函数签名：`(messages, content, contentIndex) => boolean`，其中 `content` 仅在 split 模式有值
 - Content 渲染器的 `find` 函数签名：`(message, content, contentIndex) => boolean`，`content` 为统一化后的 `ChatMessageContentItem`
 - 在 Content 渲染器中可使用 `useMessageContent(props)` 获取当前 `content` 和 `contentText`，以正确处理 `contentIndex` 与数组内容
-
-```vue
-<template>
-  <div>
-    <div>这是自定义 content 渲染器</div>
-    <div>{{ props.message.content }}</div>
-  </div>
-</template>
-
-<script setup lang="ts">
-import type { BubbleContentRendererProps } from '@opentiny/tiny-robot'
-
-const props = defineProps<BubbleContentRendererProps>()
-</script>
-```
+- 多根节点或复合渲染器应使用 `inheritAttrs: false`，并显式决定 `$attrs` 绑定到哪个节点；不要把同一份 attributes 复制到多个兄弟节点上，避免重复 `id`、ARIA 或测试选择器
 
 ### 状态管理
 
@@ -411,15 +388,15 @@ Bubble 组件支持通过 `state` 属性存储 UI 相关的数据，并通过 `s
 
 **BubbleProviderProps** - 气泡提供者组件的属性配置
 
-| 属性                      | 类型                                    | 默认值 | 说明                                                       |
-| ------------------------- | --------------------------------------- | ------ | ---------------------------------------------------------- |
-| `boxRendererMatches`      | `BubbleBoxRendererMatch[]`              | -      | Box 渲染器匹配规则数组                                     |
-| `contentRendererMatches`  | `BubbleContentRendererMatch[]`          | -      | 内容渲染器匹配规则数组                                     |
-| `boxAttributes`           | `BubbleBoxAttributesConfig`             | -      | 统一注入到 Box 的 attributes，支持静态对象或 resolver 函数 |
+| 属性                      | 类型                                    | 默认值 | 说明                                                           |
+| ------------------------- | --------------------------------------- | ------ | -------------------------------------------------------------- |
+| `boxRendererMatches`      | `BubbleBoxRendererMatch[]`              | -      | Box 渲染器匹配规则数组                                         |
+| `contentRendererMatches`  | `BubbleContentRendererMatch[]`          | -      | 内容渲染器匹配规则数组                                         |
+| `boxAttributes`           | `BubbleBoxAttributesConfig`             | -      | 统一注入到 Box 的 attributes，支持静态对象或 resolver 函数     |
 | `contentAttributes`       | `BubbleContentAttributesConfig`         | -      | 统一注入到 Content 的 attributes，支持静态对象或 resolver 函数 |
-| `fallbackBoxRenderer`     | `Component<BubbleBoxRendererProps>`     | -      | 默认 box 渲染器（当无法匹配到合适的渲染器时使用）          |
-| `fallbackContentRenderer` | `Component<BubbleContentRendererProps>` | -      | 默认内容渲染器（当无法匹配到合适的渲染器时使用）           |
-| `store`                   | `Record<string, unknown>`               | -      | 全局状态存储，用于在 BubbleList 和 Bubble 组件之间共享数据 |
+| `fallbackBoxRenderer`     | `Component<BubbleBoxRendererProps>`     | -      | 默认 box 渲染器（当无法匹配到合适的渲染器时使用）              |
+| `fallbackContentRenderer` | `Component<BubbleContentRendererProps>` | -      | 默认内容渲染器（当无法匹配到合适的渲染器时使用）               |
+| `store`                   | `Record<string, unknown>`               | -      | 全局状态存储，用于在 BubbleList 和 Bubble 组件之间共享数据     |
 
 ## Emits
 

--- a/packages/components/src/bubble/BubbleBoxWrapper.vue
+++ b/packages/components/src/bubble/BubbleBoxWrapper.vue
@@ -15,10 +15,10 @@ const renderer = useBubbleBoxRenderer(() => props.messages, props.contentIndex)
 <template>
   <component
     :is="renderer.renderer"
+    v-bind="renderer.attributes"
     :data-role="props.role"
     :data-placement="props.placement"
     :data-shape="props.shape"
-    v-bind="renderer.attributes"
   >
     <slot />
   </component>

--- a/packages/components/src/bubble/BubbleContentWrapper.vue
+++ b/packages/components/src/bubble/BubbleContentWrapper.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { setupBubbleStateChangeFn, useBubbleContentRenderer } from './composables'
 import type { BubbleContentRendererProps } from './index.type'
 
 const props = defineProps<BubbleContentRendererProps>()
 
 const renderer = useBubbleContentRenderer(() => props.message, props.contentIndex)
+const componentProps = computed(() => ({
+  ...renderer.value.attributes,
+  message: props.message,
+  contentIndex: props.contentIndex,
+}))
 
 const emit = defineEmits<{
   (e: 'state-change', payload: { key: string; value: unknown; contentIndex: number }): void
@@ -22,5 +28,5 @@ setupBubbleStateChangeFn(handleStateChange)
 </script>
 
 <template>
-  <component :is="renderer" v-bind="props"></component>
+  <component :is="renderer.renderer" v-bind="componentProps"></component>
 </template>

--- a/packages/components/src/bubble/BubbleProvider.vue
+++ b/packages/components/src/bubble/BubbleProvider.vue
@@ -33,8 +33,16 @@ const fallbackContentRenderer = computed(() => {
   return props.fallbackContentRenderer || defaultFallbackContentRenderer
 })
 
-setupBubbleBoxRenderer({ boxRendererMatches, fallbackBoxRenderer })
-setupBubbleContentRenderer({ contentRendererMatches, fallbackContentRenderer })
+setupBubbleBoxRenderer({
+  boxRendererMatches,
+  boxAttributes: () => props.boxAttributes,
+  fallbackBoxRenderer,
+})
+setupBubbleContentRenderer({
+  contentRendererMatches,
+  contentAttributes: () => props.contentAttributes,
+  fallbackContentRenderer,
+})
 </script>
 
 <template>

--- a/packages/components/src/bubble/composables/useBubbleBoxRenderer.ts
+++ b/packages/components/src/bubble/composables/useBubbleBoxRenderer.ts
@@ -1,21 +1,26 @@
 import type { Component, ComputedRef, MaybeRefOrGetter } from 'vue'
 import { computed, inject, provide, toValue } from 'vue'
 import {
+  BUBBLE_BOX_ATTRIBUTES_KEY,
   BUBBLE_BOX_FALLBACK_RENDERER_KEY,
   BUBBLE_BOX_PROP_FALLBACK_RENDERER_KEY,
   BUBBLE_BOX_RENDERER_MATCHES_KEY,
 } from '../constants'
-import type { BubbleBoxRendererMatch, BubbleMessage } from '../index.type'
+import type { BubbleAttributes, BubbleBoxAttributesConfig, BubbleBoxRendererMatch, BubbleMessage } from '../index.type'
 import { defaultBoxRendererMatches, defaultFallbackBoxRenderer } from '../renderers/defaultRenderers'
 import { useContentResolver } from './useContentResolver'
 
 export function setupBubbleBoxRenderer(renderers: {
   boxRendererMatches?: MaybeRefOrGetter<Array<BubbleBoxRendererMatch>>
+  boxAttributes?: MaybeRefOrGetter<BubbleBoxAttributesConfig | undefined>
   fallbackBoxRenderer?: MaybeRefOrGetter<Component>
 }): void {
-  const { boxRendererMatches, fallbackBoxRenderer } = renderers
+  const { boxRendererMatches, boxAttributes, fallbackBoxRenderer } = renderers
   if (boxRendererMatches) {
     provide(BUBBLE_BOX_RENDERER_MATCHES_KEY, boxRendererMatches)
+  }
+  if (boxAttributes) {
+    provide(BUBBLE_BOX_ATTRIBUTES_KEY, boxAttributes)
   }
   if (fallbackBoxRenderer) {
     provide(BUBBLE_BOX_FALLBACK_RENDERER_KEY, fallbackBoxRenderer)
@@ -40,9 +45,10 @@ export function useBubbleBoxRenderer(
   contentIndex?: number,
 ): ComputedRef<{
   renderer: Component
-  attributes?: Record<string, string>
+  attributes?: BubbleAttributes
 }> {
   const boxRendererMatches = inject(BUBBLE_BOX_RENDERER_MATCHES_KEY, defaultBoxRendererMatches)
+  const boxAttributes = inject(BUBBLE_BOX_ATTRIBUTES_KEY, undefined)
   const fallbackBoxRenderer = inject(BUBBLE_BOX_FALLBACK_RENDERER_KEY, undefined)
   const propFallbackBoxRenderer = inject(BUBBLE_BOX_PROP_FALLBACK_RENDERER_KEY, undefined)
   const contentResolver = useContentResolver()
@@ -71,19 +77,30 @@ export function useBubbleBoxRenderer(
     const msgs = toValue(messages)
 
     const { content, index } = getContentAndIndex(msgs)
+    const resolvedBoxAttributes = (() => {
+      const attrs = toValue(boxAttributes)
+      if (!attrs) {
+        return undefined
+      }
+      return typeof attrs === 'function' ? attrs(msgs, content, index) : attrs
+    })()
 
     const match = toValue(boxRendererMatches).find((match) => match.find(msgs, content, index))
 
     if (match) {
       return {
         renderer: match.renderer,
-        attributes: match.attributes,
+        attributes: {
+          ...resolvedBoxAttributes,
+          ...match.attributes,
+        },
       }
     }
 
     // Priority: prop-level > provider-level > default
     return {
       renderer: toValue(propFallbackBoxRenderer) || toValue(fallbackBoxRenderer) || defaultFallbackBoxRenderer,
+      attributes: resolvedBoxAttributes,
     }
   })
 }

--- a/packages/components/src/bubble/composables/useBubbleContentRenderer.ts
+++ b/packages/components/src/bubble/composables/useBubbleContentRenderer.ts
@@ -1,21 +1,32 @@
 import type { Component, ComputedRef, MaybeRefOrGetter } from 'vue'
 import { computed, inject, provide, toValue } from 'vue'
 import {
+  BUBBLE_CONTENT_ATTRIBUTES_KEY,
   BUBBLE_CONTENT_FALLBACK_RENDERER_KEY,
   BUBBLE_CONTENT_PROP_FALLBACK_RENDERER_KEY,
   BUBBLE_CONTENT_RENDERER_MATCHES_KEY,
 } from '../constants'
-import type { BubbleContentRendererMatch, BubbleMessage, ChatMessageContentItem } from '../index.type'
+import type {
+  BubbleAttributes,
+  BubbleContentAttributesConfig,
+  BubbleContentRendererMatch,
+  BubbleMessage,
+  ChatMessageContentItem,
+} from '../index.type'
 import { defaultContentRendererMatches, defaultFallbackContentRenderer } from '../renderers/defaultRenderers'
 import { useContentResolver } from './useContentResolver'
 
 export function setupBubbleContentRenderer(renderers: {
   contentRendererMatches?: MaybeRefOrGetter<Array<BubbleContentRendererMatch>>
+  contentAttributes?: MaybeRefOrGetter<BubbleContentAttributesConfig | undefined>
   fallbackContentRenderer?: MaybeRefOrGetter<Component>
 }): void {
-  const { contentRendererMatches, fallbackContentRenderer } = renderers
+  const { contentRendererMatches, contentAttributes, fallbackContentRenderer } = renderers
   if (contentRendererMatches) {
     provide(BUBBLE_CONTENT_RENDERER_MATCHES_KEY, contentRendererMatches)
+  }
+  if (contentAttributes) {
+    provide(BUBBLE_CONTENT_ATTRIBUTES_KEY, contentAttributes)
   }
   if (fallbackContentRenderer) {
     provide(BUBBLE_CONTENT_FALLBACK_RENDERER_KEY, fallbackContentRenderer)
@@ -38,8 +49,12 @@ export function setupBubblePropContentRenderer(renderers: {
 export function useBubbleContentRenderer(
   message: MaybeRefOrGetter<BubbleMessage>,
   contentIndex: number,
-): ComputedRef<Component> {
+): ComputedRef<{
+  renderer: Component
+  attributes?: BubbleAttributes
+}> {
   const contentRendererMatches = inject(BUBBLE_CONTENT_RENDERER_MATCHES_KEY, defaultContentRendererMatches)
+  const contentAttributes = inject(BUBBLE_CONTENT_ATTRIBUTES_KEY, undefined)
   const fallbackContentRenderer = inject(BUBBLE_CONTENT_FALLBACK_RENDERER_KEY, undefined)
   const propFallbackContentRenderer = inject(BUBBLE_CONTENT_PROP_FALLBACK_RENDERER_KEY, undefined)
   const contentResolver = useContentResolver()
@@ -50,12 +65,29 @@ export function useBubbleContentRenderer(
     const content = Array.isArray(resolvedContent)
       ? (resolvedContent.at(contentIndex ?? 0) as ChatMessageContentItem)
       : { type: 'text', text: resolvedContent || '' }
+    const resolvedProviderAttributes = (() => {
+      const attrs = toValue(contentAttributes)
+      if (!attrs) {
+        return undefined
+      }
+      return typeof attrs === 'function' ? attrs(msg, content, contentIndex) : attrs
+    })()
     const match = toValue(contentRendererMatches).find((match) => match.find(msg, content, contentIndex))
     if (match) {
-      return match.renderer
+      return {
+        renderer: match.renderer,
+        attributes: {
+          ...resolvedProviderAttributes,
+          ...match.attributes,
+        },
+      }
     }
 
     // Priority: prop-level > provider-level > default
-    return toValue(propFallbackContentRenderer) || toValue(fallbackContentRenderer) || defaultFallbackContentRenderer
+    return {
+      renderer:
+        toValue(propFallbackContentRenderer) || toValue(fallbackContentRenderer) || defaultFallbackContentRenderer,
+      attributes: resolvedProviderAttributes,
+    }
   })
 }

--- a/packages/components/src/bubble/constants.ts
+++ b/packages/components/src/bubble/constants.ts
@@ -1,5 +1,11 @@
 import type { Component, InjectionKey, MaybeRefOrGetter } from 'vue'
-import { BubbleBoxRendererMatch, BubbleContentRendererMatch, BubbleMessageGroup } from './index.type'
+import {
+  BubbleBoxAttributesConfig,
+  BubbleBoxRendererMatch,
+  BubbleContentAttributesConfig,
+  BubbleContentRendererMatch,
+  BubbleMessageGroup,
+} from './index.type'
 
 /**
  * Injection key for bubble message group
@@ -14,6 +20,9 @@ export const BUBBLE_BOX_RENDERER_MATCHES_KEY: InjectionKey<MaybeRefOrGetter<Arra
 export const BUBBLE_BOX_FALLBACK_RENDERER_KEY: InjectionKey<MaybeRefOrGetter<Component>> =
   Symbol('bubble-box-fallback-renderer')
 
+export const BUBBLE_BOX_ATTRIBUTES_KEY: InjectionKey<MaybeRefOrGetter<BubbleBoxAttributesConfig | undefined>> =
+  Symbol('bubble-box-attributes')
+
 export const BUBBLE_BOX_PROP_FALLBACK_RENDERER_KEY: InjectionKey<MaybeRefOrGetter<Component | undefined>> = Symbol(
   'bubble-box-prop-fallback-renderer',
 )
@@ -24,6 +33,9 @@ export const BUBBLE_CONTENT_RENDERER_MATCHES_KEY: InjectionKey<MaybeRefOrGetter<
 export const BUBBLE_CONTENT_FALLBACK_RENDERER_KEY: InjectionKey<MaybeRefOrGetter<Component>> = Symbol(
   'bubble-content-fallback-renderer',
 )
+
+export const BUBBLE_CONTENT_ATTRIBUTES_KEY: InjectionKey<MaybeRefOrGetter<BubbleContentAttributesConfig | undefined>> =
+  Symbol('bubble-content-attributes')
 
 export const BUBBLE_CONTENT_PROP_FALLBACK_RENDERER_KEY: InjectionKey<MaybeRefOrGetter<Component | undefined>> = Symbol(
   'bubble-content-prop-fallback-renderer',

--- a/packages/components/src/bubble/index.type.ts
+++ b/packages/components/src/bubble/index.type.ts
@@ -62,6 +62,23 @@ export type BubbleMessageGroup = {
   startIndex: number
 }
 
+export type BubbleAttributes = Record<string, unknown>
+
+export type BubbleBoxAttributesResolver = (
+  messages: BubbleMessage[],
+  content: ChatMessageContentItem | undefined,
+  contentIndex: number | undefined,
+) => BubbleAttributes | undefined
+
+export type BubbleContentAttributesResolver = (
+  message: BubbleMessage,
+  content: ChatMessageContentItem,
+  contentIndex: number,
+) => BubbleAttributes | undefined
+
+export type BubbleBoxAttributesConfig = BubbleAttributes | BubbleBoxAttributesResolver
+export type BubbleContentAttributesConfig = BubbleAttributes | BubbleContentAttributesResolver
+
 export type BubbleBoxRendererMatch = {
   /**
    * 匹配函数，用于判断是否应该使用此渲染器
@@ -77,7 +94,7 @@ export type BubbleBoxRendererMatch = {
   ) => boolean
   renderer: Component<BubbleBoxRendererProps>
   priority?: number
-  attributes?: Record<string, string>
+  attributes?: BubbleAttributes
 }
 
 export type BubbleContentRendererMatch = {
@@ -91,7 +108,7 @@ export type BubbleContentRendererMatch = {
   find: (message: BubbleMessage, content: ChatMessageContentItem, contentIndex: number) => boolean
   renderer: Component<BubbleContentRendererProps>
   priority?: number
-  attributes?: Record<string, string>
+  attributes?: BubbleAttributes
 }
 
 export type BubbleBoxRendererProps = Pick<BubbleProps, 'placement' | 'shape'>
@@ -169,6 +186,8 @@ export interface BubbleListProps {
 export interface BubbleProviderProps {
   boxRendererMatches?: BubbleBoxRendererMatch[]
   contentRendererMatches?: BubbleContentRendererMatch[]
+  boxAttributes?: BubbleBoxAttributesConfig
+  contentAttributes?: BubbleContentAttributesConfig
   fallbackBoxRenderer?: Component<BubbleBoxRendererProps>
   fallbackContentRenderer?: Component<BubbleContentRendererProps>
   store?: Record<string, unknown>

--- a/packages/components/src/bubble/renderers/Reasoning.vue
+++ b/packages/components/src/bubble/renderers/Reasoning.vue
@@ -4,6 +4,10 @@ import { nextTick, ref, watch, watchEffect } from 'vue'
 import { useBubbleContentRenderer, useBubbleStateChangeFn, useOmitMessageFields } from '../composables'
 import { BubbleContentRendererProps, ChatMessageContent } from '../index.type'
 
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = defineProps<
   BubbleContentRendererProps<
     ChatMessageContent,
@@ -52,7 +56,7 @@ watch(
 </script>
 
 <template>
-  <div class="tr-bubble__reasoning" data-type="reasoning">
+  <div class="tr-bubble__reasoning" data-type="reasoning" v-bind="$attrs">
     <div class="header" @click="handleClick">
       <div class="icon-and-text" :class="{ thinking: props.message.state?.thinking }">
         <IconAtom />
@@ -70,7 +74,7 @@ watch(
       <p class="detail-content" ref="detailRef">{{ props.message.reasoning_content }}</p>
     </div>
   </div>
-  <component :is="renderer" v-bind="restProps" />
+  <component :is="renderer.renderer" v-bind="{ ...renderer.attributes, ...restProps }" />
 </template>
 
 <style lang="less" scoped>

--- a/packages/components/src/bubble/renderers/Tools.vue
+++ b/packages/components/src/bubble/renderers/Tools.vue
@@ -3,6 +3,10 @@ import { useBubbleContentRenderer, useOmitMessageFields } from '../composables'
 import { BubbleContentRendererProps } from '../index.type'
 import Tool from './Tool.vue'
 
+defineOptions({
+  inheritAttrs: false,
+})
+
 const props = defineProps<BubbleContentRendererProps>()
 
 const { restMessage, restProps } = useOmitMessageFields(props, ['tool_calls'])
@@ -11,6 +15,8 @@ const renderer = useBubbleContentRenderer(restMessage, props.contentIndex)
 </script>
 
 <template>
-  <component :is="renderer" v-bind="restProps" />
-  <Tool v-for="(tool, index) in props.message.tool_calls" :key="tool.id" v-bind="props" :tool-call-index="index" />
+  <component :is="renderer.renderer" v-bind="{ ...renderer.attributes, ...restProps }" />
+  <div class="tr-bubble__tools" v-bind="$attrs">
+    <Tool v-for="(tool, index) in props.message.tool_calls" :key="tool.id" v-bind="props" :tool-call-index="index" />
+  </div>
 </template>


### PR DESCRIPTION
## 背景

当前如果想给所有 Box / Content 统一注入 attributes，只依赖 renderer match 不够稳定，因为无法保证所有消息都会匹配到自定义 renderer。

## 改动

- 在 `BubbleProvider` 新增 `boxAttributes` 和 `contentAttributes`
- 支持静态对象和基于上下文的动态 resolver
- `Box` / `Content` 两条渲染链路统一支持 attributes 合并
- 补齐 `useBubbleContentRenderer` 的 attributes 返回能力
- 更新文档并新增 demo 展示 provider 级 attributes 的用法

## 验证

- 已新增 demo：`docs/demos/bubble/provider-attributes.vue`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider-level attribute injection for bubbles via new box/content props; supports static objects or resolver functions and merges provider attributes with renderer-specific attributes.
  * Renderers now preserve and forward injected attributes so custom renderers receive provider metadata.

* **Documentation**
  * Expanded docs and new interactive demos showing attribute injection, composite/recursive renderer patterns, and examples for binding injected attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->