### PR TITLE
chore: update GitHub Actions to use latest versions of actions and Node.js 22

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -17,19 +17,19 @@ jobs:
     steps:
       # 步骤1: 检出代码
       - name: CheckOut Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
 
       # 步骤2: 设置pnpm包管理器
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       # 步骤3: 设置Node.js环境
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20 # 使用Node.js 20版本
+          node-version: 22 # 使用Node.js 22版本
           registry-url: 'https://registry.npmjs.org' # 设置npm registry地址
 
       # 步骤4: 获取pnpm缓存目录路径
@@ -39,7 +39,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       # 步骤5: 配置pnpm缓存
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22 # 使用Node.js 22版本
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org' # 设置npm registry地址
 
       # 步骤4: 获取pnpm缓存目录路径
@@ -43,8 +44,8 @@ jobs:
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          # 使用操作系统类型和pnpm-lock.yaml的哈希值作为缓存键
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          # 使用操作系统类型和依赖配置文件的哈希值作为缓存键
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/package.json', 'pnpm-workspace.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 

--- a/.github/workflows/deploy-playground-to-cdn.yml
+++ b/.github/workflows/deploy-playground-to-cdn.yml
@@ -55,6 +55,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22 # 使用Node.js 22版本
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org' # 设置npm registry地址
 
       # 步骤4: 获取pnpm缓存目录路径
@@ -68,8 +69,8 @@ jobs:
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          # 使用操作系统类型和pnpm-lock.yaml的哈希值作为缓存键
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          # 使用操作系统类型和依赖配置文件的哈希值作为缓存键
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/package.json', 'pnpm-workspace.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 

--- a/.github/workflows/deploy-playground-to-cdn.yml
+++ b/.github/workflows/deploy-playground-to-cdn.yml
@@ -42,19 +42,19 @@ jobs:
     steps:
       # 步骤1: 检出代码
       - name: CheckOut Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
 
       # 步骤2: 设置pnpm包管理器
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       # 步骤3: 设置Node.js环境
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20 # 使用Node.js 20版本
+          node-version: 22 # 使用Node.js 22版本
           registry-url: 'https://registry.npmjs.org' # 设置npm registry地址
 
       # 步骤4: 获取pnpm缓存目录路径
@@ -64,7 +64,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       # 步骤5: 配置pnpm缓存
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
@@ -121,7 +121,7 @@ jobs:
         run: ls -la ./packages/playground/dist
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playground-dist
           path: ./packages/playground/dist/
@@ -132,10 +132,10 @@ jobs:
     needs: [check-secrets, build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: playground-dist
           path: ./packages/playground/dist/

--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -35,19 +35,19 @@ jobs:
     steps:
       # 步骤1: 检出代码
       - name: CheckOut Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
 
       # 步骤2: 设置pnpm包管理器
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       # 步骤3: 设置Node.js环境
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20 # 使用Node.js 20版本
+          node-version: 22 # 使用Node.js 22版本
           registry-url: 'https://registry.npmjs.org' # 设置npm registry地址
 
       # 步骤4: 获取pnpm缓存目录路径
@@ -57,7 +57,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       # 步骤5: 配置pnpm缓存
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}

--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22 # 使用Node.js 22版本
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org' # 设置npm registry地址
 
       # 步骤4: 获取pnpm缓存目录路径
@@ -61,8 +62,8 @@ jobs:
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          # 使用操作系统类型和pnpm-lock.yaml的哈希值作为缓存键
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          # 使用操作系统类型和依赖配置文件的哈希值作为缓存键
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/package.json', 'pnpm-workspace.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 

--- a/.github/workflows/pr-ci-build.yml
+++ b/.github/workflows/pr-ci-build.yml
@@ -14,22 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Get pnpm store directory
         id: pnpm-cache
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -53,7 +53,7 @@ jobs:
         run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-${{ github.event.pull_request.head.sha || github.sha }}
           path: |

--- a/.github/workflows/pr-ci-build.yml
+++ b/.github/workflows/pr-ci-build.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -32,7 +33,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/package.json', 'pnpm-workspace.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 

--- a/.github/workflows/pr-ci-e2e-test.yml
+++ b/.github/workflows/pr-ci-e2e-test.yml
@@ -10,22 +10,22 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Get pnpm store directory
         id: pnpm-cache
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -36,7 +36,7 @@ jobs:
         run: pnpm i --no-frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-${{ github.event.pull_request.head.sha || github.sha }}
           path: .
@@ -50,7 +50,7 @@ jobs:
         run: pnpm test
 
       - name: Upload Playwright Test Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report-${{ github.sha }}

--- a/.github/workflows/pr-ci-e2e-test.yml
+++ b/.github/workflows/pr-ci-e2e-test.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -28,7 +29,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/package.json', 'pnpm-workspace.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 

--- a/.github/workflows/pr-ci-publish-packages.yml
+++ b/.github/workflows/pr-ci-publish-packages.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
 
       - name: Get pnpm store directory
@@ -33,7 +34,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/package.json', 'pnpm-workspace.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 

--- a/.github/workflows/pr-ci-publish-packages.yml
+++ b/.github/workflows/pr-ci-publish-packages.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Get pnpm store directory
@@ -30,7 +30,7 @@ jobs:
         run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -41,7 +41,7 @@ jobs:
         run: pnpm i --no-frozen-lockfile
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-${{ github.event.pull_request.head.sha || github.sha }}
           path: .
@@ -64,7 +64,7 @@ jobs:
           fi
 
       - name: Upload pkg.pr.new output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pkg-pr-new-output-${{ github.event.pull_request.head.sha || github.sha }}
           path: pkg-pr-new-output.json

--- a/.github/workflows/pr-deploy-preview.yml
+++ b/.github/workflows/pr-deploy-preview.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-${{ github.event.workflow_run.head_sha }}
           path: artifacts
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Download pkg.pr.new output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pkg-pr-new-output-${{ github.event.workflow_run.head_sha }}
           path: pkg-artifacts

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "robot-root",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "dev": "pnpm build:svgs && concurrently --names \"playground,docs\" --prefix-colors \"cyan,green\" \"pnpm dev:playground\" \"pnpm -F docs dev\"",
     "build": "pnpm build:components",
@@ -40,10 +40,5 @@
     "lint-staged": "^15.5.0",
     "prettier": "^3.5.3",
     "typescript": "^5.2.2"
-  },
-  "pnpm": {
-    "patchedDependencies": {
-      "vitepress-demo-plugin@1.5.0": "patches/vitepress-demo-plugin@1.5.0.patch"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ packages:
   - packages/**
   - '!packages/cli/templates/**'
   - docs
+
+patchedDependencies:
+  vitepress-demo-plugin@1.5.0: patches/vitepress-demo-plugin@1.5.0.patch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated build, testing, publishing, and deployment workflows to newer GitHub Actions tooling.
  * Upgraded the Node.js runtime to 22 across CI and deployment workflows.
  * Modernized CI caching and adjusted cache key inputs for faster, more reliable installs.
  * Improved artifact upload/download handling across CI, preview, and CDN deployment workflows.
  * Updated the project’s pnpm version to 10.34.5 and relocated the local patch configuration for the VitePress demo plugin to the workspace setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->