### PR TITLE
docs: define skill demo css variable migration

### DIFF
--- a/docs/demos/tools/skill/SkillInspector.css
+++ b/docs/demos/tools/skill/SkillInspector.css
@@ -7,9 +7,9 @@
 
 .skill-inspector .panel {
   min-width: 0;
-  border: 1px solid var(--vp-c-divider);
+  border: 1px solid color-mix(in srgb, var(--tr-text-primary) 8%, transparent);
   border-radius: 8px;
-  background: var(--vp-c-bg);
+  background: var(--tr-container-bg-default);
   padding: 16px;
 }
 
@@ -32,7 +32,7 @@
 
 .skill-inspector .panel-heading p {
   margin: 0;
-  color: var(--vp-c-text-2);
+  color: var(--tr-text-secondary);
   font-size: 13px;
   line-height: 1.6;
   overflow-wrap: anywhere;
@@ -48,10 +48,10 @@
 .skill-inspector .directory-picker {
   min-width: 0;
   min-height: 36px;
-  border: 1px solid var(--vp-c-divider);
+  border: 1px solid color-mix(in srgb, var(--tr-text-primary) 8%, transparent);
   border-radius: 6px;
-  background: var(--vp-c-bg-soft);
-  color: var(--vp-c-text-1);
+  background: var(--tr-container-bg-default-2);
+  color: var(--tr-text-primary);
   cursor: pointer;
   font-size: 13px;
   line-height: 1.3;
@@ -74,13 +74,13 @@
 }
 
 .skill-inspector .primary-action:hover {
-  border-color: var(--vp-c-brand-1);
-  color: var(--vp-c-brand-1);
+  border-color: var(--tr-color-primary);
+  color: var(--tr-color-primary);
 }
 
 .skill-inspector .danger-action:hover:not(:disabled) {
-  border-color: var(--vp-c-danger-1);
-  color: var(--vp-c-danger-1);
+  border-color: var(--tr-color-error);
+  color: var(--tr-color-error);
 }
 
 .skill-inspector .directory-picker {
@@ -89,7 +89,7 @@
   justify-content: center;
   min-width: 0;
   padding: 0 10px;
-  color: var(--vp-c-text-2);
+  color: var(--tr-text-secondary);
   text-align: center;
 }
 
@@ -107,7 +107,7 @@
   font-size: 13px;
   line-height: 1.5;
   overflow-wrap: anywhere;
-  color: var(--vp-c-danger-1);
+  color: var(--tr-color-error);
 }
 
 .skill-inspector .skill-list {
@@ -123,7 +123,7 @@
   justify-content: space-between;
   gap: 10px;
   padding: 10px;
-  border: 1px solid var(--vp-c-divider);
+  border: 1px solid color-mix(in srgb, var(--tr-text-primary) 8%, transparent);
   border-radius: 8px;
   cursor: pointer;
   min-width: 0;
@@ -134,9 +134,9 @@
 }
 
 .skill-inspector .skill-item.active {
-  border-color: var(--vp-c-brand-1);
-  box-shadow: 0 0 0 1px var(--vp-c-brand-1) inset;
-  background: var(--vp-c-bg-soft);
+  border-color: var(--tr-color-primary);
+  box-shadow: 0 0 0 1px var(--tr-color-primary) inset;
+  background: var(--tr-container-bg-default-2);
 }
 
 .skill-inspector .skill-item strong,
@@ -147,13 +147,13 @@
 
 .skill-inspector .skill-item small {
   margin-top: 4px;
-  color: var(--vp-c-text-2);
+  color: var(--tr-text-secondary);
   line-height: 1.5;
 }
 
 .skill-inspector .skill-item em {
   flex: none;
-  color: var(--vp-c-text-3);
+  color: var(--tr-text-tertiary);
   font-size: 12px;
   font-style: normal;
   line-height: 20px;
@@ -199,21 +199,21 @@
 }
 
 .skill-inspector .file-node.active {
-  border-color: var(--vp-c-brand-1);
-  color: var(--vp-c-brand-1);
-  background: var(--vp-c-bg-soft);
+  border-color: var(--tr-color-primary);
+  color: var(--tr-color-primary);
+  background: var(--tr-container-bg-default-2);
 }
 
 .skill-inspector .file-node.folder {
   cursor: default;
   border-color: transparent;
   background: transparent;
-  color: var(--vp-c-text-2);
+  color: var(--tr-text-secondary);
   font-weight: 600;
 }
 
 .skill-inspector .file-node.folder:hover {
-  color: var(--vp-c-text-2);
+  color: var(--tr-text-secondary);
 }
 
 .skill-inspector .file-node span {
@@ -223,7 +223,7 @@
 
 .skill-inspector .file-node em {
   flex: none;
-  color: var(--vp-c-text-3);
+  color: var(--tr-text-tertiary);
   font-size: 11px;
   font-style: normal;
 }
@@ -243,9 +243,9 @@
   margin: 0;
   overflow: auto;
   border-radius: 8px;
-  background: var(--vp-code-block-bg);
+  background: var(--tr-container-bg-default-2);
   padding: 14px;
-  color: var(--vp-code-block-color);
+  color: var(--tr-text-primary);
   font-size: 13px;
   line-height: 1.6;
 }

--- a/docs/demos/tools/skill/VueSkillPlugin.css
+++ b/docs/demos/tools/skill/VueSkillPlugin.css
@@ -17,9 +17,9 @@
 }
 
 .skill-chat-demo .skill-sidebar {
-  border: 1px solid var(--vp-c-divider);
+  border: 1px solid color-mix(in srgb, var(--tr-text-primary) 8%, transparent);
   border-radius: 8px;
-  background: var(--vp-c-bg);
+  background: var(--tr-container-bg-default);
   padding: 14px;
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -36,7 +36,7 @@
 }
 
 .skill-chat-demo .sidebar-hint {
-  color: var(--vp-c-text-2);
+  color: var(--tr-text-secondary);
   font-size: 12px;
   line-height: 1.5;
   margin: 0 0 10px;
@@ -53,7 +53,7 @@
   align-items: flex-start;
   gap: 6px;
   padding: 8px;
-  border: 1px solid var(--vp-c-divider);
+  border: 1px solid color-mix(in srgb, var(--tr-text-primary) 8%, transparent);
   border-radius: 6px;
   cursor: pointer;
 }
@@ -74,7 +74,7 @@
 
 .skill-chat-demo .skill-option small {
   margin-top: 2px;
-  color: var(--vp-c-text-2);
+  color: var(--tr-text-secondary);
   font-size: 11px;
   line-height: 1.4;
 }
@@ -88,21 +88,21 @@
 }
 
 .skill-chat-demo .selected-summary span {
-  color: var(--vp-c-text-2);
+  color: var(--tr-text-secondary);
   font-size: 11px;
 }
 
 .skill-chat-demo .selected-summary strong {
   border-radius: 999px;
-  background: var(--vp-c-bg-soft);
-  color: var(--vp-c-brand-1);
+  background: var(--tr-container-bg-default-2);
+  color: var(--tr-color-primary);
   padding: 2px 6px;
   font-size: 11px;
   line-height: 16px;
 }
 
 .skill-chat-demo .selected-summary em {
-  color: var(--vp-c-text-3);
+  color: var(--tr-text-tertiary);
   font-size: 12px;
   font-style: normal;
 }
@@ -110,16 +110,16 @@
 .skill-chat-demo .subsection-title {
   margin: 0 0 4px;
   font-size: 12px;
-  color: var(--vp-c-text-2);
+  color: var(--tr-text-secondary);
 }
 
 .skill-chat-demo .sidebar-pre {
   margin: 0 0 10px;
   overflow: auto;
   border-radius: 6px;
-  background: var(--vp-code-block-bg);
+  background: var(--tr-container-bg-default-2);
   padding: 8px;
-  color: var(--vp-code-block-color);
+  color: var(--tr-text-primary);
   font-size: 11px;
   line-height: 1.5;
   min-height: 60px;

--- a/packages/playground/src/utils/import-map.ts
+++ b/packages/playground/src/utils/import-map.ts
@@ -39,21 +39,22 @@ export function generateImportMap(options: ImportMapOptions) {
       'markdown-it': 'https://cdn.jsdelivr.net/npm/markdown-it@14/dist/markdown-it.min.js',
       echarts: 'https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js',
       idb: 'https://cdn.jsdelivr.net/npm/idb@8/+esm',
+      yaml: 'https://cdn.jsdelivr.net/npm/yaml@2/browser/index.min.js',
 
       // Tiptap 编辑器相关包 (用于 Sender 组件)
       // 使用 esm.sh CDN，自动处理子路径导入和依赖解析
       // 添加 ?external=vue 参数，避免 Vue 版本冲突
-      '@tiptap/core': 'https://esm.sh/@tiptap/core@3.11.0',
-      '@tiptap/vue-3': 'https://esm.sh/@tiptap/vue-3@3.11.0?external=vue',
-      '@tiptap/pm/state': 'https://esm.sh/@tiptap/pm@3.11.0/state',
-      '@tiptap/pm/view': 'https://esm.sh/@tiptap/pm@3.11.0/view',
-      '@tiptap/pm/model': 'https://esm.sh/@tiptap/pm@3.11.0/model',
-      '@tiptap/extension-document': 'https://esm.sh/@tiptap/extension-document@3.11.0',
-      '@tiptap/extension-paragraph': 'https://esm.sh/@tiptap/extension-paragraph@3.11.0',
-      '@tiptap/extension-text': 'https://esm.sh/@tiptap/extension-text@3.11.0',
-      '@tiptap/extension-history': 'https://esm.sh/@tiptap/extension-history@3.11.0',
-      '@tiptap/extension-placeholder': 'https://esm.sh/@tiptap/extension-placeholder@3.11.0',
-      '@tiptap/extension-character-count': 'https://esm.sh/@tiptap/extension-character-count@3.11.0',
+      '@tiptap/core': 'https://esm.sh/@tiptap/core@3.17.1',
+      '@tiptap/vue-3': 'https://esm.sh/@tiptap/vue-3@3.17.1?external=vue',
+      '@tiptap/pm/state': 'https://esm.sh/@tiptap/pm@3.17.1/state',
+      '@tiptap/pm/view': 'https://esm.sh/@tiptap/pm@3.17.1/view',
+      '@tiptap/pm/model': 'https://esm.sh/@tiptap/pm@3.17.1/model',
+      '@tiptap/extension-document': 'https://esm.sh/@tiptap/extension-document@3.17.1',
+      '@tiptap/extension-paragraph': 'https://esm.sh/@tiptap/extension-paragraph@3.17.1',
+      '@tiptap/extension-text': 'https://esm.sh/@tiptap/extension-text@3.17.1',
+      '@tiptap/extension-history': 'https://esm.sh/@tiptap/extension-history@3.17.1',
+      '@tiptap/extension-placeholder': 'https://esm.sh/@tiptap/extension-placeholder@3.17.1',
+      '@tiptap/extension-character-count': 'https://esm.sh/@tiptap/extension-character-count@3.17.1',
 
       ...extraImportsMap,
     },


### PR DESCRIPTION
- skill demo中的 vitepress css变量统一替换成 tiny-robot 的 css 变量(vitepress的css变量在playground未引入)
- 更新 playground 的 import map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated skill demo panels, controls, sidebars, badges, file trees, and code blocks to use the latest design tokens for more consistent theming.
  - Refined border, text, primary, secondary, tertiary, and error colors while preserving existing layout and interactions.

- **Enhancements**
  - Improved the playground’s support for YAML imports.
  - Updated Tiptap integrations to a newer version for improved compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->