### PR TITLE
fix: use boolean input for npm publish

### DIFF
--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -76,7 +76,7 @@ jobs:
 
       # 步骤8: 发布组件到NPM
       - name: Publish components
-        if: ${{ inputs.publish_npm == 'true' }}
+        if: ${{ inputs.publish_npm }}
         run: pnpm lerna publish from-package --pre-dist-tag ${{ inputs.tag }} --yes
         env:
           # 使用NPM令牌进行身份验证


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the publishing workflow so component publishing is triggered properly when the publish option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->