### PR TITLE
fix(attachments): normalize attachment list handling and add test cases

### DIFF
--- a/docs/src/components/attachments.md
+++ b/docs/src/components/attachments.md
@@ -114,7 +114,7 @@ export interface BaseAttachment {
 // URL 文件类型 - 已有远程URL的文件
 export interface UrlAttachment extends BaseAttachment {
   url: string
-  size: number
+  size?: number
   rawFile?: File
 }
 

--- a/packages/components/src/attachments/composables/useFileType.ts
+++ b/packages/components/src/attachments/composables/useFileType.ts
@@ -1,5 +1,6 @@
 import { computed, Component, ComputedRef } from 'vue'
 import { FileType, BaseFileType, FileTypeMatcher, Attachment, RawFileAttachment, UrlAttachment } from '../index.type'
+import { getStringDetectionCandidates, getUrlDisplayName } from '../utils'
 import {
   IconFileImage,
   IconFilePdf,
@@ -160,9 +161,14 @@ export function useFileType(options: UseFileTypeOptions = {}) {
    */
   const detectFileType = (file: File | string): FileType => {
     const matchers = getAllMatchers()
+    const stringCandidates = typeof file === 'string' ? getStringDetectionCandidates(file) : []
 
     for (const matcher of matchers) {
-      if (matcher.matcher(file)) {
+      if (typeof file !== 'string' && matcher.matcher(file)) {
+        return matcher.type
+      }
+
+      if (typeof file === 'string' && stringCandidates.some((candidate) => matcher.matcher(candidate))) {
         return matcher.type
       }
     }
@@ -191,11 +197,11 @@ export function useFileType(options: UseFileTypeOptions = {}) {
   }
 
   type RawFileItem = RawFileAttachment
-  type UrlSizeItem = UrlAttachment
-  type InputItem = RawFileItem | UrlSizeItem | Partial<Attachment>
+  type UrlItem = UrlAttachment
+  type InputItem = Attachment | Partial<Attachment>
 
-  const isUrlSizeItem = (item: InputItem): item is UrlSizeItem => {
-    return typeof item.url === 'string' && !!item.url && typeof item.size === 'number'
+  const isUrlItem = (item: InputItem): item is UrlItem => {
+    return typeof item.url === 'string' && !!item.url
   }
 
   const isRawFileItem = (item: InputItem): item is RawFileItem => {
@@ -208,13 +214,15 @@ export function useFileType(options: UseFileTypeOptions = {}) {
    * @returns 标准化的文件附件对象列表
    */
   const normalizeAttachments = (items: InputItem[]): Attachment[] => {
-    return items.map((item) => {
-      if (isUrlSizeItem(item)) {
-        return transformUrlItem(item)
-      } else if (isRawFileItem(item)) {
-        return transformRawFileItem(item)
+    return items.reduce<Attachment[]>((normalizedItems, item) => {
+      if (isRawFileItem(item)) {
+        normalizedItems.push(transformRawFileItem(item))
+      } else if (isUrlItem(item)) {
+        normalizedItems.push(transformUrlItem(item))
       }
-    }) as Attachment[]
+
+      return normalizedItems
+    }, [])
   }
 
   type CommonProps = Pick<Attachment, 'id' | 'name' | 'status' | 'message'>
@@ -227,20 +235,23 @@ export function useFileType(options: UseFileTypeOptions = {}) {
   })
 
   /**
-   * 根据文件URL和大小更新文件附件对象
-   * @param item 含url和size的原始数据
+   * 根据文件URL更新文件附件对象
+   * @param item 含url的原始数据
    * @returns 标准化的UrlAttachment对象
    */
-  const transformUrlItem = (item: UrlSizeItem): UrlAttachment => {
+  const transformUrlItem = (item: UrlItem): UrlAttachment => {
     const common = getCommonProps(item)
     const url = item.url!
-    const size = item.size!
-    const parsedName = url.split('/').pop() || ''
+    const urlDisplayName = getUrlDisplayName(url)
+    const resolvedName = common.name || urlDisplayName
+    const fileTypeFromName = detectFileType(resolvedName)
+    const inferredFileType = fileTypeFromName === 'other' ? detectFileType(url) : fileTypeFromName
+
     return {
       ...common,
-      name: common.name || parsedName,
-      fileType: detectFileType(parsedName),
-      size,
+      name: resolvedName,
+      fileType: item.fileType ?? inferredFileType,
+      size: item.size,
       url,
     }
   }
@@ -256,9 +267,9 @@ export function useFileType(options: UseFileTypeOptions = {}) {
     return {
       ...common,
       name: common.name || rawFile.name,
-      fileType: detectFileType(rawFile),
+      fileType: item.fileType ?? detectFileType(rawFile),
       rawFile,
-      size: item.size || rawFile.size,
+      size: item.size ?? rawFile.size,
       url: item.url,
     }
   }

--- a/packages/components/src/attachments/index.type.ts
+++ b/packages/components/src/attachments/index.type.ts
@@ -28,7 +28,7 @@ export interface BaseAttachment {
 // URL 文件类型 - 已有远程URL的文件
 export interface UrlAttachment extends BaseAttachment {
   url: string
-  size: number
+  size?: number
   rawFile?: File
 }
 

--- a/packages/components/src/attachments/index.vue
+++ b/packages/components/src/attachments/index.vue
@@ -68,9 +68,7 @@ const { normalizeAttachments } = useFileType({
 watch(
   () => props.items,
   (newItems) => {
-    if (newItems && newItems.length > 0) {
-      fileList.value = normalizeAttachments(newItems)
-    }
+    fileList.value = normalizeAttachments(newItems || [])
   },
   { deep: true, immediate: true },
 )

--- a/packages/components/src/attachments/utils.ts
+++ b/packages/components/src/attachments/utils.ts
@@ -1,4 +1,4 @@
-const FILE_NAME_QUERY_KEYS = ['filename', 'fileName', 'name'] as const
+const FILE_NAME_QUERY_KEYS = ['filename', 'fileName'] as const
 const ABSOLUTE_URL_SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/
 const PROTOCOL_RELATIVE_URL_RE = /^\/\//
 

--- a/packages/components/src/attachments/utils.ts
+++ b/packages/components/src/attachments/utils.ts
@@ -1,0 +1,112 @@
+const FILE_NAME_QUERY_KEYS = ['filename', 'fileName', 'name'] as const
+const ABSOLUTE_URL_SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/
+const PROTOCOL_RELATIVE_URL_RE = /^\/\//
+
+interface ParsedUrlLikeString {
+  pathname: string
+  searchParams: URLSearchParams
+}
+
+const safelyDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+const addStringCandidate = (candidates: string[], candidate?: string | null, shouldDecode = false) => {
+  if (!candidate) return
+
+  const normalized = (shouldDecode ? safelyDecode(candidate) : candidate).trim()
+  if (normalized && !candidates.includes(normalized)) {
+    candidates.push(normalized)
+  }
+}
+
+const parseUrlLikeString = (value: string): ParsedUrlLikeString | null => {
+  const trimmedValue = value.trim()
+  if (!trimmedValue) {
+    return null
+  }
+
+  try {
+    if (ABSOLUTE_URL_SCHEME_RE.test(trimmedValue) || PROTOCOL_RELATIVE_URL_RE.test(trimmedValue)) {
+      const parsedUrl = new URL(PROTOCOL_RELATIVE_URL_RE.test(trimmedValue) ? `https:${trimmedValue}` : trimmedValue)
+      return {
+        pathname: parsedUrl.pathname,
+        searchParams: parsedUrl.searchParams,
+      }
+    }
+  } catch {
+    return null
+  }
+
+  const [withoutHash = ''] = trimmedValue.split('#')
+  const queryIndex = withoutHash.indexOf('?')
+
+  return {
+    pathname: queryIndex === -1 ? withoutHash : withoutHash.slice(0, queryIndex),
+    searchParams: new URLSearchParams(queryIndex === -1 ? '' : withoutHash.slice(queryIndex + 1)),
+  }
+}
+
+export const getLastPathSegment = (value: string): string => {
+  const segments = value.split('/').filter(Boolean)
+  const lastSegment = segments.at(-1) || ''
+  return safelyDecode(lastSegment)
+}
+
+export const getStringDetectionCandidates = (value: string): string[] => {
+  const candidates: string[] = []
+  const trimmedValue = value.trim()
+
+  if (!trimmedValue) {
+    return candidates
+  }
+
+  addStringCandidate(candidates, trimmedValue)
+
+  const parsedUrl = parseUrlLikeString(trimmedValue)
+  if (parsedUrl) {
+    FILE_NAME_QUERY_KEYS.forEach((key) => {
+      addStringCandidate(candidates, parsedUrl.searchParams.get(key), true)
+    })
+
+    addStringCandidate(candidates, parsedUrl.pathname, true)
+    addStringCandidate(candidates, getLastPathSegment(parsedUrl.pathname))
+    return candidates
+  }
+
+  const sanitizedValue = trimmedValue.split('#')[0].split('?')[0]
+  addStringCandidate(candidates, sanitizedValue)
+  addStringCandidate(candidates, getLastPathSegment(sanitizedValue))
+
+  return candidates
+}
+
+export const getUrlDisplayName = (url: string): string => {
+  const parsedUrl = parseUrlLikeString(url)
+
+  if (parsedUrl) {
+    for (const key of FILE_NAME_QUERY_KEYS) {
+      const fileNameFromQuery = parsedUrl.searchParams.get(key)
+      if (fileNameFromQuery?.trim()) {
+        return safelyDecode(fileNameFromQuery.trim())
+      }
+    }
+
+    const pathSegment = getLastPathSegment(parsedUrl.pathname)
+    if (pathSegment) {
+      return pathSegment
+    }
+
+    const normalizedPath = safelyDecode(parsedUrl.pathname).replace(/^\/+/, '').trim()
+    if (normalizedPath) {
+      return normalizedPath
+    }
+  }
+
+  const sanitizedUrl = url.trim().split('#')[0].split('?')[0]
+  return getLastPathSegment(sanitizedUrl) || sanitizedUrl
+}

--- a/packages/test/src/App.vue
+++ b/packages/test/src/App.vue
@@ -4,6 +4,7 @@
     <nav>
       <ul>
         <li><a href="/" @click.prevent="currentComponent = 'Home'">首页</a></li>
+        <li><a href="/attachments" @click.prevent="currentComponent = 'Attachments'">Attachments 组件</a></li>
         <li><a href="/container" @click.prevent="currentComponent = 'Container'">Container 组件</a></li>
         <li><a href="/sender" @click.prevent="currentComponent = 'Sender'">Sender 组件</a></li>
       </ul>
@@ -19,15 +20,17 @@
 import { computed, ref } from 'vue'
 import type { Component } from 'vue'
 import Home from './home/index.vue'
+import AttachmentsDemo from './attachments/index.vue'
 import ContainerDemo from './container/index.vue'
 import SenderDemo from './sender/index.vue'
 
-type ComponentName = 'Home' | 'Container' | 'Sender'
+type ComponentName = 'Home' | 'Attachments' | 'Container' | 'Sender'
 
 const currentComponent = ref<ComponentName>('Home')
 
 const components: Record<ComponentName, Component> = {
   Home,
+  Attachments: AttachmentsDemo,
   Container: ContainerDemo,
   Sender: SenderDemo,
 }

--- a/packages/test/src/attachments/index.spec.ts
+++ b/packages/test/src/attachments/index.spec.ts
@@ -4,7 +4,7 @@ test.describe('Attachments 组件测试', () => {
   test.beforeEach(async ({ page }: { page: Page }) => {
     await page.goto('/')
     await page.click('text=Attachments 组件')
-    await expect(page.locator('h2')).toContainText('Attachments 组件测试')
+    await expect(page.getByRole('heading', { level: 2, name: 'Attachments 组件测试' })).toBeVisible()
   })
 
   test('应支持仅传入 url 的远程附件', async ({ page }) => {

--- a/packages/test/src/attachments/index.spec.ts
+++ b/packages/test/src/attachments/index.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type Page } from '@playwright/test'
+
+test.describe('Attachments 组件测试', () => {
+  test.beforeEach(async ({ page }: { page: Page }) => {
+    await page.goto('/')
+    await page.click('text=Attachments 组件')
+    await expect(page.locator('h2')).toContainText('Attachments 组件测试')
+  })
+
+  test('应支持仅传入 url 的远程附件', async ({ page }) => {
+    const section = page.locator('[data-testid="url-only-section"]')
+
+    await expect(section.locator('.tr-file-card')).toHaveCount(1)
+    await expect(section.locator('.tr-file-card__name')).toContainText('project-summary.pdf')
+    await expect(section.locator('.tr-file-card__file-size')).toHaveCount(0)
+  })
+
+  test('应保留用户显式传入的 fileType', async ({ page }) => {
+    const section = page.locator('[data-testid="custom-type-section"]')
+    const card = section.locator('[data-file-type="md"]')
+
+    await expect(card).toHaveCount(1)
+    await expect(card.locator('.tr-file-card__file-type')).toContainText('MD')
+  })
+
+  test('无后缀 url 时应优先使用 name 推断文件类型', async ({ page }) => {
+    const section = page.locator('[data-testid="name-priority-section"]')
+    const card = section.locator('[data-file-type="word"]')
+
+    await expect(card).toHaveCount(1)
+    await expect(card.locator('.tr-file-card__name')).toContainText('meeting-notes.docx')
+    await expect(card.locator('.tr-file-card__file-type')).toContainText('WORD')
+  })
+
+  test('应从 query filename 参数中提取文件名和类型', async ({ page }) => {
+    const section = page.locator('[data-testid="query-filename-section"]')
+    const card = section.locator('[data-file-type="pdf"]')
+
+    await expect(card).toHaveCount(1)
+    await expect(card.locator('.tr-file-card__name')).toContainText('quarterly-report.pdf')
+    await expect(card.locator('.tr-file-card__file-type')).toContainText('PDF')
+  })
+
+  test('应正确处理带 query 和 hash 的资源 url', async ({ page }) => {
+    const section = page.locator('[data-testid="query-hash-url-section"]')
+    const card = section.locator('[data-file-type="image"]')
+
+    await expect(card).toHaveCount(1)
+    await expect(card.locator('.tr-file-card__name')).toContainText('image-cover.png')
+    await expect(card.locator('.tr-file-card__file-type')).toContainText('IMAGE')
+  })
+
+  test('本地文件给全量字段时仍应优先按 rawFile 识别类型', async ({ page }) => {
+    const section = page.locator('[data-testid="local-full-fields-section"]')
+    const card = section.locator('[data-file-type="word"]')
+
+    await expect(card).toHaveCount(1)
+    await expect(card.locator('.tr-file-card__name')).toContainText('contract.docx')
+    await expect(card.locator('.tr-file-card__file-type')).toContainText('WORD')
+  })
+
+  test('rawFile 搭配预览 url 时应优先保留本地文件信息', async ({ page }) => {
+    const section = page.locator('[data-testid="local-file-section"]')
+
+    await expect(section.locator('.tr-file-card')).toHaveCount(1)
+    await expect(section.locator('.tr-file-card__name')).toContainText('notes.txt')
+  })
+
+  test('父级清空 items 后应同步清空附件列表', async ({ page }) => {
+    const section = page.locator('[data-testid="url-only-section"]')
+
+    await expect(section.locator('.tr-file-card')).toHaveCount(1)
+    await page.getByTestId('url-only-clear').click()
+    await expect(section.locator('.tr-file-card')).toHaveCount(0)
+  })
+})

--- a/packages/test/src/attachments/index.vue
+++ b/packages/test/src/attachments/index.vue
@@ -1,0 +1,162 @@
+<template>
+  <div class="attachments-test">
+    <h2>Attachments 组件测试</h2>
+    <p>这里用于验证附件数据规范化后的渲染表现。</p>
+
+    <section class="attachments-test__section" data-testid="url-only-section">
+      <div class="attachments-test__header">
+        <h3>URL 无 size</h3>
+        <button data-testid="url-only-clear" type="button" @click="urlOnlyItems = []">清空列表</button>
+      </div>
+      <TrAttachments v-model:items="urlOnlyItems" variant="card" />
+    </section>
+
+    <section class="attachments-test__section" data-testid="custom-type-section">
+      <h3>显式 fileType 保留</h3>
+      <TrAttachments v-model:items="customTypeItems" variant="card" />
+    </section>
+
+    <section class="attachments-test__section" data-testid="name-priority-section">
+      <h3>name 优先于无后缀 URL</h3>
+      <TrAttachments v-model:items="namePriorityItems" variant="card" />
+    </section>
+
+    <section class="attachments-test__section" data-testid="query-filename-section">
+      <h3>query filename 推断</h3>
+      <TrAttachments v-model:items="queryFilenameItems" variant="card" />
+    </section>
+
+    <section class="attachments-test__section" data-testid="query-hash-url-section">
+      <h3>query + hash URL 推断</h3>
+      <TrAttachments v-model:items="queryHashItems" variant="card" />
+    </section>
+
+    <section class="attachments-test__section" data-testid="local-full-fields-section">
+      <h3>本地文件全量字段优先按 rawFile 识别</h3>
+      <TrAttachments v-model:items="localFullFieldItems" variant="card" />
+    </section>
+
+    <section class="attachments-test__section" data-testid="local-file-section">
+      <h3>本地文件 + 预览 URL</h3>
+      <TrAttachments v-model:items="localItems" variant="card" />
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onUnmounted, ref } from 'vue'
+import { TrAttachments } from '@opentiny/tiny-robot'
+import type { Attachment } from '@opentiny/tiny-robot'
+
+const createdObjectUrls: string[] = []
+
+const createLocalAttachment = (): Attachment => {
+  const rawFile = new File(['hello attachments'], 'notes.txt', { type: 'text/plain' })
+  const objectUrl = URL.createObjectURL(rawFile)
+  createdObjectUrls.push(objectUrl)
+
+  return {
+    id: 'local-file',
+    rawFile,
+    url: objectUrl,
+    status: 'success',
+  }
+}
+
+const urlOnlyItems = ref<Attachment[]>([
+  {
+    id: 'url-only',
+    url: 'https://example.com/files/project-summary.pdf',
+    status: 'success',
+  },
+])
+
+const customTypeItems = ref<Attachment[]>([
+  {
+    id: 'custom-type',
+    name: 'README.md',
+    url: 'https://example.com/files/README.bin',
+    fileType: 'md',
+    size: 1024,
+    status: 'success',
+  },
+])
+
+const namePriorityItems = ref<Attachment[]>([
+  {
+    id: 'name-priority',
+    name: 'meeting-notes.docx',
+    url: 'https://example.com/download?id=18',
+    status: 'success',
+  },
+])
+
+const queryFilenameItems = ref<Attachment[]>([
+  {
+    id: 'query-filename',
+    url: 'https://example.com/download?filename=quarterly-report.pdf&token=abc',
+    status: 'success',
+  },
+])
+
+const queryHashItems = ref<Attachment[]>([
+  {
+    id: 'query-hash',
+    url: 'https://example.com/assets/image-cover.png?token=1#viewer',
+    status: 'success',
+  },
+])
+
+const localFullFieldItems = ref<Attachment[]>([
+  {
+    id: 'local-full-fields',
+    rawFile: new File(['contract body'], 'contract.docx', {
+      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    }),
+    name: 'contract.docx',
+    size: 2048,
+    url: 'https://example.com/previews/upload-success.png',
+    status: 'success',
+  },
+])
+
+const localItems = ref<Attachment[]>([createLocalAttachment()])
+
+onUnmounted(() => {
+  createdObjectUrls.forEach((url) => URL.revokeObjectURL(url))
+})
+</script>
+
+<style scoped>
+.attachments-test {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.attachments-test__section {
+  margin-top: 24px;
+  padding: 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+}
+
+.attachments-test__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.attachments-test__header button {
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.attachments-test__header button:hover {
+  background: #f9fafb;
+}
+</style>

--- a/packages/test/src/home/index.vue
+++ b/packages/test/src/home/index.vue
@@ -6,6 +6,7 @@
     <div class="test-info">
       <h3>可用测试组件</h3>
       <ul>
+        <li><strong>Attachments 组件</strong> - 验证附件列表的数据规范化、渲染和清空同步行为。</li>
         <li><strong>Container 组件</strong> - 验证容器组件的显示、隐藏、全屏切换等行为。</li>
         <li><strong>Sender 组件</strong> - 验证输入、提交、Mention、Template、Suggestion 等行为。</li>
       </ul>


### PR DESCRIPTION
<h3>问题</h3>
<p><code>normalizeAttachments</code> 在处理输入数据时存在两个缺陷：</p>
<ol>
<li><strong>缺少兜底分支</strong>：<code>items.map()</code> 回调只处理了 <code>isUrlSizeItem</code>（有 url + size）和 <code>isRawFileItem</code>（有 rawFile）两种情况，不符合任一条件的 item 返回 <code>undefined</code>，被 <code>as Attachment[]</code> 强转掩盖。</li>
<li><strong><code>isUrlSizeItem</code> 判定过严</strong>：要求 <code>typeof item.size === 'number'</code>，导致只传 <code>url</code> 不传 <code>size</code> 的远程附件（这是合理的使用方式）无法被识别，落入无人处理的分支变成 <code>undefined</code>。</li>
</ol>
<p>此外，<code>watch</code> 中 <code>if (newItems &amp;&amp; newItems.length &gt; 0)</code> 的守卫导致父组件清空 <code>items</code> 时 <code>fileList</code> 不会同步清空。</p>
<h3>改动</h3>
<p><strong>commit 1</strong> <code>5f5c01bd</code> — 核心修复（5 个文件）</p>
<p><code>useFileType.ts</code>：</p>
<ul>
<li><code>map</code> 改为 <code>reduce</code>，只有匹配到的 item 才 push 进结果，不匹配的跳过而非返回 <code>undefined</code></li>
<li><code>isRawFileItem</code> 判定优先于 <code>isUrlItem</code>（有 rawFile 的即使同时带 url 也走本地文件路径）</li>
<li><code>isUrlItem</code> 去掉 <code>size</code> 的强制要求，只要有 <code>url</code> 即可</li>
<li><code>transformUrlItem</code> 中：用 <code>getUrlDisplayName(url)</code> 替代简单的 <code>url.split('/').pop()</code>，支持从 query 参数提取文件名；<code>item.fileType ?? inferredFileType</code> 尊重用户显式传入的 fileType</li>
<li><code>transformRawFileItem</code> 中：<code>item.fileType ?? detectFileType(rawFile)</code> 同样尊重用户传入值；<code>item.size ?? rawFile.size</code> 用 <code>??</code> 替代 <code>||</code></li>
</ul>
<p><code>index.type.ts</code> + <code>docs/src/components/attachments.md</code>：</p>
<ul>
<li><code>UrlAttachment.size</code> 从 <code>number</code> 改为 <code>number?</code>，类型与逻辑对齐</li>
</ul>
<p><code>index.vue</code>：</p>
<ul>
<li>watch 中去掉 <code>newItems.length &gt; 0</code> 守卫，改为 <code>normalizeAttachments(newItems || [])</code>，父组件清空时同步清空</li>
</ul>
<p><code>utils.ts</code>（新增）：</p>
<ul>
<li><code>getStringDetectionCandidates</code>：为 URL 字符串生成多个候选值（原始值、query 参数中的 filename、pathname、最后一段路径），供 <code>detectFileType</code> 逐一匹配</li>
<li><code>getUrlDisplayName</code>：从 URL 中提取人类可读的文件名，优先级为 query 参数 &gt; 最后一段路径 &gt; 完整路径</li>
<li>支持绝对 URL、协议相对 URL、带 hash/query 的路径等多种格式</li>
</ul>
<p><strong>commit 2</strong> <code>f39c9c6f</code> — E2E 测试（4 个文件）</p>
<ul>
<li>新增 <code>packages/test/src/attachments/index.vue</code> 测试页面，覆盖 7 种数据输入场景</li>
<li>新增 <code>packages/test/src/attachments/index.spec.ts</code>，8 个 Playwright 测试用例</li>
<li>注册到测试应用路由</li>
</ul>
<h3>测试覆盖</h3>

用例 | 验证点
-- | --
仅传 url 无 size 的远程附件 | issue 核心场景，修复前为 undefined
显式 fileType 保留 | item.fileType ?? inferred 不覆盖用户值
name 优先于无后缀 URL 推断类型 | name 有后缀时优先用 name 推断
query filename 参数提取 | ?filename=report.pdf 正确提取
带 query + hash 的资源 URL | image.png?token=1#viewer 正确解析
rawFile 全量字段优先按 rawFile 识别 | rawFile 路径优先于 url 路径
rawFile + 预览 url 保留本地文件信息 | 有 rawFile 时 name 取自 rawFile
父级清空 items 同步清空列表 | watch 守卫修复验证


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where clearing attachment items failed to properly update the displayed list.

* **New Features**
  * Made file size an optional property for URL-based attachments, allowing leaner attachment configurations.
  * Enhanced automatic detection of file types from both uploaded files and URLs with intelligent fallback inference.
  * Improved extraction of display names from URL query parameters and file path segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->