### PR TITLE
fix(ci): pin Rollup to 4.62.4

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,8 @@ packages:
   - '!packages/cli/templates/**'
   - docs
 
+overrides:
+  rollup: 4.62.4
+
 patchedDependencies:
   vitepress-demo-plugin@1.5.0: patches/vitepress-demo-plugin@1.5.0.patch


### PR DESCRIPTION
## Summary

- Pin Rollup to 4.62.4 through a pnpm workspace override.
- Keep the existing Node 24 runtime and the 4 GB VitePress heap limit unchanged.
- Use this as a narrow, temporary mitigation for the recent CI out-of-memory failure.

## Why

CI currently runs `pnpm i --no-frozen-lockfile`, while `pnpm-lock.yaml` is ignored. A fresh install now resolves Rollup 4.63.0, so transitive dependencies can change without any repository diff.

The recent [upstream failure](https://github.com/opentiny/tiny-robot/actions/runs/32920613856) occurred after this dependency drift. In an A/B verification, changing only Rollup from the current 4.63.0 resolution to 4.62.4 made the complete workflow pass. Increasing the V8 heap to 8 GB and switching between Node 24 and Node 22 did not resolve the same failure.

## Verification

- [Dispatch Publish with Rollup 4.62.4](https://github.com/gene9831/tiny-robot/actions/runs/33048914364) passed.
- Component build passed.
- Playground production build passed in 23.65 seconds.
- VitePress build passed with the existing `--max-old-space-size=4096` setting in 67.62 seconds.
- Build output verification, artifact upload, and docs deployment passed.
- A fresh pnpm 10.34.5 lockfile-only resolution contained Rollup 4.62.4 and no Rollup 4.63.0 entry.

## Follow-up

This override is intentionally temporary. The durable fix is to track `pnpm-lock.yaml` and use a frozen install in CI so transitive dependency updates are explicit and reproducible. PR #396 contains a broader lockfile-based approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s build tooling configuration to use a fixed Rollup version for more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->