### PR TITLE
fix(demo): update demo styles and include demo-shell.css in examples

### DIFF
--- a/docs/demos/anchor/basic-source.vue
+++ b/docs/demos/anchor/basic-source.vue
@@ -90,9 +90,9 @@ const items = sections.map((section) => ({
 }))
 </script>
 
-<style lang="less" scoped>
-@import './demo-shell.less';
+<style scoped src="./demo-shell.css"></style>
 
+<style scoped>
 .demo {
   --anchor-demo-gap: 14px;
   --anchor-demo-controls-gap: 10px 12px;
@@ -156,6 +156,7 @@ const items = sections.map((section) => ({
 }
 
 .nav {
+  top: 0;
   right: 16px;
 }
 </style>

--- a/docs/demos/anchor/controlled-search.vue
+++ b/docs/demos/anchor/controlled-search.vue
@@ -33,7 +33,7 @@
         :search-options="searchOptions"
         v-model:active-id="activeId"
         v-model:search-query="searchQuery"
-        :target-feedback-class="styles.userBubbleActive"
+        target-feedback-class="user-bubble-active"
         :target-feedback-duration="1800"
       />
     </div>
@@ -41,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, h, ref, useCssModule, watch } from 'vue'
+import { computed, h, ref, watch } from 'vue'
 import {
   TrBubbleList,
   TrBubbleProvider,
@@ -52,8 +52,6 @@ import {
 } from '@opentiny/tiny-robot'
 import { IconAi, IconUser } from '@opentiny/tiny-robot-svgs'
 import { controlledSearchMessages } from './controlled-search.messages'
-
-const styles = useCssModule()
 
 const messages = controlledSearchMessages
 
@@ -112,47 +110,23 @@ const boxAttributes: BubbleBoxAttributesConfig = (groupedMessages) => {
   }
 
   return {
-    class: styles.userBubbleTarget,
+    class: 'user-bubble-target',
     'data-anchor-id': firstMessage.id,
   }
 }
 </script>
 
-<style module lang="less">
-.userBubbleTarget {
-  --tr-bubble-box-bg: var(--tr-color-primary-light);
-  scroll-margin-top: 20px;
-}
+<style scoped src="./demo-shell.css"></style>
 
-.userBubbleActive {
-  animation: bubble-active 1.8s ease-out !important;
-}
-
-@keyframes bubble-active {
-  0%,
-  25% {
-    background-color: #b9d7ff;
-  }
-  45% {
-    background-color: var(--tr-color-primary-light);
-  }
-  65%,
-  85% {
-    background-color: #b9d7ff;
-  }
-  100% {
-    background-color: var(--tr-color-primary-light);
-  }
-}
-</style>
-
-<style lang="less" scoped>
-@import './demo-shell.less';
-
+<style scoped>
 .demo {
   --anchor-demo-gap: 16px;
   --anchor-demo-controls-gap: 12px 16px;
   --anchor-demo-stage-height: 480px;
+}
+
+.nav {
+  top: 0;
 }
 
 .placement {
@@ -168,13 +142,37 @@ const boxAttributes: BubbleBoxAttributesConfig = (groupedMessages) => {
   height: 100%;
 }
 
-.nav {
-  &.is-right {
-    right: 16px;
-  }
+.nav.is-right {
+  right: 16px;
+}
 
-  &.is-left {
-    left: 16px;
+.nav.is-left {
+  left: 16px;
+}
+
+:deep(.user-bubble-target) {
+  --tr-bubble-box-bg: var(--tr-color-primary-light);
+  scroll-margin-top: 20px;
+}
+
+:deep(.user-bubble-active) {
+  animation: user-bubble-active-flash 1.8s ease-out !important;
+}
+
+@keyframes user-bubble-active-flash {
+  0%,
+  25% {
+    background-color: #b9d7ff;
+  }
+  45% {
+    background-color: var(--tr-color-primary-light);
+  }
+  65%,
+  85% {
+    background-color: #b9d7ff;
+  }
+  100% {
+    background-color: var(--tr-color-primary-light);
   }
 }
 </style>

--- a/docs/demos/anchor/demo-shell.css
+++ b/docs/demos/anchor/demo-shell.css
@@ -32,7 +32,3 @@
   border-radius: 12px;
   background: var(--anchor-demo-stage-bg, #fff);
 }
-
-.nav {
-  top: 0;
-}

--- a/docs/src/components/anchor.md
+++ b/docs/src/components/anchor.md
@@ -12,7 +12,7 @@ outline: [1, 3]
 
 <demo
   vue="../../demos/anchor/controlled-search.vue"
-  :vueFiles="['../../demos/anchor/controlled-search.vue', '../../demos/anchor/controlled-search.messages.ts']"
+  :vueFiles="['../../demos/anchor/controlled-search.vue', '../../demos/anchor/controlled-search.messages.ts', '../../demos/anchor/demo-shell.css']"
 />
 
 使用要点：
@@ -28,7 +28,7 @@ outline: [1, 3]
 
 <demo
   vue="../../demos/anchor/basic-source.vue"
-  :vueFiles="['../../demos/anchor/basic-source.vue', '../../demos/anchor/basic-source.messages.ts']"
+  :vueFiles="['../../demos/anchor/basic-source.vue', '../../demos/anchor/basic-source.messages.ts', '../../demos/anchor/demo-shell.css']"
 />
 
 使用要点：


### PR DESCRIPTION
问题：处理 playground 无法渲染 less 和 css module 的问题

解决方案：把 css module 和 less 写法改成普通的 css 写法

**修改前**
<img width="1920" height="953" alt="image" src="https://github.com/user-attachments/assets/05b98ae2-fa03-4397-9579-44912c80c7e2" />


**修改后**
<img width="1920" height="953" alt="image" src="https://github.com/user-attachments/assets/feda633e-cc75-4642-b541-52574567d278" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated anchor component demo styling and layout for improved visual presentation.

* **Style**
  * Refined navigation positioning and active/target state styling in demo components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-robot/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->