### PR TITLE
chore: updated the playground import map to include the idb library via CDN

### DIFF
--- a/packages/playground/src/utils/import-map.ts
+++ b/packages/playground/src/utils/import-map.ts
@@ -38,7 +38,7 @@ export function generateImportMap(options: ImportMapOptions) {
       dompurify: 'https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js',
       'markdown-it': 'https://cdn.jsdelivr.net/npm/markdown-it@14/dist/markdown-it.min.js',
       echarts: 'https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js',
-      idb: 'https://cdn.jsdelivr.net/npm/idb@8.0.3/+esm',
+      idb: 'https://cdn.jsdelivr.net/npm/idb@8/+esm',
 
       // Tiptap 编辑器相关包 (用于 Sender 组件)
       // 使用 esm.sh CDN，自动处理子路径导入和依赖解析

--- a/packages/playground/src/utils/import-map.ts
+++ b/packages/playground/src/utils/import-map.ts
@@ -38,6 +38,7 @@ export function generateImportMap(options: ImportMapOptions) {
       dompurify: 'https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js',
       'markdown-it': 'https://cdn.jsdelivr.net/npm/markdown-it@14/dist/markdown-it.min.js',
       echarts: 'https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js',
+      idb: 'https://cdn.jsdelivr.net/npm/idb@8.0.3/+esm',
 
       // Tiptap 编辑器相关包 (用于 Sender 组件)
       // 使用 esm.sh CDN，自动处理子路径导入和依赖解析


### PR DESCRIPTION
修复缺少依赖导致的 playground 案例无法正常显示

**修改前：**

<img width="1920" height="953" alt="image" src="https://github.com/user-attachments/assets/4c90168d-3fd6-4eb8-97ba-a6b66d752d1a" />



**修改后：**

<img width="1920" height="953" alt="image" src="https://github.com/user-attachments/assets/4ab25aa9-a4aa-4484-8d83-8a2fad8c9868" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the playground import map to include the `idb` library (version 8.0.3) via CDN.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-robot/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->