### PR TITLE
perf: batch reasoning renderer updates

### DIFF
--- a/packages/components/src/bubble/renderers/Reasoning.vue
+++ b/packages/components/src/bubble/renderers/Reasoning.vue
@@ -37,11 +37,16 @@ const scrollDetailToBottom = () => {
 }
 
 const scheduleDetailUpdate = () => {
+  if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+    displayedReasoningContent.value = props.message.reasoning_content ?? ''
+    return
+  }
+
   if (renderFrame !== null) {
     return
   }
 
-  renderFrame = requestAnimationFrame(() => {
+  renderFrame = window.requestAnimationFrame(() => {
     renderFrame = null
     displayedReasoningContent.value = props.message.reasoning_content ?? ''
     nextTick(scrollDetailToBottom)
@@ -80,8 +85,9 @@ const handleClick = () => {
 }
 
 onBeforeUnmount(() => {
-  if (renderFrame !== null) {
-    cancelAnimationFrame(renderFrame)
+  if (renderFrame !== null && typeof window !== 'undefined') {
+    window.cancelAnimationFrame(renderFrame)
+    renderFrame = null
   }
 })
 </script>

--- a/packages/components/src/bubble/renderers/Reasoning.vue
+++ b/packages/components/src/bubble/renderers/Reasoning.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { IconArrowDown, IconAtom } from '@opentiny/tiny-robot-svgs'
-import { nextTick, ref, watch, watchEffect } from 'vue'
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import { useBubbleContentRenderer, useBubbleEventFn, useOmitMessageFields } from '../composables'
 import { BubbleContentRendererProps, ChatMessageContent } from '../index.type'
 
@@ -23,16 +23,53 @@ const { restMessage, restProps } = useOmitMessageFields(props, ['reasoning_conte
 const renderer = useBubbleContentRenderer(restMessage, props.contentIndex)
 
 const open = ref(true)
+const displayedReasoningContent = ref(props.message.reasoning_content ?? '')
+const detailRef = ref<HTMLParagraphElement | null>(null)
 
-watchEffect(() => {
-  // 思考过程默认展开
-  open.value = props.message.state?.open ?? true
-})
+let renderFrame: number | null = null
+
+const scrollDetailToBottom = () => {
+  if (!open.value || !detailRef.value) {
+    return
+  }
+
+  detailRef.value.scrollTop = detailRef.value.scrollHeight
+}
+
+const scheduleDetailUpdate = () => {
+  if (renderFrame !== null) {
+    return
+  }
+
+  renderFrame = requestAnimationFrame(() => {
+    renderFrame = null
+    displayedReasoningContent.value = props.message.reasoning_content ?? ''
+    nextTick(scrollDetailToBottom)
+  })
+}
+
+watch(
+  () => props.message.state?.open,
+  (value) => {
+    // 思考过程默认展开
+    open.value = value ?? true
+    if (open.value) {
+      scheduleDetailUpdate()
+    }
+  },
+  { immediate: true },
+)
+
+watch(() => props.message.reasoning_content, scheduleDetailUpdate, { immediate: true })
 
 const handleBubbleEvent = useBubbleEventFn()
 
 const handleClick = () => {
   open.value = !open.value
+  if (open.value) {
+    scheduleDetailUpdate()
+  }
+
   handleBubbleEvent({
     name: 'state:update',
     payload: {
@@ -42,23 +79,11 @@ const handleClick = () => {
   })
 }
 
-const detailRef = ref<HTMLParagraphElement | null>(null)
-
-watch(
-  () => props.message.reasoning_content,
-  () => {
-    nextTick(() => {
-      if (!detailRef.value) {
-        return
-      }
-
-      detailRef.value.scrollTo({
-        top: detailRef.value.scrollHeight,
-        behavior: 'smooth',
-      })
-    })
-  },
-)
+onBeforeUnmount(() => {
+  if (renderFrame !== null) {
+    cancelAnimationFrame(renderFrame)
+  }
+})
 </script>
 
 <template>
@@ -77,7 +102,7 @@ watch(
         </div>
         <div class="border-line"></div>
       </div>
-      <p class="detail-content" ref="detailRef">{{ props.message.reasoning_content }}</p>
+      <p class="detail-content" ref="detailRef">{{ displayedReasoningContent }}</p>
     </div>
   </div>
   <component :is="renderer.renderer" v-bind="{ ...renderer.attributes, ...restProps }" />


### PR DESCRIPTION
# 优化 Reasoning 流式内容渲染，避免大文本场景卡顿

## 背景

Reasoning 内容持续流式增长时，组件会频繁更新文本并执行自动滚动。原实现每次更新都会触发 `nextTick` 和 `smooth` 滚动，内容较大时容易造成主线程阻塞，导致页面卡顿。

## 改动内容

- 使用 `requestAnimationFrame` 合并高频内容更新
- 增加本地展示缓冲，减少重复文本渲染
- 将平滑滚动改为直接设置 `scrollTop`
- 组件卸载时取消未执行的动画帧任务
- 保留原有展开、收起和自动滚动行为

## 验证

- 流式超大 `reasoning_content` 测试通过
- `pnpm -F @opentiny/tiny-robot build` 构建通过
- 修改范围：`packages/components/src/bubble/renderers/Reasoning.vue`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reasoning content now appears more smoothly as it updates.
  * Expanded reasoning sections automatically stay scrolled to the latest content.
  * Scrolling behavior is more consistent when opening sections or receiving new reasoning updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->