### PR TITLE
fix(thinkingPlugin): update thinking condition to use length check

### DIFF
--- a/packages/kit/src/message/plugins/thinkingPlugin.ts
+++ b/packages/kit/src/message/plugins/thinkingPlugin.ts
@@ -13,7 +13,7 @@ export const thinkingPlugin = (options: MessageEnginePlugin = {}): MessageEngine
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const c = choice as any
       const reasoning_content = c?.message?.reasoning_content || c?.delta?.reasoning_content
-      const thinking = typeof reasoning_content === 'string' && reasoning_content.trim() !== ''
+      const thinking = typeof reasoning_content === 'string' && reasoning_content.length > 0
 
       if (thinking) {
         if (currentMessage.state && typeof currentMessage.state === 'object') {


### PR DESCRIPTION
问题：在某些场景出现  "正在思考->已思考->正在思考" 状态频繁转换

reasoning_content 在传输过程中可能是长度大于0的空白字符串

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of thinking content so whitespace-only text is handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->