### PR TITLE
fix(docs): refine dark mode navigation and code block styles

### DIFF
--- a/docs/.vitepress/theme/components/TabNavigation.vue
+++ b/docs/.vitepress/theme/components/TabNavigation.vue
@@ -156,6 +156,8 @@ onUnmounted(() => {
 
 <style lang="less" scoped>
 .custom-tabs {
+  --custom-tabs-active-color: var(--vp-c-text-1);
+  --custom-tabs-active-indicator: var(--custom-tabs-active-color);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -193,13 +195,13 @@ onUnmounted(() => {
       bottom: 0;
       width: 0;
       height: 2px;
-      background: #191919;
+      background: var(--custom-tabs-active-indicator);
       border-radius: 1px;
       transition: all 0.3s ease;
       transform: translateX(0);
 
       &--active {
-        background: #191919;
+        background: var(--custom-tabs-active-indicator);
       }
     }
 
@@ -209,11 +211,11 @@ onUnmounted(() => {
     }
 
     &--active {
-      color: #191919;
+      color: var(--custom-tabs-active-color);
       font-weight: 600;
 
       .custom-tabs__item-title {
-        color: #191919;
+        color: var(--custom-tabs-active-color);
         font-weight: 600;
       }
     }
@@ -258,7 +260,11 @@ onUnmounted(() => {
     }
 
     &--active {
-      color: #191919;
+      color: var(--custom-tabs-active-color);
+
+      .custom-tabs__item-title {
+        color: var(--custom-tabs-active-color);
+      }
     }
 
     &--disabled {

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -77,7 +77,7 @@ div:has(h1[id='bubble-气泡组件']) {
 /* 侧边栏项目样式增强 */
 .VPSidebarItem .link {
   border-radius: 12px;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease;
   position: relative;
 }
 

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -98,6 +98,21 @@ div:has(h1[id='bubble-气泡组件']) {
 .VPSidebarItem.level-1.is-link.is-active.has-active > .item .link > .text {
   color: #1476ff;
 }
+
+.dark .VPSidebarItem .link:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--vp-c-text-1);
+}
+
+.dark .VPSidebarItem.is-active .link {
+  background-color: rgba(20, 118, 255, 0.14);
+  border: 1px solid rgba(20, 118, 255, 0.2);
+}
+
+.dark .VPSidebarItem.level-1.is-link.is-active.has-active > .item .link > .text {
+  color: var(--vp-c-brand-1);
+}
+
 .main-content .group {
   margin-top: 22px;
 }
@@ -146,8 +161,8 @@ div:has(h1[id='bubble-气泡组件']) {
   padding-top: 2rem;
 }
 .VPDoc .vp-doc .vp-adaptive-theme {
-  background: #ffffff;
-  border: 1px solid #e8e8e8;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
 }
 
 .VPDocAside {


### PR DESCRIPTION
## 变更说明

本次主要优化了文档站点在暗色模式下的导航与内容展示样式，重点解决了激活态颜色硬编码、侧边栏高亮过亮，以及代码块容器在暗色模式下偏白的问题。


[文档效果预览👉](https://sonyleo.github.io/tiny-robot/alpha/guide/quick-start.html)

> 如果预览失败刷新几次，应该就可以看哈

## 修改内容

- 顶部 Tab 导航激活态改为使用主题变量，移除硬编码深色文字
- 顶部 Tab 激活条改为复用激活文字颜色，实现亮色/暗色下的黑白自适应切换
- 优化左侧侧边栏在暗色模式下的 hover 和 active 样式，降低高亮刺眼感
- 修复代码块外层容器在暗色模式下仍然使用白色背景的问题，改为跟随 VitePress 主题变量

## 修改前

### 顶部导航
- 激活文字和激活条存在硬编码颜色
- 暗色模式下激活态容易与背景冲突，视觉表现不稳定

### 左侧侧边栏
- 激活项背景偏白，暗色模式下对比过强，观感较刺眼
- hover 态沿用了浅色模式思路，不够协调

### 代码块区域
- 代码块外层容器使用固定白色背景和浅色边框
- 暗色模式下整体区域发白，和页面环境不一致

## 修改后

### 顶部导航
- 激活文字统一走主题变量
- 激活条与激活文字复用同一色值，亮色下为深色，暗色下为浅色
- 导航激活态在两种主题下都更自然一致

### 左侧侧边栏
- 暗色模式下 hover 态改为轻量提亮
- 激活项改为低透明度品牌色背景，减少刺眼感
- 激活态仍然清晰，但整体更柔和

### 代码块区域
- 外层容器背景和边框改为使用主题变量
- 暗色模式下代码块不再出现明显白底，和页面整体风格保持一致

## 截图对比

### 修改前
- 顶部导航激活态

<img width="431" height="74" alt="image" src="https://github.com/user-attachments/assets/170cd9a0-e409-44c6-8e29-eab1198ee9a0" />

- 左侧侧边栏激活态

<img width="1081" height="603" alt="image" src="https://github.com/user-attachments/assets/7796c654-5e54-4600-889d-49b0d9f1fefb" />

- 暗色模式代码块样式

<img width="739" height="294" alt="image" src="https://github.com/user-attachments/assets/84d70598-3dcf-420d-89d1-efd26ed9d7f0" />

### 修改后
- 顶部导航激活态

<img width="428" height="66" alt="image" src="https://github.com/user-attachments/assets/10701f9e-3066-4dc2-b313-af370578288f" />

- 左侧侧边栏激活态

<img width="1119" height="685" alt="image" src="https://github.com/user-attachments/assets/e0d256a2-fe95-4838-ac7f-dc20005f2668" />

- 暗色模式代码块样式

<img width="726" height="286" alt="image" src="https://github.com/user-attachments/assets/1e082efd-c276-42f5-9485-829e0a883e7a" />

## 影响范围

- 仅涉及 `docs/.vitepress/theme` 下的样式调整
- 不涉及业务逻辑、路由逻辑和组件行为变更

## 验证建议

- 在亮色模式下检查顶部导航激活态是否仍然清晰
- 在暗色模式下检查顶部导航、左侧侧边栏、代码块区域的视觉一致性
- 对比修改前后截图，确认高亮强度和整体观感是否符合预期


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined documentation theme styling for improved visual consistency across light and dark modes
  * Converted hardcoded tab active colors to configurable theme variables for easier customization
  * Improved active tab underline and indicator styling for clearer navigation cues
  * Tightened sidebar link transitions to specific properties for smoother interactions
  * Enhanced dark-mode sidebar and content container colors using theme variables

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-robot/pull/343)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->