### PR TITLE
feat(sender-template): support appendTo for template select

### DIFF
--- a/docs/src/components/sender.md
+++ b/docs/src/components/sender.md
@@ -78,6 +78,7 @@ TrSender.mention(mentions, '@')
 TrSender.suggestion(suggestions) // 不过滤
 TrSender.suggestion(suggestions, { filterFn: customFilter }) // 自定义过滤
 TrSender.template(templates)
+TrSender.template(templates, { appendTo: '.chat-window' })
 
 // 标准配置（用于复杂场景）
 TrSender.Mention.configure({ items: mentions, char: '@', allowSpaces: false })
@@ -310,14 +311,16 @@ Sender 提供了多个插槽位置，方便扩展功能：
 ```typescript
 // 便捷函数
 TrSender.template(templates)
+TrSender.template(templates, { appendTo: '.chat-window' })
 
 // 标准配置
-TrSender.Template.configure({ items: templates })
+TrSender.Template.configure({ items: templates, appendTo: '.chat-window' })
 ```
 
 | 配置项  | 类型                                      | 说明         |
 | ------- | ----------------------------------------- | ------------ |
 | `items` | `TemplateItem[]` \| `Ref<TemplateItem[]>` | 模板数据列表 |
+| `appendTo` | `string` \| `HTMLElement` | Template Select 下拉菜单的挂载目标，默认挂载到 `body` |
 
 #### Mention
 

--- a/packages/components/src/sender/extensions/template/extension.ts
+++ b/packages/components/src/sender/extensions/template/extension.ts
@@ -16,7 +16,7 @@ export const Template = Extension.create<TemplateOptions>({
   name: EXTENSION_NAMES.TEMPLATE,
 
   addExtensions() {
-    return [TemplateBlock.configure(this.options), TemplateSelect]
+    return [TemplateBlock.configure(this.options), TemplateSelect.configure(this.options)]
   },
 
   // 添加命令（统一命令入口）

--- a/packages/components/src/sender/extensions/template/select/extension.ts
+++ b/packages/components/src/sender/extensions/template/select/extension.ts
@@ -4,7 +4,7 @@
 
 import { Node, mergeAttributes } from '@tiptap/core'
 import { VueNodeViewRenderer } from '@tiptap/vue-3'
-import type { TemplateSelectAttrs } from '../types'
+import type { TemplateOptions, TemplateSelectAttrs } from '../types'
 import TemplateSelectView from './template-select-view.vue'
 import { selectDropdownStatePlugin, selectZeroWidthPlugin, selectKeyboardPlugin } from './plugins'
 import { NODE_TYPE_NAMES } from '../../constants'
@@ -12,7 +12,7 @@ import { NODE_TYPE_NAMES } from '../../constants'
 /**
  * TemplateSelect 节点定义
  */
-export const TemplateSelect = Node.create<Record<string, unknown>>({
+export const TemplateSelect = Node.create<TemplateOptions>({
   name: NODE_TYPE_NAMES.TEMPLATE_SELECT,
 
   // 节点配置

--- a/packages/components/src/sender/extensions/template/select/template-select-view.vue
+++ b/packages/components/src/sender/extensions/template/select/template-select-view.vue
@@ -7,6 +7,7 @@ import { IconArrowDown } from '@opentiny/tiny-robot-svgs'
 import { TemplateSelectDropdownPluginKey } from './plugins'
 import type { SelectOption } from '../types'
 import { closeAllDropdowns, setupClickOutside } from './dropdown-manager'
+import { useTeleportTarget } from '../../../../shared/composables'
 
 interface NodeAttrs {
   id: string
@@ -21,6 +22,11 @@ interface Props {
   }
   updateAttributes: (attrs: Record<string, unknown>) => void
   editor: Editor
+  extension: {
+    options: {
+      appendTo?: string | HTMLElement
+    }
+  }
 }
 
 const props = defineProps<Props>()
@@ -32,6 +38,11 @@ const triggerRef = ref<HTMLElement>()
 const dropdownRef = ref<HTMLElement>()
 let cleanupClickOutside: (() => void) | null = null
 let cleanupAutoUpdate: (() => void) | null = null
+const teleportTarget = useTeleportTarget(triggerRef, props.extension.options.appendTo)
+const isCustomTeleportTarget = computed(() => {
+  const target = teleportTarget.value
+  return target instanceof HTMLElement && target !== document.body
+})
 
 // 计算属性
 const selectedOption = computed(() => {
@@ -136,7 +147,8 @@ const updatePosition = () => {
 
     computePosition(triggerRef.value, dropdownRef.value, {
       placement: 'bottom-start',
-      strategy: 'fixed', // 使用 fixed 定位策略，相对于视口
+      // 自定义挂载目标使用 absolute 定位
+      strategy: isCustomTeleportTarget.value ? 'absolute' : 'fixed', // 使用 fixed 定位策略，相对于视口
       middleware: [offset(4), flip(), shift({ padding: 8 })],
     }).then(({ x, y }) => {
       if (dropdownRef.value) {
@@ -252,8 +264,13 @@ onUnmounted(() => {
     </span>
     <span contenteditable="false" class="template-select__suffix">&#8203;</span>
 
-    <Teleport to="body">
-      <div v-if="showDropdown" ref="dropdownRef" class="template-select__dropdown">
+    <Teleport :to="teleportTarget">
+      <div
+        v-if="showDropdown"
+        ref="dropdownRef"
+        class="template-select__dropdown"
+        :class="{ 'is-absolute': isCustomTeleportTarget }"
+      >
         <div
           v-for="(option, index) in node.attrs.options"
           :key="option.value"
@@ -337,6 +354,10 @@ onUnmounted(() => {
   border-radius: 12px;
   box-shadow: var(--tr-sender-template-select-dropdown-shadow);
   padding: 6px;
+
+  &.is-absolute {
+    position: absolute;
+  }
 
   &::-webkit-scrollbar {
     width: 8px;

--- a/packages/components/src/sender/extensions/template/select/template-select-view.vue
+++ b/packages/components/src/sender/extensions/template/select/template-select-view.vue
@@ -5,7 +5,7 @@ import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { computePosition, flip, shift, offset, autoUpdate } from '@floating-ui/dom'
 import { IconArrowDown } from '@opentiny/tiny-robot-svgs'
 import { TemplateSelectDropdownPluginKey } from './plugins'
-import type { SelectOption } from '../types'
+import type { SelectOption, TemplateOptions } from '../types'
 import { closeAllDropdowns, setupClickOutside } from './dropdown-manager'
 import { useTeleportTarget } from '../../../../shared/composables'
 
@@ -23,9 +23,7 @@ interface Props {
   updateAttributes: (attrs: Record<string, unknown>) => void
   editor: Editor
   extension: {
-    options: {
-      appendTo?: string | HTMLElement
-    }
+    options: Pick<TemplateOptions, 'appendTo'>
   }
 }
 
@@ -38,7 +36,7 @@ const triggerRef = ref<HTMLElement>()
 const dropdownRef = ref<HTMLElement>()
 let cleanupClickOutside: (() => void) | null = null
 let cleanupAutoUpdate: (() => void) | null = null
-const teleportTarget = useTeleportTarget(triggerRef, props.extension.options.appendTo)
+const teleportTarget = useTeleportTarget(triggerRef, props.extension.options.appendTo, { fallback: 'body' })
 const isCustomTeleportTarget = computed(() => {
   const target = teleportTarget.value
   return target instanceof HTMLElement && target !== document.body

--- a/packages/components/src/sender/extensions/template/types.ts
+++ b/packages/components/src/sender/extensions/template/types.ts
@@ -85,6 +85,11 @@ export interface TemplateOptions {
    * HTML 属性
    */
   HTMLAttributes?: Record<string, unknown>
+
+  /**
+   * 下拉菜单挂载目标
+   */
+  appendTo?: string | HTMLElement
 }
 
 // ===== 模块扩展声明 =====

--- a/packages/components/src/shared/composables/useTeleportTarget.ts
+++ b/packages/components/src/shared/composables/useTeleportTarget.ts
@@ -10,7 +10,11 @@ import { computed } from 'vue'
  *   - 否则在 document.body 内查找 target（如果 target 为 'body'，直接返回 document.body）。
  *   - 如果查找失败，则返回查找的根节点（ShadowRoot 或 body）。
  */
-export function useTeleportTarget(reference?: MaybeElementRef, target?: string | HTMLElement) {
+export function useTeleportTarget(
+  reference?: MaybeElementRef,
+  target?: string | HTMLElement,
+  options: { fallback?: 'root' | 'body' } = {},
+) {
   return computed(() => {
     if (target instanceof HTMLElement) {
       return target
@@ -22,17 +26,22 @@ export function useTeleportTarget(reference?: MaybeElementRef, target?: string |
     const rootNode = referentceEl?.getRootNode?.()
     const inShadowDOM = rootNode instanceof ShadowRoot
     const searchRoot = inShadowDOM ? rootNode : document.body
+    const fallbackTarget = options.fallback === 'body' ? document.body : searchRoot
 
     if (selector) {
-      if (!inShadowDOM && selector === 'body') {
+      if (selector === 'body' && (!inShadowDOM || options.fallback === 'body')) {
         // 特殊处理，直接返回 <body>
         return document.body
       }
 
-      const found = searchRoot.querySelector(selector)
-      if (found instanceof Node) return found
+      try {
+        const found = searchRoot.querySelector(selector)
+        if (found instanceof Node) return found
+      } catch {
+        return fallbackTarget
+      }
     }
 
-    return searchRoot
+    return fallbackTarget
   })
 }

--- a/packages/components/src/shared/composables/useTeleportTarget.ts
+++ b/packages/components/src/shared/composables/useTeleportTarget.ts
@@ -16,17 +16,17 @@ export function useTeleportTarget(
   options: { fallback?: 'root' | 'body' } = {},
 ) {
   return computed(() => {
-    if (target instanceof HTMLElement) {
-      return target
-    }
-
-    const selector = target
-
     const referentceEl = unrefElement(reference)
     const rootNode = referentceEl?.getRootNode?.()
     const inShadowDOM = rootNode instanceof ShadowRoot
     const searchRoot = inShadowDOM ? rootNode : document.body
     const fallbackTarget = options.fallback === 'body' ? document.body : searchRoot
+
+    if (target instanceof HTMLElement) {
+      return target.isConnected ? target : fallbackTarget
+    }
+
+    const selector = target
 
     if (selector) {
       if (selector === 'body' && (!inShadowDOM || options.fallback === 'body')) {

--- a/packages/test/src/sender/helpers/template-helper.ts
+++ b/packages/test/src/sender/helpers/template-helper.ts
@@ -81,6 +81,29 @@ export function createTemplateTestHelper(page: Page) {
     },
 
     /**
+     * 设置模板选择器
+     */
+    async setSelectTemplate() {
+      await page.click(selectors.setTemplateSelectBtn)
+      await expect(page.locator(selectors.templateSelect)).toBeVisible()
+    },
+
+    /**
+     * 获取模板选择器
+     */
+    getTemplateSelect() {
+      return page.locator(selectors.templateSelect)
+    },
+
+    /**
+     * 打开模板选择器
+     */
+    async openTemplateSelect() {
+      await this.getTemplateSelect().locator(selectors.templateSelectTrigger).click()
+      await expect(page.locator(selectors.templateSelectDropdown)).toBeVisible()
+    },
+
+    /**
      * 清空模板
      */
     async clearTemplates() {

--- a/packages/test/src/sender/index.vue
+++ b/packages/test/src/sender/index.vue
@@ -16,7 +16,7 @@ declare global {
     __senderTestApi?: {
       moveCursorBeforeTemplate: (index: number) => boolean
       pressDeleteBeforeTemplate: (index: number) => boolean
-      setTemplateAppendTo: (value: string | undefined) => void
+      setTemplateAppendTo: (value: string | HTMLElement | undefined) => void
     }
   }
 }
@@ -41,7 +41,7 @@ const enableMention = ref(false)
 const enableTemplate = ref(false)
 const enableSuggestion = ref(false)
 const templateData = ref<TemplateItem[]>([])
-const templateAppendTo = ref<string | undefined>()
+const templateAppendTo = ref<string | HTMLElement | undefined>()
 const attachmentsSourceMounted = ref(false)
 const senderAttachmentItems = ref<Attachment[]>([
   {
@@ -177,7 +177,7 @@ const toggleTemplateAppendTo = () => {
   result.value = templateAppendTo.value ? '模板选择器挂载到自定义容器' : '模板选择器挂载到 body'
 }
 
-const setTemplateAppendTo = (value: string | undefined) => {
+const setTemplateAppendTo = (value: string | HTMLElement | undefined) => {
   templateAppendTo.value = value
 }
 

--- a/packages/test/src/sender/index.vue
+++ b/packages/test/src/sender/index.vue
@@ -16,6 +16,7 @@ declare global {
     __senderTestApi?: {
       moveCursorBeforeTemplate: (index: number) => boolean
       pressDeleteBeforeTemplate: (index: number) => boolean
+      setTemplateAppendTo: (value: string | undefined) => void
     }
   }
 }
@@ -176,6 +177,10 @@ const toggleTemplateAppendTo = () => {
   result.value = templateAppendTo.value ? '模板选择器挂载到自定义容器' : '模板选择器挂载到 body'
 }
 
+const setTemplateAppendTo = (value: string | undefined) => {
+  templateAppendTo.value = value
+}
+
 const mentions = ref<MentionItem[]>([
   {
     label: '小小画家',
@@ -263,6 +268,7 @@ onMounted(() => {
   window.__senderTestApi = {
     moveCursorBeforeTemplate,
     pressDeleteBeforeTemplate,
+    setTemplateAppendTo,
   }
 })
 

--- a/packages/test/src/sender/index.vue
+++ b/packages/test/src/sender/index.vue
@@ -40,6 +40,7 @@ const enableMention = ref(false)
 const enableTemplate = ref(false)
 const enableSuggestion = ref(false)
 const templateData = ref<TemplateItem[]>([])
+const templateAppendTo = ref<string | undefined>()
 const attachmentsSourceMounted = ref(false)
 const senderAttachmentItems = ref<Attachment[]>([
   {
@@ -54,7 +55,7 @@ const mode = computed(() => (isMultipleMode.value ? 'multiple' : 'single'))
 const size = computed(() => (isSmallSize.value ? 'small' : 'normal'))
 
 const componentKey = computed(() => {
-  return `${enableMention.value}-${enableTemplate.value}-${enableSuggestion.value}`
+  return `${enableMention.value}-${enableTemplate.value}-${enableSuggestion.value}-${templateAppendTo.value || 'body'}`
 })
 
 const handleModeChange = () => {
@@ -154,6 +155,27 @@ const clearTemplate = () => {
   result.value = '已清空模板'
 }
 
+const setTemplateSelect = () => {
+  templateData.value = [
+    { type: 'text', content: '模型：' },
+    {
+      type: 'select',
+      content: '',
+      placeholder: '请选择模型',
+      options: [
+        { label: 'GPT-4', value: 'gpt-4' },
+        { label: 'DeepSeek', value: 'deepseek' },
+      ],
+    },
+  ]
+  result.value = '已设置模板选择器'
+}
+
+const toggleTemplateAppendTo = () => {
+  templateAppendTo.value = templateAppendTo.value ? undefined : '#template-select-teleport-target'
+  result.value = templateAppendTo.value ? '模板选择器挂载到自定义容器' : '模板选择器挂载到 body'
+}
+
 const mentions = ref<MentionItem[]>([
   {
     label: '小小画家',
@@ -188,7 +210,7 @@ const extensions = computed(() => {
     exts.push(Sender.mention(mentions))
   }
   if (enableTemplate.value) {
-    exts.push(Sender.template(templateData))
+    exts.push(Sender.template(templateData, { appendTo: templateAppendTo.value }))
   }
   if (enableSuggestion.value) {
     exts.push(Sender.suggestion(suggestions))
@@ -332,6 +354,10 @@ onBeforeUnmount(() => {
             <tiny-switch data-testid="toggle-template-btn" v-model="enableTemplate"></tiny-switch>
           </div>
           <div class="control-item">
+            <label>template appendTo:</label>
+            <button data-testid="toggle-template-append-to-btn" @click="toggleTemplateAppendTo">切换</button>
+          </div>
+          <div class="control-item">
             <label>suggestion:</label>
             <tiny-switch data-testid="toggle-suggestion-btn" v-model="enableSuggestion"></tiny-switch>
           </div>
@@ -356,6 +382,7 @@ onBeforeUnmount(() => {
           <button data-testid="set-template-simple-btn" @click="setTemplateSimple">简单模板</button>
           <button data-testid="set-template-empty-btn" @click="setTemplateEmpty">空模板块</button>
           <button data-testid="set-template-multiple-btn" @click="setTemplateMultiple">多模板块</button>
+          <button data-testid="set-template-select-btn" @click="setTemplateSelect">模板选择器</button>
           <button data-testid="clear-template-btn" @click="clearTemplate">清空模板</button>
         </div>
       </fieldset>
@@ -396,6 +423,8 @@ onBeforeUnmount(() => {
         <button data-testid="custom-footer-btn" @click="handleCustomAction">自定义按钮</button>
       </template>
     </Sender>
+
+    <div id="template-select-teleport-target" data-testid="template-select-teleport-target"></div>
   </div>
 </template>
 
@@ -442,5 +471,9 @@ onBeforeUnmount(() => {
 .result-display {
   margin: 0;
   word-break: break-all;
+}
+
+#template-select-teleport-target {
+  position: relative;
 }
 </style>

--- a/packages/test/src/sender/selectors.ts
+++ b/packages/test/src/sender/selectors.ts
@@ -25,6 +25,7 @@ export const SENDER_SELECTORS = {
 
   toggleMentionBtn: '[data-testid="toggle-mention-btn"]',
   toggleTemplateBtn: '[data-testid="toggle-template-btn"]',
+  toggleTemplateAppendToBtn: '[data-testid="toggle-template-append-to-btn"]',
   toggleSuggestionBtn: '[data-testid="toggle-suggestion-btn"]',
 
   sender: '[data-testid="test-sender"]',
@@ -55,7 +56,13 @@ export const SENDER_SELECTORS = {
   setTemplateSimpleBtn: '[data-testid="set-template-simple-btn"]',
   setTemplateEmptyBtn: '[data-testid="set-template-empty-btn"]',
   setTemplateMultipleBtn: '[data-testid="set-template-multiple-btn"]',
+  setTemplateSelectBtn: '[data-testid="set-template-select-btn"]',
   clearTemplateBtn: '[data-testid="clear-template-btn"]',
+
+  templateSelect: '.template-select',
+  templateSelectTrigger: '.template-select__trigger',
+  templateSelectDropdown: '.template-select__dropdown',
+  templateSelectOption: '.template-select__option',
 
   suggestionList: '.suggestion-list',
   suggestionItem: '.suggestion-list__item',

--- a/packages/test/src/sender/specs/template/append-to.spec.ts
+++ b/packages/test/src/sender/specs/template/append-to.spec.ts
@@ -49,4 +49,47 @@ test.describe('Template Select - appendTo', () => {
     await page.keyboard.press('Escape')
     await expect(dropdown).toHaveCount(0)
   })
+
+  test('非法选择器回退到 body，并保持模板选择器可用', async () => {
+    await page.evaluate(() => {
+      window.__senderTestApi?.setTemplateAppendTo('[')
+    })
+    await helper.wait(300)
+    await templateHelper.setSelectTemplate()
+    await templateHelper.openTemplateSelect()
+
+    const dropdown = page.locator(templateHelper.selectors.templateSelectDropdown)
+    await expect(dropdown.evaluate((element) => element.parentElement?.tagName)).resolves.toBe('BODY')
+  })
+
+  for (const [name, appendTo] of [
+    ['未配置 appendTo', undefined],
+    ['配置 body', 'body'],
+    ['配置不存在的选择器', '#template-select-missing'],
+  ] as const) {
+    test(`ShadowRoot 下${name}时回退到 body`, async () => {
+      await page.evaluate(() => {
+        const shadowHost = document.createElement('div')
+        const shadowRoot = shadowHost.attachShadow({ mode: 'open' })
+        document.body.appendChild(shadowHost)
+
+        const getRootNode = Element.prototype.getRootNode
+        Element.prototype.getRootNode = function (options) {
+          if (this.matches('.template-select__trigger')) {
+            return shadowRoot
+          }
+          return getRootNode.call(this, options)
+        }
+      })
+      await page.evaluate((value) => {
+        window.__senderTestApi?.setTemplateAppendTo(value)
+      }, appendTo)
+      await helper.wait(300)
+      await templateHelper.setSelectTemplate()
+      await templateHelper.openTemplateSelect()
+
+      const dropdown = page.locator(templateHelper.selectors.templateSelectDropdown)
+      await expect(dropdown.evaluate((element) => element.parentElement?.tagName)).resolves.toBe('BODY')
+    })
+  }
 })

--- a/packages/test/src/sender/specs/template/append-to.spec.ts
+++ b/packages/test/src/sender/specs/template/append-to.spec.ts
@@ -62,6 +62,18 @@ test.describe('Template Select - appendTo', () => {
     await expect(dropdown.evaluate((element) => element.parentElement?.tagName)).resolves.toBe('BODY')
   })
 
+  test('传入脱离 DOM 的 HTMLElement 时回退到 body', async () => {
+    await page.evaluate(() => {
+      window.__senderTestApi?.setTemplateAppendTo(document.createElement('div'))
+    })
+    await helper.wait(300)
+    await templateHelper.setSelectTemplate()
+    await templateHelper.openTemplateSelect()
+
+    const dropdown = page.locator(templateHelper.selectors.templateSelectDropdown)
+    await expect(dropdown.evaluate((element) => element.parentElement?.tagName)).resolves.toBe('BODY')
+  })
+
   for (const [name, appendTo] of [
     ['未配置 appendTo', undefined],
     ['配置 body', 'body'],

--- a/packages/test/src/sender/specs/template/append-to.spec.ts
+++ b/packages/test/src/sender/specs/template/append-to.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect, type Page } from '@playwright/test'
+import { createSenderTestHelper } from '../../helpers'
+import { createTemplateTestHelper } from '../../helpers/template-helper'
+
+test.describe('Template Select - appendTo', () => {
+  test.describe.configure({ mode: 'serial' })
+
+  let page: Page
+  let helper: ReturnType<typeof createSenderTestHelper>
+  let templateHelper: ReturnType<typeof createTemplateTestHelper>
+
+  test.beforeEach(async ({ page: currentPage }) => {
+    page = currentPage
+    await page.goto('/')
+    await page.click('text=Sender 组件')
+    helper = createSenderTestHelper(page)
+    templateHelper = createTemplateTestHelper(page)
+
+    await helper.toggleTemplate()
+    await helper.wait(300)
+    await helper.clearContent()
+    await templateHelper.clearTemplates()
+  })
+
+  test('默认挂载到 body，并支持选择和关闭', async () => {
+    await templateHelper.setSelectTemplate()
+    await templateHelper.openTemplateSelect()
+
+    const dropdown = page.locator(templateHelper.selectors.templateSelectDropdown)
+    await expect(dropdown.evaluate((element) => element.parentElement?.tagName)).resolves.toBe('BODY')
+
+    await dropdown.locator(templateHelper.selectors.templateSelectOption).first().click()
+    await expect(templateHelper.getTemplateSelect()).toContainText('GPT-4')
+    await expect(dropdown).toHaveCount(0)
+  })
+
+  test('指定选择器后挂载到目标容器，并使用 absolute 定位', async () => {
+    await page.click(templateHelper.selectors.toggleTemplateAppendToBtn)
+    await helper.wait(300)
+    await templateHelper.setSelectTemplate()
+    await templateHelper.openTemplateSelect()
+
+    const dropdown = page.locator(templateHelper.selectors.templateSelectDropdown)
+    await expect(dropdown).toHaveClass(/is-absolute/)
+    await expect(dropdown.evaluate((element) => element.parentElement?.id)).resolves.toBe(
+      'template-select-teleport-target',
+    )
+
+    await page.keyboard.press('Escape')
+    await expect(dropdown).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## 背景

`Template Select` 下拉菜单此前固定挂载到 `body`，并使用 `fixed` 定位。

在局部容器、嵌入式界面或独立 Surface 中使用时，弹层无法归属于对应容器的层叠上下文，可能出现层级或定位不符合预期的问题。

## 改动内容

为 `TemplateOptions` 新增 `appendTo` 配置：

```ts
appendTo?: string | HTMLElement
```

支持通过 CSS 选择器或 DOM 元素指定 `Template Select` 下拉菜单的 Teleport 目标。

```ts
TrSender.template(templateItems, {
  appendTo: '.custom-surface',
})
```

配置透传链路：

```text
Template
  -> TemplateSelect
  -> TemplateSelectNodeView
  -> TemplateSelectView
```

### 定位策略

根据实际挂载目标选择定位方式：

| 挂载目标 | 定位策略 |
| --- | --- |
| 未配置或挂载到 `body` | `fixed` |
| 自定义容器 | `absolute` |

具体行为：

- 未配置 `appendTo` 时，保持原有 `body + fixed` 行为。
- 指定自定义容器时，弹层挂载到目标容器并使用 `absolute` 定位。
- 保留现有 `offset`、`flip`、`shift` 和 `autoUpdate` 定位逻辑。
- 复用现有 `useTeleportTarget`，统一处理选择器、DOM 元素和目标回退逻辑。

### 容器解析与回退

- `appendTo` 为字符串时，通过 CSS 选择器查找目标元素。
- `appendTo` 为 `HTMLElement` 时，直接使用该元素。
- 目标不存在时，自动回退到 `body`。
- 未配置 `appendTo` 时，默认挂载到 `body`。

## 使用方式

默认行为无需修改：

```ts
TrSender.template(templateItems)
```

挂载到指定容器：

```ts
TrSender.template(templateItems, {
  appendTo: '.custom-surface',
})
```

或传入 DOM 元素：

```ts
TrSender.template(templateItems, {
  appendTo: containerElement,
})
```

## 兼容性

- 未配置 `appendTo` 时，行为与改动前保持一致。
- 不影响 `TemplateBlock`、普通文本模板项和模板数据结构。
- 不影响 Template Select 的选择、键盘操作和点击外部关闭逻辑。
- 不影响自动定位、翻转和边界避让逻辑。

## 测试验证

- 默认场景：弹层挂载到 `body`。
- 自定义容器：弹层挂载到指定容器并使用 `absolute` 定位。
- 验证下拉选项选择和关闭行为。
- 通过现有 Template 相关 Playwright 用例。

验证结果：

```text
21 passed
type-check passed
build:components passed
git diff --check passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable mounting for the Sender template dropdown using a CSS selector or HTML element.
  * Dropdowns now support custom containers with appropriate positioning, while retaining `body` as the default target.
  * Added safe fallback behavior for invalid or unavailable mounting targets, including Shadow DOM scenarios.

* **Documentation**
  * Updated Sender documentation and examples to describe the new `appendTo` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->