### PR TITLE
chore: migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -9,15 +9,15 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
-  id-token: write
-
 # 定义工作流中的作业
 jobs:
   build:
     # 指定运行环境为最新版本的ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      dist_tag: ${{ steps.parse_tag.outputs.dist_tag }}
     steps:
       # 步骤1: 检出代码
       - name: CheckOut Code
@@ -91,13 +91,79 @@ jobs:
             exit 1
           fi
 
-      # 步骤8: 发布组件到NPM
-      - name: Publish components
-        run: pnpm lerna publish from-package --pre-dist-tag ${{ steps.parse_tag.outputs.dist_tag }} --yes
+      # 步骤8: 构建文档
+      - name: Build VitePress
+        run: pnpm build:docs --nocomponents
+        env:
+          VITEPRESS_BASE: /tiny-robot/${{ steps.parse_tag.outputs.dist_tag }}/
+          PLAYGROUND_BASE: /tiny-robot/${{ steps.parse_tag.outputs.dist_tag }}/playground
 
-      # 步骤9: 发布组件到GitHub Release
+      - name: Verify build output
+        run: ls -la ./docs/dist
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: package-dist
+          path: |
+            packages/components/dist
+            packages/kit/dist
+            packages/svgs/dist
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload docs artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: docs-dist
+          path: docs/dist
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: CheckOut Code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          package-manager-cache: false
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install publish dependencies
+        run: pnpm i --no-frozen-lockfile --ignore-scripts
+
+      - name: Download package artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: package-dist
+          path: ./packages
+
+      # 步骤9: 发布组件到NPM
+      - name: Publish components
+        run: pnpm lerna publish from-package --pre-dist-tag ${{ needs.build.outputs.dist_tag }} --yes
+
+  release:
+    needs: [build, publish]
+    if: ${{ needs.build.outputs.dist_tag == 'latest' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # 步骤10: 发布组件到GitHub Release
       - name: Release
-        if: ${{ steps.parse_tag.outputs.dist_tag == 'latest' }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
@@ -105,22 +171,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
-      # 步骤10: 构建文档
-      - name: Build VitePress
-        run: pnpm build:docs --nocomponents
-        env:
-          VITEPRESS_BASE: /tiny-robot/${{steps.parse_tag.outputs.dist_tag}}/
-          PLAYGROUND_BASE: /tiny-robot/${{steps.parse_tag.outputs.dist_tag}}/playground
-
-      - name: Verify build output
-        run: ls -la ./docs/dist
+  deploy-docs:
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download docs artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: docs-dist
+          path: ./docs/dist
 
       - name: Deploy docs
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/dist
-          destination_dir: ./${{steps.parse_tag.outputs.dist_tag}}/
+          destination_dir: ./${{ needs.build.outputs.dist_tag }}/
           keep_files: true
           force_orphan: false
           user_name: 'github-actions[bot]'

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -164,12 +164,11 @@ jobs:
     steps:
       # 步骤10: 发布组件到GitHub Release
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
   deploy-docs:
     needs: [build, publish]
@@ -184,7 +183,7 @@ jobs:
           path: ./docs/dist
 
       - name: Deploy docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/dist

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+  id-token: write
+
 # 定义工作流中的作业
 jobs:
   build:
@@ -29,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 22 # 使用Node.js 22版本
+          node-version: 24 # 使用Node.js 24版本
           package-manager-cache: false
           registry-url: 'https://registry.npmjs.org' # 设置npm registry地址
 
@@ -89,10 +93,7 @@ jobs:
 
       # 步骤8: 发布组件到NPM
       - name: Publish components
-        run: pnpm lerna publish from-package --pre-dist-tag ${{steps.parse_tag.outputs.dist_tag}} --yes
-        env:
-          # 使用NPM令牌进行身份验证
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_OPENTINY_ROBOT_TOKEN }}
+        run: pnpm lerna publish from-package --pre-dist-tag ${{ steps.parse_tag.outputs.dist_tag }} --yes
 
       # 步骤9: 发布组件到GitHub Release
       - name: Release

--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -33,8 +33,7 @@ jobs:
     # 指定运行环境为最新版本的ubuntu
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
+      contents: read
     steps:
       # 步骤1: 检出代码
       - name: CheckOut Code
@@ -78,12 +77,7 @@ jobs:
       - name: Run Build Components
         run: pnpm build
 
-      # 步骤8: 发布组件到NPM
-      - name: Publish components
-        if: ${{ inputs.publish_npm }}
-        run: pnpm lerna publish from-package --pre-dist-tag ${{ inputs.tag }} --yes
-
-      # 步骤9: 构建文档
+      # 步骤8: 构建文档
       - name: Build VitePress
         run: pnpm build:docs --nocomponents
         env:
@@ -92,6 +86,75 @@ jobs:
 
       - name: Verify build output
         run: ls -la ./docs/dist
+
+      - name: Upload package artifacts
+        if: ${{ inputs.publish_npm }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: dispatch-package-dist
+          path: |
+            packages/components/dist
+            packages/kit/dist
+            packages/svgs/dist
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload docs artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: dispatch-docs-dist
+          path: docs/dist
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: build
+    if: ${{ inputs.publish_npm }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: CheckOut Code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          package-manager-cache: false
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install publish dependencies
+        run: pnpm i --no-frozen-lockfile --ignore-scripts
+
+      - name: Download package artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: dispatch-package-dist
+          path: ./packages
+
+      # 步骤9: 发布组件到NPM
+      - name: Publish components
+        run: pnpm lerna publish from-package --pre-dist-tag ${{ inputs.tag }} --yes
+
+  deploy-docs:
+    needs: [build, publish]
+    if: ${{ always() && needs.build.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download docs artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: dispatch-docs-dist
+          path: ./docs/dist
 
       - name: Deploy docs
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -157,7 +157,7 @@ jobs:
           path: ./docs/dist
 
       - name: Deploy docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/dist

--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -32,6 +32,9 @@ jobs:
   build:
     # 指定运行环境为最新版本的ubuntu
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       # 步骤1: 检出代码
       - name: CheckOut Code
@@ -47,7 +50,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 22 # 使用Node.js 22版本
+          node-version: 24 # 使用Node.js 24版本
           package-manager-cache: false
           registry-url: 'https://registry.npmjs.org' # 设置npm registry地址
 
@@ -79,9 +82,6 @@ jobs:
       - name: Publish components
         if: ${{ inputs.publish_npm }}
         run: pnpm lerna publish from-package --pre-dist-tag ${{ inputs.tag }} --yes
-        env:
-          # 使用NPM令牌进行身份验证
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_OPENTINY_ROBOT_TOKEN }}
 
       # 步骤9: 构建文档
       - name: Build VitePress

--- a/lerna.json
+++ b/lerna.json
@@ -11,5 +11,6 @@
     "npmClient": "pnpm"
   },
   "ignoreChanges": ["**/*.md", "**/test/**", ".npmrc"],
-  "granularPathspec": false
+  "granularPathspec": false,
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-vue": "^10.0.0",
     "husky": "^9.1.7",
     "jiti": "^2.4.2",
-    "lerna": "^7.2.0",
+    "lerna": "^9.0.7",
     "lint-staged": "^15.5.0",
     "prettier": "^3.5.3",
     "typescript": "^5.2.2"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,13 @@
   "name": "@opentiny/tiny-robot-cli",
   "version": "0.5.0",
   "description": "CLI to scaffold TinyRobot product projects",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/opentiny/tiny-robot.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "bin": {
     "tiny-robot-cli": "./bin/cli.js"


### PR DESCRIPTION
## Summary

- migrate both tag-triggered and manually dispatched npm publishing from a long-lived npm token to GitHub OIDC trusted publishing
- scope the automatic release workflow permissions by separating build, npm publish, GitHub Release, and docs deployment jobs, with artifacts passed between jobs
- use Node.js 24 and Lerna v9 for trusted publishing support
- add repository and public publish metadata for `@opentiny/tiny-robot-cli`

## Verification

- `pnpm build`
- `VITEPRESS_BASE=/tiny-robot/latest/ PLAYGROUND_BASE=/tiny-robot/latest/playground pnpm build:docs --nocomponents`
- `pnpm i --no-frozen-lockfile --ignore-scripts`
- parsed both workflow files and verified their job permissions, Node.js versions, artifact dependencies, and removal of long-lived npm token references

GitHub Actions OIDC publishing verification:

<img width="1479" height="544" alt="image" src="https://github.com/user-attachments/assets/9f87618d-7c71-4b18-b801-7b0f1e03eabf" />
<img width="1011" height="266" alt="image" src="https://github.com/user-attachments/assets/d3d54355-6aff-432d-9d98-8fa96a37cd59" />

## Notes

- `pnpm-lock.yaml` remains intentionally untracked because this repository explicitly ignores package-manager lockfiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflows to improve automated package, documentation, and release publishing.
  * Upgraded the project’s Lerna tooling and added configuration schema metadata.
  * Updated workflow tooling to use Node.js 24.
  * Configured the CLI package with repository details and public publishing settings.
  * Improved release handling for different distribution channels and documentation deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
