### PR TITLE
fix(cli): correct DeepSeek API URL in basic template

### DIFF
--- a/packages/cli/templates/basic/src/models.ts
+++ b/packages/cli/templates/basic/src/models.ts
@@ -64,7 +64,7 @@ export const ModelConfigs: Record<string, ProviderModelConfig> = {
     ],
   },
   deepseek: {
-    apiUrl: 'https://api.deepseek.com/v1',
+    apiUrl: 'https://api.deepseek.com/chat/completions',
     icon: IconModelDeepseek,
     apiKey: import.meta.env.VITE_DEEPSEEK_API_KEY,
     models: [


### PR DESCRIPTION
## Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DeepSeek API endpoint configuration to use the correct service URL, ensuring proper integration with the DeepSeek provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->