### PR TITLE
fix(workspace): exclude CLI template packages from workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - packages/**
+  - '!packages/cli/templates/**'
   - docs


### PR DESCRIPTION
修复问题：`lerna ERR! Error: Invalid package name "__PROJECT_NAME__": name cannot start with an underscore`

<img width="1458" height="364" alt="{EF83269B-6701-4932-8863-90F28928562A}" src="https://github.com/user-attachments/assets/899dce2c-1032-4932-bf86-bcdcdb091523" />


修改后本地测试 `pnpm lerna list --scope=@opentiny/tiny-robot --json`

<img width="1012" height="288" alt="{A135B1B7-0FB2-4E92-AD61-2B8C5192E338}" src="https://github.com/user-attachments/assets/db932caf-0e84-4b0c-ae44-a869b6d7d2fd" />
