### PR TITLE
styles(docs): optimize docs layout and mobile navigation styles

### DIFF
--- a/docs/.vitepress/theme/components/CustomHeader.vue
+++ b/docs/.vitepress/theme/components/CustomHeader.vue
@@ -468,4 +468,19 @@ const openSearch = () => {
     transition: none;
   }
 }
+@media (max-width: 360px) {
+  .logo-icon {
+    width: 36px;
+    height: 36px;
+  }
+
+  .home-link svg {
+    display: none;
+  }
+
+  .tool-button {
+    width: 24px;
+    height: 24px;
+  }
+}
 </style>

--- a/docs/.vitepress/theme/components/CustomHeader.vue
+++ b/docs/.vitepress/theme/components/CustomHeader.vue
@@ -213,6 +213,7 @@ const openSearch = () => {
 .custom-header {
   --vp-c-divider: #f9f9f9;
   --search-border-color: #dfdfdf;
+  --header-inline-padding: 24px;
 
   position: sticky;
   top: 0;
@@ -230,18 +231,19 @@ const openSearch = () => {
 }
 
 .header-container {
-  max-width: 92rem;
-  margin: 0 auto;
   width: 100%;
 }
 
 /* 第一行样式 */
 .header-top {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(280px, 1fr) auto;
+  column-gap: clamp(20px, 3vw, 40px);
   height: 4rem;
   align-items: center;
-  justify-content: space-between;
+  justify-content: stretch;
   border-bottom: 1px solid var(--vp-c-divider);
+  padding: 0 var(--header-inline-padding);
 }
 
 .logo-section {
@@ -270,9 +272,10 @@ const openSearch = () => {
 /* 搜索栏样式 */
 .search-section {
   display: flex;
-  flex: 1;
+  justify-self: center;
+  width: 100%;
   max-width: 512px;
-  margin: 0 32px;
+  margin: 0;
 }
 
 .search-container {
@@ -332,6 +335,7 @@ const openSearch = () => {
 .tools-section {
   display: flex;
   align-items: center;
+  justify-self: end;
   gap: 8px;
 }
 
@@ -379,25 +383,38 @@ const openSearch = () => {
 
 /* 第二行样式 */
 .header-bottom {
+  display: flex;
   height: var(--vp-nav-bottom-height);
   align-items: center;
-  padding-left: 3rem;
-  padding-right: 3rem;
+  overflow-x: auto;
+  padding: 0 var(--header-inline-padding);
+  scrollbar-width: none;
+}
+
+.header-bottom::-webkit-scrollbar {
+  display: none;
 }
 
 /* 响应式设计 */
-@media (min-width: 1024px) {
-  .header-bottom {
-    display: flex;
+@media (min-width: 960px) {
+  .custom-header {
+    --header-inline-padding: 32px;
   }
+}
+
+@media (min-width: 1024px) {
   .header-top {
-    padding: 0 3rem;
     margin-left: 0;
     margin-right: 0;
   }
 }
 
 @media (max-width: 768px) {
+  .header-top {
+    grid-template-columns: auto 1fr auto;
+    column-gap: 16px;
+  }
+
   .search-section {
     display: none;
   }

--- a/docs/.vitepress/theme/components/CustomHeader.vue
+++ b/docs/.vitepress/theme/components/CustomHeader.vue
@@ -429,8 +429,13 @@ const openSearch = () => {
 }
 
 @media (max-width: 640px) {
+  .custom-header {
+    --header-inline-padding: 12px;
+  }
+
   .header-top {
-    padding: 0 12px;
+    column-gap: 6px;
+    padding-right: 8px;
   }
 
   .tools-section {

--- a/docs/.vitepress/theme/components/TabNavigation.vue
+++ b/docs/.vitepress/theme/components/TabNavigation.vue
@@ -279,15 +279,15 @@ onUnmounted(() => {
 @media (max-width: 768px) {
   .custom-tabs {
     &__header {
-      padding: 0 12px;
+      padding: 0;
     }
 
     &__nav {
-      gap: 2px;
+      gap: 24px;
     }
 
     &__item {
-      padding: 6px 12px;
+      padding: 0;
       font-size: 13px;
     }
   }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -236,8 +236,68 @@ div:has(h1[id='bubble-气泡组件']) {
 }
 
 .main-content > .Layout {
-  min-height: calc(100vh - 113px);
-  min-height: calc(100dvh - 113px);
+  min-height: calc(100vh - var(--vp-nav-height) - var(--vp-nav-bottom-height) - 1px);
+  min-height: calc(100dvh - var(--vp-nav-height) - var(--vp-nav-bottom-height) - 1px);
+}
+
+/* ===== 文档页宽屏布局优化 ===== */
+.main-content {
+  --tr-doc-aside-width: 224px;
+  --tr-doc-side-gap: clamp(48px, 2.5vw, 96px);
+  --tr-doc-content-max-width: clamp(920px, 60vw, 4640px);
+  --tr-doc-demo-content-max-width: clamp(1200px, 68vw, 5200px);
+}
+
+@media (min-width: 1280px) {
+  .main-content .VPDoc.has-aside .container {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) var(--tr-doc-aside-width);
+    column-gap: var(--tr-doc-side-gap);
+    align-items: start;
+    justify-content: stretch;
+    width: 100%;
+    max-width: none !important;
+  }
+
+  .main-content .VPDoc.has-aside > .container > .content {
+    grid-column: 1;
+    grid-row: 1;
+    min-width: 0;
+    max-width: none;
+    width: 100%;
+  }
+
+  .main-content .VPDoc.has-aside .content-container {
+    width: 100%;
+    max-width: min(100%, var(--tr-doc-content-max-width)) !important;
+    margin: 0 auto;
+  }
+
+  .main-content .VPDoc:has(.vitepress-demo-plugin__container) .content-container,
+  .main-content .VPDoc:has(.vitepress-demo-plugin-placeholder__container) .content-container {
+    max-width: min(100%, var(--tr-doc-demo-content-max-width)) !important;
+  }
+
+  .main-content .VPDoc.has-aside > .container > .aside {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+    width: var(--tr-doc-aside-width) !important;
+    max-width: var(--tr-doc-aside-width) !important;
+    padding-left: 0 !important;
+  }
+}
+
+@media (min-width: 1440px) {
+  .main-content .VPContent.has-sidebar {
+    padding-left: calc(var(--vp-sidebar-width) + var(--tr-doc-side-gap)) !important;
+    padding-right: var(--tr-doc-side-gap) !important;
+  }
+
+  .main-content .VPSidebar {
+    width: var(--vp-sidebar-width) !important;
+    padding-left: 32px !important;
+  }
 }
 
 /* ===== 响应式布局 ===== */


### PR DESCRIPTION
## 背景

文档站在不同屏幕尺寸下存在布局体验问题：

- 宽屏下文档内容区和右侧目录区域宽度受限，组件 demo 展示空间不足。
- 顶部 header 第一行和第二行导航的横向间距不统一。
- 移动端窄屏下，header 右侧操作区容易挤压 Logo 文案。
- 移动端二级导航存在多层 padding 叠加，导致导航项位置和选中下划线展示不自然。

## 修改内容

- 优化文档站顶部 Header 布局
  - Header 容器改为占满宽度，不再受固定最大宽度限制。
  - Header 第一行由 flex 调整为 grid，使 Logo、搜索框、右侧工具区布局更稳定。
  - 抽取 `--header-inline-padding`，统一 Header 第一行和第二行导航的横向间距。
  - 第二行导航支持横向滚动，避免窄屏下内容被裁切。

- 优化文档页宽屏展示
  - 调整文档内容区和右侧目录的栅格布局。
  - 增加普通文档页和 demo 文档页的内容最大宽度配置。
  - 优化宽屏下侧边栏、正文、右侧目录之间的间距。
  - 使用 VitePress 导航高度变量计算主内容最小高度，减少硬编码。

- 修复移动端样式问题
  - 在 `max-width: 640px` 下收窄 Header 横向间距，改善 Samsung Galaxy S8+ 等窄屏设备下的挤压问题。
  - 调整移动端二级导航 padding 和 gap，避免多层间距叠加，使导航项和选中下划线展示更自然。

## 影响范围

- 仅涉及文档站主题样式和布局调整。
- 不影响组件库运行逻辑和公开 API。

## 验证

- 已检查窄屏移动端场景下 Header 和二级导航展示。
- 已执行 `git diff --check`，无空白格式问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style

* Improved documentation header alignment and responsive spacing across screen sizes.
* Added horizontal scrolling for secondary navigation on smaller screens.
* Enhanced wide-screen documentation layouts with better content, sidebar, and spacing proportions.
* Updated content height handling to adapt dynamically to the navigation layout.
* Improved mobile tab navigation spacing and touch-friendly presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->