### PR TITLE
chore: wip submitToolResult and tool approval flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md
+
+## 当前主线任务
+
+当前正在完善 `useMessage` 的工具调用确认流程，核心目标是把工具调用从“运行时 Promise 等待确认”改为“通过可序列化的消息状态和 `role: 'tool'` 结果消息继续流程”。
+
+这条线的后续重点是：给 `useMessage` 增加一个等待工具结果提交的 processing 状态，让工具确认流程可以被存储、恢复，并支持 pause/resume。
+
+## 已完成内容
+
+- 新增 `submitToolResult(message | message[])` API。
+  - core：`packages/kit/src/message/core/engine.ts`
+  - 类型：`packages/kit/src/message/types.ts`
+  - Vue 返回值：`packages/kit/src/vue/message/useMessage.ts`
+  - Vue 类型：`packages/kit/src/vue/message/types.ts`
+- `submitToolResult` 只接受 `role: 'tool'` 消息。
+- 提交 tool result 后，会检查最近一个 assistant message 的 `tool_calls` 是否都已有结果。
+- 全部 tool result 齐全后，kit 会自动继续下一轮请求。
+- `toolPlugin.confirmToolCall` 已改为布尔判断：
+  - 返回 `true`：标记工具调用为 `awaiting-approval`，不创建空 tool message，不执行 `callTool`。
+  - 返回 `false` 或未传：按原自动工具调用逻辑执行 `callTool`。
+- Vue 侧 `toolPlugin` 已同步简化，不再包装旧的 `ToolCallDecision` Promise 等待逻辑。
+- Tool 渲染器已支持 `awaiting-approval` 状态下展示“允许 / 拒绝”按钮。
+- 按钮点击通过 Bubble 的通用 `state-change` 事件发出 `toolCallDecision`，业务侧再调用 `submitToolResult`。
+- 文档 demo 已抽成组件：
+  - `docs/demos/tools/message/ToolCallConfirm.ts`
+  - `docs/demos/tools/message/ToolCallConfirm.vue`
+- 已新增后续设计 TODO：
+  - `packages/kit/TODO.md`
+
+## 后续待做
+
+主要 TODO 在 `packages/kit/TODO.md`。
+
+下一步建议实现：
+
+1. 扩展 `RequestProcessingState`，增加 `awaiting-tool-results`。
+2. 当 `toolPlugin` 发现有工具调用需要确认时：
+   - 设置对应 `state.toolCall[id].status = 'awaiting-approval'`。
+   - 设置全局 `processingState = 'awaiting-tool-results'`。
+   - 停止本轮自动 `requestNext`。
+3. `submitToolResult` 提交部分 tool result 后：
+   - 更新对应 tool call 状态。
+   - 如果仍有缺失结果，保持 `awaiting-tool-results`。
+   - 如果全部结果齐全，进入下一轮请求。
+4. 恢复会话时，根据最近一个 assistant message 的 `tool_calls` 和后续 tool messages 差集推导是否仍在等待工具结果。
+5. UI 可根据 `processingState === 'awaiting-tool-results'` 展示全局等待状态。
+
+## 关键设计约束
+
+- 不要恢复旧的 `await confirmToolCall` 内存等待方案。页面刷新后 Promise/resolver 无法恢复。
+- deny 也应该是一条 `role: 'tool'` 消息，通过 `submitToolResult` 提交。
+- 多个并行 tool call 可以部分提交，但只有全部结果齐全后才能继续请求。
+- `submitToolResult` 应只针对最近一个带 `tool_calls` 的 assistant message 生效。
+- 如果最近一个 assistant message 没有 `tool_calls`，提交 tool result 应拒绝或警告。
+- 不要通过监听变量触发工具调用，优先使用 Bubble 现有 `state-change` 事件机制。
+- 文档构建很慢，除非明确要求，不要运行 docs build。
+
+## 常用验证命令
+
+```bash
+pnpm -F @opentiny/tiny-robot-kit test -- src/vue/message/useMessage.test.ts
+pnpm -F @opentiny/tiny-robot-kit build
+```
+
+当前相关单测已覆盖：
+
+- 等待外部提交 tool result 后再继续请求。
+- 并行 tool calls 支持部分提交，全部提交后再继续。
+- Vue 侧 toolPlugin 仍能正常走自动工具调用流程。
+
+## 相关文件
+
+- `packages/kit/src/message/core/engine.ts`
+- `packages/kit/src/message/plugins/toolPlugin.ts`
+- `packages/kit/src/vue/message/plugins/toolPlugin.ts`
+- `packages/kit/src/vue/message/useMessage.ts`
+- `packages/kit/src/vue/message/useMessage.test.ts`
+- `packages/components/src/bubble/renderers/Tool.vue`
+- `packages/components/src/bubble/composables/useToolCall.ts`
+- `docs/demos/tools/message/ToolCallConfirm.ts`
+- `docs/demos/tools/message/ToolCallConfirm.vue`
+- `docs/src/tools/message.md`
+- `packages/kit/TODO.md`
+
+## 工作区注意事项
+
+当前工作区可能包含与这条任务无关的已有改动，例如：
+
+- `.gitignore`
+- `docs/.vitepress/config.mts`
+- `packages/playground/vite.config.ts`
+
+继续工作时不要随意 revert 这些文件，除非明确知道它们属于当前任务并且需要处理。

--- a/docs/demos/bubble/tool-choice.vue
+++ b/docs/demos/bubble/tool-choice.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { Bubble } from '@opentiny/tiny-robot'
+import { IconAi } from '@opentiny/tiny-robot-svgs'
+import { h, ref } from 'vue'
+
+const aiAvatar = h(IconAi, { style: { fontSize: '32px' } })
+
+const toolCalls = [
+  {
+    id: 'tool_call_id_01',
+    type: 'function',
+    function: {
+      name: '天气查询',
+      arguments: JSON.stringify({ city: '深圳' }),
+    },
+  },
+]
+
+const state = ref<{
+  toolCall: Record<string, { status?: string; open?: boolean }>
+}>({
+  toolCall: {
+    tool_call_id_01: { status: 'awaiting-approval' },
+  },
+})
+
+const selectedChoice = ref<'allow' | 'deny' | undefined>()
+const choiceText = {
+  allow: '允许',
+  deny: '拒绝',
+}
+
+const handleReset = () => {
+  selectedChoice.value = undefined
+  state.value.toolCall.tool_call_id_01.status = 'awaiting-approval'
+}
+
+const handleStateChange = (payload: { key: string; value: unknown }) => {
+  if (payload.key === 'toolCallDecision') {
+    const value = payload.value as {
+      toolCallId: string
+      decision: { action: 'allow' | 'deny' }
+    }
+
+    selectedChoice.value = value.decision.action
+    state.value.toolCall[value.toolCallId].status = value.decision.action === 'allow' ? 'success' : 'denied'
+    return
+  }
+
+  if (payload.key === 'toolCall') {
+    state.value.toolCall = payload.value as typeof state.value.toolCall
+  }
+}
+</script>
+
+<template>
+  <div style="display: flex; flex-direction: column; gap: 12px">
+    <div class="demo-toolbar">
+      <button class="reset-button" type="button" @click="handleReset">重置工具状态</button>
+      <span v-if="selectedChoice" class="choice-status" :data-choice="selectedChoice">
+        <span class="choice-dot"></span>
+        <span class="choice-label">已选择</span>
+        <strong>{{ choiceText[selectedChoice] }}</strong>
+      </span>
+    </div>
+
+    <Bubble
+      content="查询天气前需要确认。"
+      :tool_calls="toolCalls"
+      :avatar="aiAvatar"
+      :state="state"
+      @state-change="handleStateChange"
+    ></Bubble>
+  </div>
+</template>
+
+<style scoped>
+.demo-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.reset-button {
+  height: 28px;
+  padding: 0 12px;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.reset-button:hover {
+  background: var(--vp-c-default-soft);
+}
+
+.choice-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+}
+
+.choice-status strong {
+  color: var(--vp-c-text-1);
+  font-weight: 600;
+}
+
+.choice-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--vp-c-green-2);
+}
+
+.choice-status[data-choice='deny'] .choice-dot {
+  background: var(--vp-c-red-2);
+}
+
+:deep(.tr-bubble__tool-call) {
+  min-width: 350px;
+}
+</style>

--- a/docs/demos/tools/message/ToolCallConfirm.ts
+++ b/docs/demos/tools/message/ToolCallConfirm.ts
@@ -1,0 +1,107 @@
+import type { ChatCompletion, MessageRequestBody, Tool } from '@opentiny/tiny-robot-kit'
+import { toolPlugin, useMessage } from '@opentiny/tiny-robot-kit'
+
+const getTools = async (): Promise<Tool[]> => [
+  {
+    type: 'function',
+    function: {
+      name: 'search_private_docs',
+      description: '搜索内部文档。',
+      parameters: {
+        type: 'object',
+        properties: { keyword: { type: 'string' } },
+        required: ['keyword'],
+      },
+    },
+  },
+]
+
+export function useMessageToolCallConfirm() {
+  return useMessage({
+    responseProvider: mockStreamWithConfirmTools,
+    plugins: [
+      toolPlugin({
+        getTools,
+        confirmToolCall() {
+          return true
+        },
+        callTool: async (toolCall) => {
+          const args = JSON.parse(toolCall.function?.arguments || '{}')
+          return `已搜索内部文档：${args.keyword}`
+        },
+      }),
+    ],
+    initialMessages: [
+      {
+        content: '发送任意消息后，示例会模拟一次需要确认的工具调用。',
+        role: 'assistant',
+      },
+    ],
+  })
+}
+
+async function* mockStreamWithConfirmTools(
+  requestBody: MessageRequestBody,
+  abortSignal: AbortSignal,
+): AsyncGenerator<ChatCompletion> {
+  const msgs = requestBody.messages || []
+  const last = msgs[msgs.length - 1]
+  const id = 'mock-confirm-tool-' + Date.now()
+
+  if (last?.role === 'tool') {
+    const text = '工具调用已处理完成。'
+    for (let i = 0; i < text.length && !abortSignal.aborted; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 40))
+      const content = text[i]
+      yield {
+        id,
+        object: 'chat.completion.chunk',
+        created: Math.floor(Date.now() / 1000),
+        model: 'mock',
+        system_fingerprint: null,
+        choices: [
+          {
+            index: 0,
+            message: undefined,
+            delta: i === 0 ? { role: 'assistant', content } : { content },
+            finish_reason: i === text.length - 1 ? 'stop' : null,
+            logprobs: null,
+          },
+        ],
+      }
+    }
+    return
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  yield {
+    id,
+    object: 'chat.completion.chunk',
+    created: Math.floor(Date.now() / 1000),
+    model: 'mock',
+    system_fingerprint: null,
+    choices: [
+      {
+        index: 0,
+        message: undefined,
+        delta: {
+          role: 'assistant',
+          content: '这个操作需要确认后再执行。',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_confirm_search_1',
+              type: 'function',
+              function: {
+                name: 'search_private_docs',
+                arguments: '{"keyword":"Q3 roadmap"}',
+              },
+            },
+          ],
+        },
+        finish_reason: 'tool_calls',
+        logprobs: null,
+      },
+    ],
+  }
+}

--- a/docs/demos/tools/message/ToolCallConfirm.vue
+++ b/docs/demos/tools/message/ToolCallConfirm.vue
@@ -1,0 +1,80 @@
+<template>
+  <div>
+    <p class="hint">
+      使用 <code>confirmToolCall</code> 标记需要确认的工具调用，点击“允许 / 拒绝”后通过
+      <code>submitToolResult</code> 继续流程。
+    </p>
+    <tr-bubble-list :messages="messages" :role-configs="roles" @state-change="handleStateChange"></tr-bubble-list>
+    <tr-sender
+      v-model="inputMessage"
+      :placeholder="isProcessing ? '处理中...' : '发送任意消息触发确认'"
+      :clearable="true"
+      :loading="isProcessing"
+      @submit="handleSubmit"
+      @cancel="abortRequest"
+    ></tr-sender>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { TrBubbleList, TrSender } from '@opentiny/tiny-robot'
+import { type BubbleRoleConfig } from '@opentiny/tiny-robot'
+import { IconAi, IconUser } from '@opentiny/tiny-robot-svgs'
+import { h, ref } from 'vue'
+import { useMessageToolCallConfirm } from './ToolCallConfirm'
+
+const aiAvatar = h(IconAi, { style: { fontSize: '32px' } })
+const userAvatar = h(IconUser, { style: { fontSize: '32px' } })
+
+const { messages, isProcessing, sendMessage, submitToolResult, abortRequest } = useMessageToolCallConfirm()
+
+const inputMessage = ref('')
+
+function handleSubmit(content: string) {
+  sendMessage(content)
+  inputMessage.value = ''
+}
+
+function handleStateChange(payload: { key: string; value: unknown; messageIndex: number }) {
+  if (payload.key === 'toolCallDecision') {
+    const { toolCallId, decision } = payload.value as {
+      toolCallId: string
+      decision: { action: 'allow' | 'deny'; message?: string }
+    }
+
+    submitToolResult({
+      role: 'tool',
+      tool_call_id: toolCallId,
+      content:
+        decision.action === 'allow' ? '已搜索内部文档：Q3 roadmap' : decision.message || '用户拒绝了本次工具调用。',
+      metadata: {
+        toolCallStatus: decision.action === 'allow' ? 'success' : 'denied',
+      },
+    })
+    return
+  }
+
+  messages.value[payload.messageIndex].state ??= {}
+  messages.value[payload.messageIndex].state![payload.key] = payload.value
+}
+
+const roles: Record<string, BubbleRoleConfig> = {
+  assistant: { placement: 'start', avatar: aiAvatar },
+  user: { placement: 'end', avatar: userAvatar },
+  tool: { placement: 'start', avatar: aiAvatar },
+}
+</script>
+
+<style scoped>
+.hint {
+  margin-bottom: 8px;
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+}
+.hint code {
+  padding: 2px 6px;
+  background: var(--vp-c-bg-soft);
+  border-radius: 4px;
+  font-size: 13px;
+}
+</style>

--- a/docs/src/components/bubble.md
+++ b/docs/src/components/bubble.md
@@ -264,6 +264,8 @@ Bubble 组件采用渲染器架构，支持灵活的内容渲染和自定义扩�
 
 <demo vue="../../demos/bubble/tools.vue" />
 
+<demo vue="../../demos/bubble/tool-choice.vue" />
+
 #### 实现自定义渲染器
 
 **Content 渲染器**

--- a/docs/src/tools/message.md
+++ b/docs/src/tools/message.md
@@ -302,6 +302,15 @@ useMessage({
 })
 ```
 
+##### 工具调用确认示例
+
+当工具调用需要用户确认时，可以使用 `confirmToolCall` 将单个工具调用标记为等待确认。内置 Tool 渲染器会在
+`state.toolCall[toolCallId].status === 'awaiting-approval'` 时展示“允许 / 拒绝”按钮；按钮点击后通过
+Bubble 的 `state-change` 事件触发 `toolCallDecision`，业务侧执行或拒绝工具调用，并通过 `submitToolResult`
+提交对应的 `role: 'tool'` 结果消息。上一个 assistant message 的全部 `tool_calls` 都有结果后，kit 会继续发起下一轮请求。
+
+<demo vue="../../demos/tools/message/ToolCallConfirm.vue" :vueFiles="['../../demos/tools/message/ToolCallConfirm.ts', '../../demos/tools/message/ToolCallConfirm.vue']" />
+
 ##### 搭配 MCP 服务
 
 `toolPlugin` 可以搭配 MCP（Model Context Protocol）服务使用，扩展 AI 的工具调用能力。以下示例展示如何接入高德地图 MCP 服务。

--- a/packages/components/src/bubble/composables/useToolCall.ts
+++ b/packages/components/src/bubble/composables/useToolCall.ts
@@ -3,7 +3,7 @@ import { BubbleContentRendererProps, ChatMessageContent } from '../index.type'
 import { getJsonrepair } from '../utils'
 import { useBubbleStore } from './useBubbleStore'
 
-const toolCallStatus = ['running', 'success', 'failed', 'cancelled'] as const
+const toolCallStatus = ['awaiting-approval', 'running', 'success', 'failed', 'cancelled', 'denied'] as const
 export type ToolCallStatus = (typeof toolCallStatus)[number]
 
 export const useToolCall = (

--- a/packages/components/src/bubble/renderers/Tool.vue
+++ b/packages/components/src/bubble/renderers/Tool.vue
@@ -15,18 +15,32 @@ const props = defineProps<
 
 const { toolCall, toolCallWithResult, state } = useToolCall(props)
 
-const textAndIconMap = new Map<string, { text: string; icon: Component }>([
-  ['awaiting-approval', { text: '等待确认', icon: IconPlugin }],
-  ['running', { text: '正在调用', icon: IconLoading }],
-  ['success', { text: '已调用', icon: IconPlugin }],
-  ['failed', { text: '调用失败', icon: IconError }],
-  ['cancelled', { text: '已取消', icon: IconCancelled }],
-  ['denied', { text: '已拒绝', icon: IconCancelled }],
+const textAndIconMap = new Map<
+  string,
+  { prefixText: string; suffixText?: string; allowText?: string; denyText?: string; icon: Component }
+>([
+  [
+    'awaiting-approval',
+    {
+      prefixText: '即将调用',
+      suffixText: '工具，请问是否同意？',
+      allowText: '同意',
+      denyText: '拒绝',
+      icon: IconPlugin,
+    },
+  ],
+  ['running', { prefixText: '正在调用', icon: IconLoading }],
+  ['success', { prefixText: '已调用', icon: IconPlugin }],
+  ['failed', { prefixText: '调用失败', icon: IconError }],
+  ['cancelled', { prefixText: '已取消', icon: IconCancelled }],
+  ['denied', { prefixText: '已拒绝', icon: IconCancelled }],
 ])
 
 const textAndIcon = computed(() => {
-  return textAndIconMap.get(state.value?.status || '') || { text: '', icon: IconPlugin }
+  return textAndIconMap.get(state.value?.status || '') || { prefixText: '', icon: IconPlugin }
 })
+
+const isAwaitingApproval = computed(() => state.value.status === 'awaiting-approval' && !approvalSubmitted.value)
 
 const prettyJSON = (json: unknown, space = 2) => {
   let prettyJson = ''
@@ -147,25 +161,26 @@ const handleDecision = (action: 'allow' | 'deny') => {
 
 <template>
   <div class="tr-bubble__tool-call" data-type="tool-call">
-    <div class="header">
+    <div class="header" :class="{ 'is-approval': isAwaitingApproval }">
       <div class="header-left">
         <component :is="textAndIcon.icon" class="header-icon" :class="`icon-${state.status}`" />
         <span>
-          <span>{{ textAndIcon.text }}&nbsp;</span>
-          <span class="title">{{ toolCall?.function.name || 'Untitled' }} </span>
+          <span>{{ textAndIcon.prefixText }}&nbsp;</span>
+          <span class="title">{{ toolCall?.function.name || 'Untitled' }}</span>
+          <span v-if="textAndIcon.suffixText">&nbsp;{{ textAndIcon.suffixText }}</span>
         </span>
       </div>
       <div class="header-right">
-        <div v-if="state.status === 'awaiting-approval' && !approvalSubmitted" class="approval-actions">
-          <button class="approval-button approval-button--allow" type="button" @click.stop="handleDecision('allow')">
-            允许
-          </button>
-          <button class="approval-button approval-button--deny" type="button" @click.stop="handleDecision('deny')">
-            拒绝
-          </button>
-        </div>
         <IconArrowDown class="expand-icon" :class="{ '-rotate-90': !open }" @click="handleClick" />
       </div>
+    </div>
+    <div v-if="isAwaitingApproval" class="approval-actions">
+      <button class="approval-button approval-button--allow" type="button" @click.stop="handleDecision('allow')">
+        {{ textAndIcon.allowText }}
+      </button>
+      <button class="approval-button approval-button--deny" type="button" @click.stop="handleDecision('deny')">
+        {{ textAndIcon.denyText }}
+      </button>
     </div>
     <div v-show="open" class="divider"></div>
     <div v-show="open" class="detail" v-html="detail" ref="detailRef"></div>
@@ -249,31 +264,49 @@ const handleDecision = (action: 'allow' | 'deny') => {
   }
 }
 
+.header.is-approval {
+  .header-left {
+    color: var(--tr-text-secondary);
+  }
+
+  .header-icon {
+    color: var(--tr-icon-color-default);
+  }
+}
+
 .approval-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+  padding-left: 28px;
+  margin-top: 8px;
 }
 
 .approval-button {
   height: 24px;
-  padding: 0 10px;
-  border-radius: 4px;
-  border: 1px solid var(--tr-border-color-default);
-  background: var(--tr-container-bg-default);
+  min-width: 56px;
+  padding: 0 16px;
+  border-radius: 12px;
+  border: 1px solid var(--tr-text-secondary);
+  background: transparent;
   color: var(--tr-text-primary);
   font-size: 12px;
-  line-height: 22px;
+  line-height: 18px;
   cursor: pointer;
 
   &:hover {
-    border-color: var(--tr-color-primary);
-    color: var(--tr-color-primary);
+    border-color: var(--tr-text-primary);
   }
 
-  &--deny:hover {
-    border-color: var(--tr-color-error);
-    color: var(--tr-color-error);
+  &--allow {
+    border-color: var(--tr-text-primary);
+    background: var(--tr-text-primary);
+    color: var(--tr-container-bg-default);
+
+    &:hover {
+      background: var(--tr-text-secondary);
+      border-color: var(--tr-text-secondary);
+    }
   }
 }
 

--- a/packages/components/src/bubble/renderers/Tool.vue
+++ b/packages/components/src/bubble/renderers/Tool.vue
@@ -16,10 +16,12 @@ const props = defineProps<
 const { toolCall, toolCallWithResult, state } = useToolCall(props)
 
 const textAndIconMap = new Map<string, { text: string; icon: Component }>([
+  ['awaiting-approval', { text: '等待确认', icon: IconPlugin }],
   ['running', { text: '正在调用', icon: IconLoading }],
   ['success', { text: '已调用', icon: IconPlugin }],
   ['failed', { text: '调用失败', icon: IconError }],
   ['cancelled', { text: '已取消', icon: IconCancelled }],
+  ['denied', { text: '已拒绝', icon: IconCancelled }],
 ])
 
 const textAndIcon = computed(() => {
@@ -86,6 +88,7 @@ const detail = computed(() => {
 })
 
 const detailRef = ref<HTMLDivElement | null>(null)
+const approvalSubmitted = ref(false)
 
 watch(jsonStr, (_, oldValue) => {
   if (oldValue === '' || oldValue === '{}') {
@@ -108,6 +111,10 @@ const open = ref(false)
 
 watchEffect(() => {
   open.value = state.value.open ?? false
+
+  if (state.value.status !== 'awaiting-approval') {
+    approvalSubmitted.value = false
+  }
 })
 
 const handleStateChange = useBubbleStateChangeFn()
@@ -123,6 +130,19 @@ const handleClick = () => {
     })
   }
 }
+
+const handleDecision = (action: 'allow' | 'deny') => {
+  const toolCallId = toolCall.value?.id
+  if (!toolCallId) {
+    return
+  }
+
+  approvalSubmitted.value = true
+  handleStateChange('toolCallDecision', {
+    toolCallId,
+    decision: { action },
+  })
+}
 </script>
 
 <template>
@@ -136,6 +156,14 @@ const handleClick = () => {
         </span>
       </div>
       <div class="header-right">
+        <div v-if="state.status === 'awaiting-approval' && !approvalSubmitted" class="approval-actions">
+          <button class="approval-button approval-button--allow" type="button" @click.stop="handleDecision('allow')">
+            允许
+          </button>
+          <button class="approval-button approval-button--deny" type="button" @click.stop="handleDecision('deny')">
+            拒绝
+          </button>
+        </div>
         <IconArrowDown class="expand-icon" :class="{ '-rotate-90': !open }" @click="handleClick" />
       </div>
     </div>
@@ -187,6 +215,7 @@ const handleClick = () => {
     flex-shrink: 0;
     display: flex;
     align-items: center;
+    gap: 8px;
   }
 
   .header-icon {
@@ -198,12 +227,14 @@ const handleClick = () => {
       animation: spin 1s linear infinite;
     }
 
+    &.icon-awaiting-approval,
     &.icon-success {
       color: #898989;
     }
 
     &.icon-failed,
-    &.icon-cancelled {
+    &.icon-cancelled,
+    &.icon-denied {
       color: var(--tr-color-error);
     }
   }
@@ -215,6 +246,34 @@ const handleClick = () => {
     &.-rotate-90 {
       transform: rotate(-90deg);
     }
+  }
+}
+
+.approval-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.approval-button {
+  height: 24px;
+  padding: 0 10px;
+  border-radius: 4px;
+  border: 1px solid var(--tr-border-color-default);
+  background: var(--tr-container-bg-default);
+  color: var(--tr-text-primary);
+  font-size: 12px;
+  line-height: 22px;
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--tr-color-primary);
+    color: var(--tr-color-primary);
+  }
+
+  &--deny:hover {
+    border-color: var(--tr-color-error);
+    color: var(--tr-color-error);
   }
 }
 

--- a/packages/kit/TODO.md
+++ b/packages/kit/TODO.md
@@ -1,0 +1,70 @@
+# TODO: useMessage 工具结果等待状态
+
+## 背景
+
+当前 `submitToolResult` 已经支持通过追加 `role: 'tool'` 消息来继续工具调用流程：当最近一个 assistant message 的 `tool_calls` 都有对应 tool result 后，kit 会自动发起下一轮请求。
+
+后续还需要把“等待 tool result 提交”显式纳入 `useMessage` 的状态模型，避免只依赖 message state 判断流程位置。这样状态可以被序列化存储，页面关闭、会话切换或应用重启后，也能恢复到可继续处理的 pause/resume 状态。
+
+## 目标
+
+- 为 `useMessage` 增加一个等待工具结果提交的 processing 状态。
+- 让等待状态可以随消息一起序列化存储。
+- 恢复会话后，UI 能根据状态继续展示待处理工具调用。
+- 用户允许或拒绝后，业务侧调用 `submitToolResult`，kit 自动判断是否继续请求。
+
+## 建议状态
+
+当前 `requestState` 仍保持：
+
+- `idle`
+- `processing`
+- `completed`
+- `aborted`
+- `error`
+
+建议扩展 `processingState`：
+
+- `requesting`：正在请求模型。
+- `completing`：正在消费模型响应。
+- `calling-tools`：正在自动执行工具。
+- `awaiting-tool-results`：模型已返回 `tool_calls`，但仍有工具结果未提交。
+
+`awaiting-tool-results` 的语义是：当前没有运行中的模型请求，也没有运行中的自动工具调用；流程暂停在等待外部提交 tool result 的阶段。
+
+## 序列化模型
+
+建议最小化存储以下信息：
+
+- `messages`：完整消息列表，包括 assistant message 上的 `tool_calls` 和 `state.toolCall`。
+- `requestState`：建议恢复为 `completed` 或新增更明确的暂停态后再决定。
+- `processingState`：恢复时可以从消息推导，也可以持久化 `awaiting-tool-results`。
+- pending tool call ids：优先从最近一个 assistant message 的 `tool_calls` 与其后的 tool messages 差集推导。
+
+不要在内存里保存 Promise、resolver 或运行时闭包。pause/resume 只能依赖可序列化的数据。
+
+## 实现清单
+
+1. 增加 `RequestProcessingState` 可选值：`awaiting-tool-results`。
+2. 当 `toolPlugin` 发现存在需要确认的工具调用时：
+   - 标记对应 `state.toolCall[id].status = 'awaiting-approval'`。
+   - 将 `processingState` 置为 `awaiting-tool-results`。
+   - 停止本轮自动 `requestNext`。
+3. `submitToolResult` 提交 tool message 后：
+   - 更新对应 tool call 状态。
+   - 如果仍有缺失结果，保持 `awaiting-tool-results`。
+   - 如果全部结果齐全，进入下一轮 `requesting`。
+4. 恢复会话时：
+   - 根据最近一个 assistant message 的 `tool_calls` 和后续 tool messages 推导是否仍在等待。
+   - 若仍有缺失结果，恢复 `processingState = 'awaiting-tool-results'`。
+5. UI 层：
+   - 根据 `state.toolCall[id].status === 'awaiting-approval'` 展示允许/拒绝按钮。
+   - 根据全局 `processingState === 'awaiting-tool-results'` 展示“等待工具结果”类状态。
+
+## 注意点
+
+- 不要把 `await confirmToolCall` 作为恢复机制，刷新页面后 Promise 无法恢复。
+- `submitToolResult` 应只允许提交到最近一个带 `tool_calls` 的 assistant message 后面。
+- 如果最近一个 assistant message 没有 `tool_calls`，提交 tool result 应该直接拒绝或警告。
+- 多个并行 tool call 可以部分提交，但只有全部结果齐全后才继续请求。
+- deny 也应表现为一条 `role: 'tool'` 消息，而不是单纯前端状态。

--- a/packages/kit/src/message/core/engine.ts
+++ b/packages/kit/src/message/core/engine.ts
@@ -87,6 +87,7 @@ export const createMessageEngine = (
     currentTurn: [],
     customContext: {},
     abortController: null,
+    currentTurnResponseProvider: null,
     responseProvider: initialResponseProvider,
   }
 
@@ -175,6 +176,11 @@ export const createMessageEngine = (
     const resultIds = new Set(toolMessages.map((message) => message.tool_call_id).filter(Boolean))
 
     return expectedIds.length > 0 && expectedIds.every((id) => resultIds.has(id))
+  }
+
+  const isAwaitingToolResults = () => {
+    const state = getState()
+    return state.requestState === 'processing' && state.processingState === 'awaiting-tool-results'
   }
 
   const updateSubmittedToolCallStates = (assistantMessageIndex: number, toolMessages: ChatMessage[]) => {
@@ -376,14 +382,105 @@ export const createMessageEngine = (
     }
   }
 
+  async function runTurnEnd(abortSignal: AbortSignal) {
+    const baseContextAtEnd = getBaseContext(abortSignal)
+    for (const plugin of plugins.filter((plugin) => !isPluginDisabled(plugin, baseContextAtEnd))) {
+      await plugin.onTurnEnd?.(baseContextAtEnd)
+    }
+  }
+
+  function cleanupTurn(abortSignal: AbortSignal, assistantMessage: ChatMessage | null) {
+    const context = getBaseContext(abortSignal)
+    for (const plugin of plugins.filter((plugin) => !isPluginDisabled(plugin, context))) {
+      try {
+        plugin.onFinally?.(context)
+      } catch (error) {
+        console.error(`Error in onFinally hook for plugin [${plugin.name || 'Anonymous'}]:`, error)
+      }
+    }
+
+    runtime.abortController = null
+    runtime.currentTurnResponseProvider = null
+    runtime.currentTurn = []
+
+    // 如果请求立即出错，loading 可能一直为 true，这时需要手动将其置为 false
+    mutate('messages', (_, skipNotify) => {
+      if (assistantMessage?.loading) {
+        assistantMessage.loading = undefined
+      } else {
+        skipNotify()
+      }
+    })
+  }
+
+  async function continueTurn() {
+    const ac = runtime.abortController ?? new AbortController()
+    runtime.abortController = ac
+
+    let assistantMessage: ChatMessage | null = null
+    let paused = false
+    const setAssistantMessage = (message: ChatMessage) => {
+      assistantMessage = message
+    }
+
+    try {
+      const turnResponseProvider = runtime.currentTurnResponseProvider ?? runtime.responseProvider
+
+      try {
+        await executeRequest(turnResponseProvider, ac.signal, { setAssistantMessage })
+
+        if (isAwaitingToolResults()) {
+          paused = true
+          return
+        }
+
+        setRequestState('completed')
+      } catch (error) {
+        if (
+          ac.signal.aborted ||
+          error instanceof AbortError ||
+          (error instanceof Error && error.name === 'AbortError')
+        ) {
+          setRequestState('aborted')
+        } else {
+          throw error
+        }
+      }
+
+      await runTurnEnd(ac.signal)
+    } catch (error) {
+      setRequestState('error')
+
+      let hasOnError = false
+      const context = getBaseContext(ac.signal)
+
+      for (const plugin of plugins.filter((plugin) => !isPluginDisabled(plugin, context))) {
+        if (plugin.onError) {
+          hasOnError = true
+          plugin.onError({ ...context, error })
+        }
+      }
+
+      if (!hasOnError) {
+        throw error
+      }
+    } finally {
+      if (!paused) {
+        cleanupTurn(ac.signal, assistantMessage)
+      }
+    }
+  }
+
   async function runTurn() {
     const ac = new AbortController()
     runtime.abortController = ac
     // 在每个回合开始时重置自定义上下文
     runtime.customContext = {}
+    runtime.currentTurnResponseProvider = null
 
     // 记录当前请求的 assistantMessage，方便在 finally 中进行状态清理（如将 loading 置为 false）
     let assistantMessage: ChatMessage | null = null
+    let paused = false
     const setAssistantMessage = (message: ChatMessage) => {
       assistantMessage = message
     }
@@ -400,9 +497,16 @@ export const createMessageEngine = (
       // 允许插件在 onTurnStart 钩子中修改 responseProvider
       // 并在整个 turn 请求过程中防止因它发生变化而导致的不一致
       const turnResponseProvider = runtime.responseProvider
+      runtime.currentTurnResponseProvider = turnResponseProvider
 
       try {
         await executeRequest(turnResponseProvider, ac.signal, { setAssistantMessage })
+
+        if (isAwaitingToolResults()) {
+          paused = true
+          return
+        }
+
         setRequestState('completed')
       } catch (error) {
         // 检查是否是中止错误：优先检查当前使用的 AbortController 的信号状态
@@ -420,10 +524,7 @@ export const createMessageEngine = (
       }
 
       // 3) onTurnEnd 串行执行，有错误则中断
-      const baseContextAtEnd = getBaseContext(ac.signal)
-      for (const plugin of plugins.filter((plugin) => !isPluginDisabled(plugin, baseContextAtEnd))) {
-        await plugin.onTurnEnd?.(baseContextAtEnd)
-      }
+      await runTurnEnd(ac.signal)
     } catch (error) {
       setRequestState('error')
 
@@ -442,26 +543,9 @@ export const createMessageEngine = (
         throw error
       }
     } finally {
-      const context = getBaseContext(ac.signal)
-      for (const plugin of plugins.filter((plugin) => !isPluginDisabled(plugin, context))) {
-        try {
-          plugin.onFinally?.(context)
-        } catch (error) {
-          console.error(`Error in onFinally hook for plugin [${plugin.name || 'Anonymous'}]:`, error)
-        }
+      if (!paused) {
+        cleanupTurn(ac.signal, assistantMessage)
       }
-
-      runtime.abortController = null
-      runtime.currentTurn = []
-
-      // 如果请求立即出错，loading 可能一直为 true，这时需要手动将其置为 false
-      mutate('messages', (_, skipNotify) => {
-        if (assistantMessage?.loading) {
-          assistantMessage.loading = undefined
-        } else {
-          skipNotify()
-        }
-      })
     }
   }
 
@@ -500,7 +584,8 @@ export const createMessageEngine = (
   }
 
   async function submitToolResult(message: ChatMessage | ChatMessage[]) {
-    if (getState().requestState === 'processing') {
+    const state = getState()
+    if (state.requestState === 'processing' && state.processingState !== 'awaiting-tool-results') {
       console.warn('Cannot submit tool result while processing is in progress')
       return
     }
@@ -533,11 +618,27 @@ export const createMessageEngine = (
     updateSubmittedToolCallStates(pendingAssistant.index, toolMessages)
 
     if (allToolCallsHaveResults(pendingAssistant.message, toolMessages)) {
-      await runTurn()
+      if (isAwaitingToolResults()) {
+        await continueTurn()
+      } else {
+        await runTurn()
+      }
+    } else {
+      setRequestState('processing', 'awaiting-tool-results')
     }
   }
 
   async function abort() {
+    if (isAwaitingToolResults()) {
+      const ac = runtime.abortController ?? new AbortController()
+      runtime.abortController = ac
+      ac.abort()
+      setRequestState('aborted')
+      await runTurnEnd(ac.signal)
+      cleanupTurn(ac.signal, null)
+      return
+    }
+
     runtime.abortController?.abort()
 
     // 等待直到 isProcessing 变为 false

--- a/packages/kit/src/message/core/engine.ts
+++ b/packages/kit/src/message/core/engine.ts
@@ -149,6 +149,62 @@ export const createMessageEngine = (
     return runtimeMessages
   }
 
+  const findLastAssistantMessageWithToolCalls = () => {
+    const messages = getState().messages
+    const lastAssistant = messages
+      .map((message, index) => ({ message, index }))
+      .slice()
+      .reverse()
+      .find(({ message }) => message.role === 'assistant')
+
+    return lastAssistant?.message.tool_calls?.length ? lastAssistant : undefined
+  }
+
+  const getToolMessagesAfter = (index: number) => {
+    const messages = getState().messages
+    const nextMessages = messages.slice(index + 1)
+    const nextAssistantIndex = nextMessages.findIndex((message) => message.role === 'assistant')
+    const messagesBeforeNextAssistant =
+      nextAssistantIndex === -1 ? nextMessages : nextMessages.slice(0, nextAssistantIndex)
+
+    return messagesBeforeNextAssistant.filter((message) => message.role === 'tool')
+  }
+
+  const allToolCallsHaveResults = (assistantMessage: ChatMessage, toolMessages: ChatMessage[]) => {
+    const expectedIds = assistantMessage.tool_calls?.map((toolCall) => toolCall.id) ?? []
+    const resultIds = new Set(toolMessages.map((message) => message.tool_call_id).filter(Boolean))
+
+    return expectedIds.length > 0 && expectedIds.every((id) => resultIds.has(id))
+  }
+
+  const updateSubmittedToolCallStates = (assistantMessageIndex: number, toolMessages: ChatMessage[]) => {
+    mutate('messages', (draft) => {
+      const assistantMessage = draft.messages[assistantMessageIndex]
+      if (!assistantMessage) {
+        return
+      }
+
+      assistantMessage.state ??= {}
+      const state = assistantMessage.state as Record<string, unknown>
+      state.toolCall ??= {}
+      const toolCallState = state.toolCall as Record<string, Record<string, unknown>>
+
+      for (const toolMessage of toolMessages) {
+        const toolCallId = toolMessage.tool_call_id
+        if (!toolCallId) {
+          continue
+        }
+
+        toolCallState[toolCallId] ??= {}
+        const currentStatus = toolCallState[toolCallId].status
+        toolCallState[toolCallId].status =
+          toolMessage.metadata?.toolCallStatus ??
+          (currentStatus === 'awaiting-approval' ? 'success' : currentStatus) ??
+          'success'
+      }
+    })
+  }
+
   // Create base context for plugins
   const getBaseContext = (abortSignal: AbortSignal): BasePluginContext => ({
     getState,
@@ -443,6 +499,44 @@ export const createMessageEngine = (
     await runTurn()
   }
 
+  async function submitToolResult(message: ChatMessage | ChatMessage[]) {
+    if (getState().requestState === 'processing') {
+      console.warn('Cannot submit tool result while processing is in progress')
+      return
+    }
+
+    const messages = Array.isArray(message) ? message : [message]
+    if (messages.some((item) => item.role !== 'tool')) {
+      console.warn('submitToolResult only accepts messages with role "tool"')
+      return
+    }
+
+    const pendingAssistant = findLastAssistantMessageWithToolCalls()
+    if (!pendingAssistant) {
+      console.warn('Cannot submit tool result without a pending assistant tool call')
+      return
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+    appendMessages(
+      ...messages.map((item) => ({
+        ...item,
+        metadata: {
+          createdAt: now,
+          updatedAt: now,
+          ...item.metadata,
+        },
+      })),
+    )
+
+    const toolMessages = getToolMessagesAfter(pendingAssistant.index)
+    updateSubmittedToolCallStates(pendingAssistant.index, toolMessages)
+
+    if (allToolCallsHaveResults(pendingAssistant.message, toolMessages)) {
+      await runTurn()
+    }
+  }
+
   async function abort() {
     runtime.abortController?.abort()
 
@@ -465,6 +559,7 @@ export const createMessageEngine = (
     subscribe,
     sendMessage,
     send,
+    submitToolResult,
     abort,
     setResponseProvider(provider) {
       runtime.responseProvider = provider

--- a/packages/kit/src/message/plugins/index.ts
+++ b/packages/kit/src/message/plugins/index.ts
@@ -1,3 +1,4 @@
 export { lengthPlugin } from './lengthPlugin'
 export { thinkingPlugin } from './thinkingPlugin'
 export { toolPlugin } from './toolPlugin'
+export type { ToolCallDecision } from './toolPlugin'

--- a/packages/kit/src/message/plugins/toolPlugin.ts
+++ b/packages/kit/src/message/plugins/toolPlugin.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ChatCompletionMessageToolCall, ChatCompletionTool } from 'openai/resources/index'
+import type { MaybePromise } from '../../types'
 import type { BasePluginContext, ChatMessage, MessageEnginePlugin, MutateMessageStateFn } from '../types'
 import { combineDeltaData, normalizeToAsyncGenerator } from '../utils'
 
@@ -12,6 +13,29 @@ type ToolCallContext = BasePluginContext & {
   assistantMessage: AssistantMessageWithState
   toolMessage: ChatMessage
 }
+
+type ToolCallConfirmContext = BasePluginContext & {
+  assistantMessage: AssistantMessageWithState
+}
+
+export type ToolCallDecision =
+  | {
+      /**
+       * 允许当前工具调用继续执行。
+       *
+       * 后续可扩展的候选动作：
+       * - `{ action: 'allow_session' }`：允许当前会话中匹配的工具调用。
+       * - `{ action: 'respond'; message: string }`：跳过工具执行，并将引导信息返回给模型。
+       */
+      action: 'allow'
+    }
+  | {
+      /**
+       * 拒绝当前工具调用，并可将 message 作为工具结果返回给模型。
+       */
+      action: 'deny'
+      message?: string
+    }
 
 /**
  * 补全缺失的工具消息
@@ -117,6 +141,22 @@ export const toolPlugin = (
       context: ToolCallContext,
     ) => Promise<string | Record<string, any>> | AsyncGenerator<string | Record<string, any>>
     /**
+     * 判断当前工具调用是否需要外部确认。
+     *
+     * 返回 true 时，工具调用会停在 `awaiting-approval` 状态，不会创建空的 tool message，也不会执行 `callTool`。
+     * 业务侧确认后应调用 `submitToolResult` 补齐对应的 `role: 'tool'` 结果消息；当上一个 assistant message
+     * 的全部 `tool_calls` 都有结果后，kit 会继续下一轮请求。
+     *
+     * 未传入时默认不需要确认，会直接执行 `callTool`。
+     *
+     * TODO(v2): 当前只支持“本次允许/拒绝并提交结果”。后续可在消息状态和提交 API 上扩展
+     * allow_session、respond/tell ai how to do 等动作，并支持按会话持久化授权策略。
+     */
+    confirmToolCall?: (
+      toolCall: ChatCompletionMessageToolCall,
+      context: ToolCallConfirmContext,
+    ) => MaybePromise<boolean>
+    /**
      * 工具调用开始时的回调函数。
      * 触发时机：工具消息已创建并追加后，调用 callTool 之前触发。
      * @param toolCall - 工具调用对象
@@ -128,13 +168,13 @@ export const toolPlugin = (
      * 触发时机：工具调用完成（成功、失败或取消）时触发。
      * @param toolCall - 工具调用对象
      * @param context - 插件上下文，包含当前工具消息、状态和错误信息
-     * @param context.status - 工具调用状态：'success' | 'failed' | 'cancelled'
+     * @param context.status - 工具调用状态：'success' | 'failed' | 'cancelled' | 'denied'
      * @param context.error - 当状态为 'failed' 或 'cancelled' 时，可能包含错误信息
      */
     onToolCallEnd?: (
       toolCall: ChatCompletionMessageToolCall,
       context: ToolCallContext & {
-        status: 'success' | 'failed' | 'cancelled'
+        status: 'success' | 'failed' | 'cancelled' | 'denied'
         error?: Error
       },
     ) => void
@@ -147,6 +187,10 @@ export const toolPlugin = (
      */
     toolCallFailedContent?: string
     /**
+     * 当工具调用被拒绝时使用的默认消息内容。
+     */
+    toolCallDeniedContent?: string
+    /**
      * 是否在请求前自动补充缺失的 tool 消息。
      * 当 assistant 响应了 tool_calls 但未追加对应的 tool 消息时，
      * 插件将自动补充"工具调用已取消"的 tool 消息。默认：false。
@@ -158,10 +202,12 @@ export const toolPlugin = (
     getTools,
     beforeCallTools,
     callTool,
+    confirmToolCall,
     onToolCallStart,
     onToolCallEnd,
     toolCallCancelledContent = 'Tool call cancelled.',
     toolCallFailedContent = 'Tool call failed.',
+    toolCallDeniedContent: _toolCallDeniedContent = 'Tool call denied.',
     autoFillMissingToolMessages = false,
     ...restOptions
   } = options
@@ -184,6 +230,15 @@ export const toolPlugin = (
     })
 
     onToolCallStart?.(...args)
+  }
+
+  const toolCallAwaitApproval = (toolCall: ChatCompletionMessageToolCall, context: ToolCallConfirmContext) => {
+    const { assistantMessage, mutate } = context
+
+    mutate('messages', () => {
+      const message = ensureToolCallState(assistantMessage, toolCall.id)
+      message.state.toolCall[toolCall.id].status = 'awaiting-approval'
+    })
   }
 
   const toolCallEnd = (...args: Parameters<NonNullable<typeof onToolCallEnd>>) => {
@@ -237,35 +292,56 @@ export const toolPlugin = (
       }
 
       setRequestState('processing', 'calling-tools')
+      const assistantMessage = currentMessage as AssistantMessageWithState
+      const contextWithAssistant = {
+        ...context,
+        assistantMessage,
+      }
+
       await beforeCallTools?.(currentMessage.tool_calls as ChatCompletionMessageToolCall[], {
         ...context,
-        assistantMessage: currentMessage as AssistantMessageWithState,
+        assistantMessage,
       })
 
       const toolCallPromises = currentMessage.tool_calls.map(async (toolCall) => {
         const now = Math.floor(Date.now() / 1000)
         let hasMeaningfulResult = false
-        const toolMessage: ChatMessage = createMessage({
-          role: 'tool',
-          tool_call_id: toolCall.id,
-          content: '',
-          metadata: {
-            createdAt: now,
-            updatedAt: now,
-          },
-        })
+        let toolMessage: ChatMessage | undefined
+        let contextWithToolMessage: ToolCallContext | undefined
 
-        appendMessage(toolMessage)
-
-        const contextWithToolMessage = {
-          ...context,
-          assistantMessage: currentMessage as AssistantMessageWithState,
-          toolMessage,
-        }
-
-        toolCallStart(toolCall, contextWithToolMessage)
         try {
-          const result = callTool(toolCall, contextWithToolMessage)
+          const requiresApproval = confirmToolCall
+            ? await Promise.resolve(confirmToolCall(toolCall, contextWithAssistant))
+            : false
+
+          if (requiresApproval) {
+            toolCallAwaitApproval(toolCall, contextWithAssistant)
+            return 'pending' as const
+          }
+
+          toolMessage = createMessage({
+            role: 'tool',
+            tool_call_id: toolCall.id,
+            content: '',
+            metadata: {
+              createdAt: now,
+              updatedAt: now,
+            },
+          })
+
+          appendMessage(toolMessage)
+
+          contextWithToolMessage = {
+            ...context,
+            assistantMessage,
+            toolMessage,
+          }
+          const activeToolMessage = toolMessage
+          const activeContextWithToolMessage = contextWithToolMessage
+
+          toolCallStart(toolCall, activeContextWithToolMessage)
+
+          const result = callTool(toolCall, activeContextWithToolMessage)
 
           // 将 Promise 或异步迭代器统一转换为异步生成器
           const iterator = normalizeToAsyncGenerator(result)
@@ -282,34 +358,52 @@ export const toolPlugin = (
 
               // 字符串拼接或 JSON 合并
               if (typeof chunk === 'string') {
-                toolMessage.content += chunk
+                activeToolMessage.content += chunk
               } else {
                 let parsedContent: Record<string, any> = {}
                 try {
-                  const content = Array.isArray(toolMessage.content)
-                    ? toolMessage.content.map((item) => item.text).join('')
-                    : toolMessage.content
+                  const content = Array.isArray(activeToolMessage.content)
+                    ? activeToolMessage.content.map((item: any) => item.text).join('')
+                    : activeToolMessage.content
                   parsedContent = JSON.parse(content || '{}')
                 } catch (error) {
                   console.warn(error)
                 }
-                toolMessage.content = JSON.stringify(combineDeltaData(parsedContent, chunk))
+                activeToolMessage.content = JSON.stringify(combineDeltaData(parsedContent, chunk))
               }
 
-              toolMessage.metadata!.updatedAt = Math.floor(Date.now() / 1000)
+              activeToolMessage.metadata!.updatedAt = Math.floor(Date.now() / 1000)
             })
           }
 
-          toolCallEnd(toolCall, { ...contextWithToolMessage, status: 'success' })
+          toolCallEnd(toolCall, { ...activeContextWithToolMessage, status: 'success' })
         } catch (error) {
           const err = error instanceof Error ? error : new Error(String(error))
+
+          if (!toolMessage || !contextWithToolMessage) {
+            console.error(error)
+            mutate('messages', () => {
+              const message = ensureToolCallState(assistantMessage, toolCall.id)
+              message.state.toolCall[toolCall.id].status = 'failed'
+            })
+            return 'handled' as const
+          }
+          const activeToolMessage = toolMessage
+          const activeContextWithToolMessage = contextWithToolMessage
 
           // 如果被 abort ，则抛出错误，主流程会处理状态
           // 也可以不抛出错误，直接返回，主流程会自动处理 abort 场景
           if (abortSignal.aborted) {
-            toolCallEnd(toolCall, { ...contextWithToolMessage, status: 'cancelled', error: err })
+            if (!hasMeaningfulResult) {
+              mutate('messages', () => {
+                activeToolMessage.content = toolCallCancelledContent
+                activeToolMessage.metadata!.updatedAt = Math.floor(Date.now() / 1000)
+              })
+            }
+
+            toolCallEnd(toolCall, { ...activeContextWithToolMessage, status: 'cancelled', error: err })
             // throw error
-            return
+            return 'handled' as const
           }
 
           // 其他错误视为工具调用失败，则将工具消息内容设置为失败内容
@@ -317,17 +411,19 @@ export const toolPlugin = (
 
           if (!hasMeaningfulResult) {
             mutate('messages', () => {
-              toolMessage.content = toolCallFailedContent
-              toolMessage.metadata!.updatedAt = Math.floor(Date.now() / 1000)
+              activeToolMessage.content = toolCallFailedContent
+              activeToolMessage.metadata!.updatedAt = Math.floor(Date.now() / 1000)
             })
           }
 
-          toolCallEnd(toolCall, { ...contextWithToolMessage, status: 'failed', error: err })
+          toolCallEnd(toolCall, { ...activeContextWithToolMessage, status: 'failed', error: err })
         }
+
+        return 'handled' as const
       })
 
-      await Promise.all(toolCallPromises)
-      if (!abortSignal.aborted) {
+      const toolCallResults = await Promise.all(toolCallPromises)
+      if (!abortSignal.aborted && toolCallResults.every((result) => result !== 'pending')) {
         requestNext()
       }
 

--- a/packages/kit/src/message/plugins/toolPlugin.ts
+++ b/packages/kit/src/message/plugins/toolPlugin.ts
@@ -143,11 +143,11 @@ export const toolPlugin = (
     /**
      * 判断当前工具调用是否需要外部确认。
      *
-     * 返回 true 时，工具调用会停在 `awaiting-approval` 状态，不会创建空的 tool message，也不会执行 `callTool`。
+     * 传入该函数时，工具调用会停在 `awaiting-approval` 状态，不会创建空的 tool message，也不会执行 `callTool`。
      * 业务侧确认后应调用 `submitToolResult` 补齐对应的 `role: 'tool'` 结果消息；当上一个 assistant message
      * 的全部 `tool_calls` 都有结果后，kit 会继续下一轮请求。
      *
-     * 未传入时默认不需要确认，会直接执行 `callTool`。
+     * 未传入时默认不需要确认，会直接执行 `callTool`。返回值保留用于业务侧兼容，但不再控制是否暂停。
      *
      * TODO(v2): 当前只支持“本次允许/拒绝并提交结果”。后续可在消息状态和提交 API 上扩展
      * allow_session、respond/tell ai how to do 等动作，并支持按会话持久化授权策略。
@@ -310,11 +310,8 @@ export const toolPlugin = (
         let contextWithToolMessage: ToolCallContext | undefined
 
         try {
-          const requiresApproval = confirmToolCall
-            ? await Promise.resolve(confirmToolCall(toolCall, contextWithAssistant))
-            : false
-
-          if (requiresApproval) {
+          if (confirmToolCall) {
+            await Promise.resolve(confirmToolCall(toolCall, contextWithAssistant))
             toolCallAwaitApproval(toolCall, contextWithAssistant)
             return 'pending' as const
           }
@@ -423,7 +420,13 @@ export const toolPlugin = (
       })
 
       const toolCallResults = await Promise.all(toolCallPromises)
-      if (!abortSignal.aborted && toolCallResults.every((result) => result !== 'pending')) {
+      if (abortSignal.aborted) {
+        return restOptions.onAfterRequest?.(context)
+      }
+
+      if (toolCallResults.some((result) => result === 'pending')) {
+        setRequestState('processing', 'awaiting-tool-results')
+      } else {
         requestNext()
       }
 

--- a/packages/kit/src/message/types.ts
+++ b/packages/kit/src/message/types.ts
@@ -17,7 +17,7 @@ export type DeepReadonly<T> = T extends (...args: any[]) => any
 
 // Define different states for the request process
 export type RequestState = 'idle' | 'processing' | 'completed' | 'aborted' | 'error'
-export type RequestProcessingState = 'requesting' | 'completing' | string
+export type RequestProcessingState = 'requesting' | 'completing' | 'calling-tools' | 'awaiting-tool-results' | string
 
 export type ChatMessage<
   Metadata extends object = Record<string, unknown>,
@@ -57,6 +57,7 @@ export interface MessageRuntime {
   currentTurn: ChatMessage[]
   customContext: Record<string, unknown>
   abortController: AbortController | null
+  currentTurnResponseProvider: ResponseProvider | null
   responseProvider: ResponseProvider
 }
 

--- a/packages/kit/src/message/types.ts
+++ b/packages/kit/src/message/types.ts
@@ -66,6 +66,7 @@ export interface MessageEngine {
   subscribe(kinds: MessageUpdateKinds, listener: (state: PublicMessageState) => void): () => void
   sendMessage(content: string): Promise<void>
   send(...msgs: ChatMessage[]): Promise<void>
+  submitToolResult(message: ChatMessage | ChatMessage[]): Promise<void>
   abort(): Promise<void>
   setResponseProvider(provider: ResponseProvider): void
 }

--- a/packages/kit/src/vue/message/plugins/toolPlugin.ts
+++ b/packages/kit/src/vue/message/plugins/toolPlugin.ts
@@ -46,8 +46,9 @@ export const toolPlugin = (
     /**
      * 判断当前工具调用是否需要外部确认。
      *
-     * 返回 true 时，工具调用会停在 `awaiting-approval` 状态。业务侧确认后应调用
-     * `submitToolResult` 提交对应的 `role: 'tool'` 结果消息。
+     * 传入该函数时，工具调用会停在 `awaiting-approval` 状态。业务侧确认后应调用
+     * `submitToolResult` 提交对应的 `role: 'tool'` 结果消息。返回值保留用于业务侧兼容，
+     * 不再控制是否暂停。
      */
     confirmToolCall?: (toolCall: ToolCall, context: UseMessageToolActionContext) => MaybePromise<boolean>
     /**

--- a/packages/kit/src/vue/message/plugins/toolPlugin.ts
+++ b/packages/kit/src/vue/message/plugins/toolPlugin.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { toolPlugin as createCoreToolPlugin } from '../../../message/plugins'
 import { normalizeToAsyncGenerator } from '../../../message/utils'
-import { ChatMessage, ToolCall } from '../../../types'
+import { ChatMessage, MaybePromise, ToolCall } from '../../../types'
 import type { VueMessagePluginRuntime } from '../types.internal'
 import { BasePluginContext, Tool, UseMessagePlugin } from '../types'
 
@@ -44,6 +44,13 @@ export const toolPlugin = (
       context: UseMessageCallToolContext,
     ) => Promise<string | Record<string, any>> | AsyncGenerator<string | Record<string, any>>
     /**
+     * 判断当前工具调用是否需要外部确认。
+     *
+     * 返回 true 时，工具调用会停在 `awaiting-approval` 状态。业务侧确认后应调用
+     * `submitToolResult` 提交对应的 `role: 'tool'` 结果消息。
+     */
+    confirmToolCall?: (toolCall: ToolCall, context: UseMessageToolActionContext) => MaybePromise<boolean>
+    /**
      * 工具调用开始时的回调函数。
      * 触发时机：工具消息已创建并追加后，调用 callTool 之前触发。
      * @param toolCall - 工具调用对象
@@ -55,13 +62,13 @@ export const toolPlugin = (
      * 触发时机：工具调用完成（成功、失败或取消）时触发。
      * @param toolCall - 工具调用对象
      * @param context - 插件上下文，包含当前工具消息、状态和错误信息
-     * @param context.status - 工具调用状态：'success' | 'failed' | 'cancelled'
+     * @param context.status - 工具调用状态：'success' | 'failed' | 'cancelled' | 'denied'
      * @param context.error - 当状态为 'failed' 或 'cancelled' 时，可能包含错误信息
      */
     onToolCallEnd?: (
       toolCall: ToolCall,
       context: UseMessageToolCallContext & {
-        status: 'success' | 'failed' | 'cancelled'
+        status: 'success' | 'failed' | 'cancelled' | 'denied'
         error?: Error
       },
     ) => void
@@ -74,6 +81,10 @@ export const toolPlugin = (
      */
     toolCallFailedContent?: string
     /**
+     * 当工具调用被拒绝时使用的默认消息内容。
+     */
+    toolCallDeniedContent?: string
+    /**
      * 是否在请求前自动补充缺失的 tool 消息。
      * 当 assistant 响应了 tool_calls 但未追加对应的 tool 消息时，
      * 插件将自动补充"工具调用已取消"的 tool 消息。默认：false。
@@ -85,10 +96,12 @@ export const toolPlugin = (
     getTools,
     beforeCallTools,
     callTool,
+    confirmToolCall,
     onToolCallStart,
     onToolCallEnd,
     toolCallCancelledContent = 'Tool call cancelled.',
     toolCallFailedContent = 'Tool call failed.',
+    toolCallDeniedContent = 'Tool call denied.',
     autoFillMissingToolMessages = false,
     ...restOptions
   } = options
@@ -130,6 +143,17 @@ export const toolPlugin = (
             yield chunk
           }
         },
+        confirmToolCall: confirmToolCall
+          ? (toolCall, context) => {
+              const assistantMessage = runtime.resolveReactiveMessage(context.assistantMessage as ChatMessage)
+
+              return confirmToolCall(toolCall as unknown as ToolCall, {
+                ...runtime.createVueBaseContext(context),
+                assistantMessage,
+                currentMessage: assistantMessage,
+              })
+            }
+          : undefined,
         onToolCallStart: onToolCallStart
           ? (toolCall, context) => {
               const assistantMessage = runtime.resolveReactiveMessage(context.assistantMessage as ChatMessage)
@@ -160,6 +184,7 @@ export const toolPlugin = (
           : undefined,
         toolCallCancelledContent,
         toolCallFailedContent,
+        toolCallDeniedContent,
         autoFillMissingToolMessages,
       })
     },

--- a/packages/kit/src/vue/message/types.ts
+++ b/packages/kit/src/vue/message/types.ts
@@ -119,6 +119,7 @@ export interface UseMessageReturn {
   isProcessing: ComputedRef<boolean>
   sendMessage: (content: string) => Promise<void>
   send: (...msgs: ChatMessage[]) => Promise<void>
+  submitToolResult: (message: ChatMessage | ChatMessage[]) => Promise<void>
   abortRequest: () => Promise<void>
 }
 

--- a/packages/kit/src/vue/message/types.ts
+++ b/packages/kit/src/vue/message/types.ts
@@ -24,7 +24,7 @@ export interface MessageRequestBody {
 
 // Define different states for the request process
 export type RequestState = 'idle' | 'processing' | 'completed' | 'aborted' | 'error'
-export type RequestProcessingState = 'requesting' | 'completing' | string
+export type RequestProcessingState = 'requesting' | 'completing' | 'calling-tools' | 'awaiting-tool-results' | string
 
 // Usage information for API response
 export interface Usage {

--- a/packages/kit/src/vue/message/useMessage.test.ts
+++ b/packages/kit/src/vue/message/useMessage.test.ts
@@ -1,10 +1,22 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ChatMessage } from '../../types'
 import { mockResponseProvider, mockSequentialResponseProvider } from './mockResponseProvider'
 import { lengthPlugin } from './plugins/lengthPlugin'
 import { toolPlugin } from './plugins/toolPlugin'
 import type { ResponseProvider } from './types'
 import { useMessage } from './useMessage'
+
+const waitFor = async (condition: () => boolean, timeout = 1000) => {
+  const startedAt = Date.now()
+
+  while (!condition()) {
+    if (Date.now() - startedAt > timeout) {
+      throw new Error('Timed out waiting for condition')
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
 
 describe('useMessage', () => {
   it('uses the core vue adapter while keeping the original return shape', async () => {
@@ -187,6 +199,244 @@ describe('useMessage', () => {
       content: 'prefix result',
     })
     expect(engine.messages.value[3]).toMatchObject({
+      role: 'assistant',
+      content: 'done',
+    })
+  })
+
+  it('waits for submitted tool results before continuing confirmed tool calls', async () => {
+    const callTool = vi.fn()
+    const secondRequestToolMessages: ChatMessage[] = []
+    let requestCount = 0
+
+    const responseProvider = mockSequentialResponseProvider([
+      {
+        finish_reason: 'tool_calls',
+        content: '',
+        tool_calls: [
+          {
+            index: 0,
+            id: 'call-allow',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{}',
+            },
+          },
+          {
+            index: 1,
+            id: 'call-deny',
+            type: 'function',
+            function: {
+              name: 'delete',
+              arguments: '{}',
+            },
+          },
+        ],
+      },
+      {
+        content: 'done',
+        onRequest(requestBody) {
+          requestCount += 1
+          secondRequestToolMessages.push(
+            ...(requestBody.messages.filter((message) => message.role === 'tool') as ChatMessage[]),
+          )
+        },
+      },
+    ])
+
+    const engine = useMessage({
+      responseProvider,
+      plugins: [
+        toolPlugin({
+          async getTools() {
+            return [
+              {
+                type: 'function',
+                function: {
+                  name: 'lookup',
+                },
+              },
+              {
+                type: 'function',
+                function: {
+                  name: 'delete',
+                },
+              },
+            ]
+          },
+          confirmToolCall(toolCall, context) {
+            expect(context.assistantMessage.tool_calls?.some((item) => item.id === toolCall.id)).toBe(true)
+            return true
+          },
+          callTool,
+        }),
+      ],
+    })
+
+    await engine.sendMessage('ping')
+
+    await waitFor(() => engine.messages.value[1]?.state?.toolCall?.['call-allow']?.status === 'awaiting-approval')
+    expect(engine.messages.value[1]).toMatchObject({
+      role: 'assistant',
+      state: {
+        toolCall: {
+          'call-allow': { status: 'awaiting-approval' },
+          'call-deny': { status: 'awaiting-approval' },
+        },
+      },
+    })
+    expect(callTool).not.toHaveBeenCalled()
+    expect(engine.messages.value).toHaveLength(2)
+
+    await engine.submitToolResult({
+      role: 'tool',
+      tool_call_id: 'call-allow',
+      content: 'result:call-allow',
+      metadata: { toolCallStatus: 'success' },
+    })
+
+    expect(requestCount).toBe(0)
+    expect(engine.messages.value[1]).toMatchObject({
+      role: 'assistant',
+      state: {
+        toolCall: {
+          'call-allow': { status: 'success' },
+          'call-deny': { status: 'awaiting-approval' },
+        },
+      },
+    })
+
+    await engine.submitToolResult({
+      role: 'tool',
+      tool_call_id: 'call-deny',
+      content: 'Tool call denied.',
+      metadata: { toolCallStatus: 'denied' },
+    })
+
+    expect(requestCount).toBe(1)
+    expect(secondRequestToolMessages).toMatchObject([
+      {
+        role: 'tool',
+        tool_call_id: 'call-allow',
+        content: 'result:call-allow',
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call-deny',
+        content: 'Tool call denied.',
+      },
+    ])
+    expect(engine.messages.value[1]).toMatchObject({
+      role: 'assistant',
+      state: {
+        toolCall: {
+          'call-allow': { status: 'success' },
+          'call-deny': { status: 'denied' },
+        },
+      },
+    })
+    expect(engine.messages.value.at(-1)).toMatchObject({
+      role: 'assistant',
+      content: 'done',
+    })
+  })
+
+  it('continues after submitToolResult receives every tool call result at once', async () => {
+    const secondRequestToolMessages: ChatMessage[] = []
+    let requestCount = 0
+
+    const responseProvider = mockSequentialResponseProvider([
+      {
+        finish_reason: 'tool_calls',
+        content: '',
+        tool_calls: [
+          {
+            index: 0,
+            id: 'call-a',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{}',
+            },
+          },
+          {
+            index: 1,
+            id: 'call-b',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{}',
+            },
+          },
+        ],
+      },
+      {
+        content: 'done',
+        onRequest(requestBody) {
+          requestCount += 1
+          secondRequestToolMessages.push(
+            ...(requestBody.messages.filter((message) => message.role === 'tool') as ChatMessage[]),
+          )
+        },
+      },
+    ])
+
+    const engine = useMessage({
+      responseProvider,
+      plugins: [
+        toolPlugin({
+          async getTools() {
+            return [
+              {
+                type: 'function',
+                function: {
+                  name: 'lookup',
+                },
+              },
+            ]
+          },
+          confirmToolCall() {
+            return true
+          },
+          async callTool() {
+            return 'unused'
+          },
+        }),
+      ],
+    })
+
+    await engine.sendMessage('ping')
+
+    await waitFor(() => engine.messages.value[1]?.state?.toolCall?.['call-a']?.status === 'awaiting-approval')
+    await engine.submitToolResult([
+      {
+        role: 'tool',
+        tool_call_id: 'call-a',
+        content: 'result:a',
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call-b',
+        content: 'result:b',
+      },
+    ])
+
+    expect(requestCount).toBe(1)
+    expect(secondRequestToolMessages).toMatchObject([
+      { role: 'tool', tool_call_id: 'call-a', content: 'result:a' },
+      { role: 'tool', tool_call_id: 'call-b', content: 'result:b' },
+    ])
+    expect(engine.messages.value[1]).toMatchObject({
+      role: 'assistant',
+      state: {
+        toolCall: {
+          'call-a': { status: 'success' },
+          'call-b': { status: 'success' },
+        },
+      },
+    })
+    expect(engine.messages.value.at(-1)).toMatchObject({
       role: 'assistant',
       content: 'done',
     })

--- a/packages/kit/src/vue/message/useMessage.test.ts
+++ b/packages/kit/src/vue/message/useMessage.test.ts
@@ -277,6 +277,9 @@ describe('useMessage', () => {
     await engine.sendMessage('ping')
 
     await waitFor(() => engine.messages.value[1]?.state?.toolCall?.['call-allow']?.status === 'awaiting-approval')
+    expect(engine.requestState.value).toBe('processing')
+    expect(engine.processingState.value).toBe('awaiting-tool-results')
+    expect(engine.isProcessing.value).toBe(true)
     expect(engine.messages.value[1]).toMatchObject({
       role: 'assistant',
       state: {
@@ -289,6 +292,12 @@ describe('useMessage', () => {
     expect(callTool).not.toHaveBeenCalled()
     expect(engine.messages.value).toHaveLength(2)
 
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await engine.sendMessage('should be blocked while awaiting tool results')
+    expect(warnSpy).toHaveBeenCalledWith('Cannot send message while processing is in progress')
+    warnSpy.mockRestore()
+    expect(engine.messages.value).toHaveLength(2)
+
     await engine.submitToolResult({
       role: 'tool',
       tool_call_id: 'call-allow',
@@ -297,6 +306,8 @@ describe('useMessage', () => {
     })
 
     expect(requestCount).toBe(0)
+    expect(engine.requestState.value).toBe('processing')
+    expect(engine.processingState.value).toBe('awaiting-tool-results')
     expect(engine.messages.value[1]).toMatchObject({
       role: 'assistant',
       state: {
@@ -315,6 +326,9 @@ describe('useMessage', () => {
     })
 
     expect(requestCount).toBe(1)
+    expect(engine.requestState.value).toBe('completed')
+    expect(engine.processingState.value).toBeUndefined()
+    expect(engine.isProcessing.value).toBe(false)
     expect(secondRequestToolMessages).toMatchObject([
       {
         role: 'tool',

--- a/packages/kit/src/vue/message/useMessage.ts
+++ b/packages/kit/src/vue/message/useMessage.ts
@@ -186,6 +186,7 @@ export const useMessage = (options: UseMessageOptions): UseMessageReturn => {
     isProcessing: adapter.isProcessing,
     sendMessage: engine.sendMessage,
     send: engine.send,
+    submitToolResult: engine.submitToolResult,
     abortRequest: engine.abort,
   } as UseMessageReturn
 }


### PR DESCRIPTION
Checkpoint commit for continuing work on another machine.

Adds submitToolResult, switches tool approval away from in-memory Promise waiting, updates Vue/tool UI/demo wiring, and records the remaining awaiting-tool-results serialization work in TODO/AGENTS docs.

The full pause/resume requirement is not complete yet.