### PR TITLE
fix(ci): replace blocked comment action in preview workflows

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -21,14 +21,44 @@ jobs:
         continue-on-error: true
 
       - name: Comment cleanup status
-        uses: actions-cool/maintain-one-comment@v3.1.1
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = process.env.COMMENT_MARKER;
+            const body = process.env.COMMENT_BODY;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existingComment = comments.find((comment) =>
+              comment.body?.includes(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMENT_MARKER: '<!-- DEPLOY_PREVIEW -->'
+          COMMENT_BODY: |
             ## 🧹 Preview Cleaned Up
 
             The preview deployment has been removed.
 
             <!-- DEPLOY_PREVIEW -->
-          body-include: '<!-- DEPLOY_PREVIEW -->'
-          number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -35,6 +35,7 @@ jobs:
               per_page: 100,
             });
             const existingComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
               comment.body?.includes(marker)
             );
 

--- a/.github/workflows/pr-deploy-preview.yml
+++ b/.github/workflows/pr-deploy-preview.yml
@@ -47,16 +47,46 @@ jobs:
         continue-on-error: true
 
       - name: Comment build generating
-        uses: actions-cool/maintain-one-comment@v3.1.1
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = process.env.COMMENT_MARKER;
+            const body = process.env.COMMENT_BODY;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existingComment = comments.find((comment) =>
+              comment.body?.includes(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          COMMENT_MARKER: '<!-- TINY_ROBOT_BUILD -->'
+          COMMENT_BODY: |
             [<img width="400" src="https://github.com/user-attachments/assets/c25bbbe4-0cf5-4aca-b4b3-db49e7a264d9">](#)
             
             🔨 Deploying preview...
             <!-- TINY_ROBOT_BUILD -->
-          body-include: '<!-- TINY_ROBOT_BUILD -->'
-          number: ${{ steps.pr.outputs.number }}
 
       - name: Post or update pkg.pr.new comment
         if: hashFiles('pkg-artifacts/pkg-pr-new-output.json') != ''
@@ -117,10 +147,42 @@ jobs:
 
       - name: Comment build success
         if: success()
-        uses: actions-cool/maintain-one-comment@v3.1.1
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = process.env.COMMENT_MARKER;
+            const body = process.env.COMMENT_BODY;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existingComment = comments.find((comment) =>
+              comment.body?.includes(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          COMMENT_MARKER: '<!-- TINY_ROBOT_BUILD -->'
+          COMMENT_BODY: |
             [<img width="400" src="https://github.com/user-attachments/assets/2a0bb639-dfaf-4384-8d73-cec616ea4b97">](https://preview-${{ steps.pr.outputs.number }}-tiny-robot.surge.sh)
             
             ✅ Preview build completed successfully!
@@ -128,18 +190,46 @@ jobs:
             > Click the image above to preview. 
             > Preview will be automatically removed when this PR is closed.  
             <!-- TINY_ROBOT_BUILD -->
-          body-include: '<!-- TINY_ROBOT_BUILD -->'
-          number: ${{ steps.pr.outputs.number }}
 
       - name: Comment build failed
         if: failure()
-        uses: actions-cool/maintain-one-comment@v3.1.1
+        uses: actions/github-script@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const marker = process.env.COMMENT_MARKER;
+            const body = process.env.COMMENT_BODY;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existingComment = comments.find((comment) =>
+              comment.body?.includes(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          COMMENT_MARKER: '<!-- TINY_ROBOT_BUILD -->'
+          COMMENT_BODY: |
             [<img width="400" src="https://github.com/user-attachments/assets/acfe799d-40be-4ffb-8190-da33f84056dc">](#)
             
             ❌ Deploy failed. Please check the logs for details.
             <!-- TINY_ROBOT_BUILD -->
-          body-include: '<!-- TINY_ROBOT_BUILD -->'
-          number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/pr-deploy-preview.yml
+++ b/.github/workflows/pr-deploy-preview.yml
@@ -61,6 +61,7 @@ jobs:
               per_page: 100,
             });
             const existingComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
               comment.body?.includes(marker)
             );
 
@@ -116,7 +117,8 @@ jobs:
             });
             
             const existingComment = comments.data.find((comment) =>
-              comment.body.includes(botCommentIdentifier)
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.includes(botCommentIdentifier)
             );
             
             if (existingComment) {
@@ -161,6 +163,7 @@ jobs:
               per_page: 100,
             });
             const existingComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
               comment.body?.includes(marker)
             );
 
@@ -207,6 +210,7 @@ jobs:
               per_page: 100,
             });
             const existingComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
               comment.body?.includes(marker)
             );
 


### PR DESCRIPTION
## 背景

`CI: Deploy Preview` 和 `CI: Docs Cleanup` 依赖 `actions-cool/maintain-one-comment` 更新 PR 评论。

该第三方 action 当前已不可用，会导致 workflow 在下载 action 阶段直接失败，报错 `Repository access blocked`。

<img width="1169" height="82" alt="image" src="https://github.com/user-attachments/assets/65ccdd87-69f3-4f46-aa17-6d378ac3a26f" />

<img width="1608" height="139" alt="image" src="https://github.com/user-attachments/assets/8d2dad60-b55a-4a3b-a550-49750bdad1a8" />


## 变更内容

- 将 `pr-deploy-preview.yml` 中用于维护 PR 评论的步骤从 `actions-cool/maintain-one-comment` 替换为 `actions/github-script`
- 将 `pr-cleanup.yml` 中用于维护 PR 评论的步骤从 `actions-cool/maintain-one-comment` 替换为 `actions/github-script`
- 保留原有行为：
  - 预览部署开始时更新评论
  - 预览部署成功时更新评论
  - 预览部署失败时更新评论
  - PR 关闭后更新清理状态评论
- 收紧已有评论的匹配逻辑，只更新 `github-actions[bot]` 创建且包含 marker 的评论，避免误更新用户评论
- 顺带收紧 `pkg.pr.new` 评论更新逻辑，统一限制为只匹配 bot 评论

## 影响文件

- `.github/workflows/pr-deploy-preview.yml`
- `.github/workflows/pr-cleanup.yml`

## 验证目标

- `CI: Deploy Preview` 不再因为 `actions-cool/maintain-one-comment` 报 `Repository access blocked`
- 预览评论可以正常创建或更新
- PR 关闭后清理评论可以正常创建或更新

## 验证截图

> ❗❗ 当前 PR 在合入前触发的仍是目标分支上的旧工作流。

> 😮 该修复已在 fork 仓库完成验证并可正常运行（以下是结果截图），需在合入后才会在目标分支正式生效。

### 评论截图

<img width="741" height="856" alt="image" src="https://github.com/user-attachments/assets/678266c1-9311-4de5-9e13-60e9c96d46c6" />

### 工作流运行结果

<img width="1108" height="357" alt="image" src="https://github.com/user-attachments/assets/9d5564f2-47d4-4d2f-8629-2737a81006eb" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored GitHub workflows for pull request management to use inline automation scripts instead of external actions, improving workflow reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opentiny/tiny-robot/pull/350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->