### PR TITLE
feat(sender): add input-prefix slot for multi-line mode and enhance styling

### DIFF
--- a/docs/demos/sender/custom-slots.vue
+++ b/docs/demos/sender/custom-slots.vue
@@ -50,6 +50,9 @@ const handleEmoji = () => {
       <template #prefix>
         <IconAi :style="{ fontSize: '26px' }" />
       </template>
+      <template #input-prefix>
+        <span class="input-prefix-label">需求</span>
+      </template>
       <template #footer-right>
         <UploadButton tooltip="文件上传" tooltip-placement="top" />
       </template>
@@ -82,6 +85,11 @@ const handleEmoji = () => {
   background: #f5f5f5;
   border-color: #1476ff;
   color: #1476ff;
+}
+
+.input-prefix-label {
+  color: #1476ff;
+  font-weight: 600;
 }
 
 .message {

--- a/docs/src/components/sender.md
+++ b/docs/src/components/sender.md
@@ -248,6 +248,7 @@ Sender 提供了多个插槽位置，方便扩展功能：
 
 - **`header`** - 顶部区域，可添加标题、提示信息等
 - **`prefix`** - 输入框前缀区域，可添加图标、标签等（位于输入框内部）
+- **`input-prefix`** - 多行模式首行前置区域，支持自定义交互内容
 - **`footer`** - 底部左侧区域，可添加功能按钮
 - **`footer-right`** - 底部右侧区域，可添加操作按钮
 
@@ -451,6 +452,7 @@ onSelect: (item) => {
 |---------|------|-----------|
 | header | 头部插槽，位于输入框上方 | - |
 | prefix | 前缀插槽，位于输入框左侧 | - |
+| input-prefix @new | 多行模式首行前置插槽 | - |
 | content @0.4 | 内容插槽，用于完全自定义编辑器内容 | `{ editor }` |
 | actions-inline @0.4 | 单行模式下的操作按钮区域 | - |
 | footer | 底部自定义区域 | `{ editor, hasContent, disabled, loading }` |

--- a/packages/components/src/sender/components/editor-content/index.vue
+++ b/packages/components/src/sender/components/editor-content/index.vue
@@ -1,15 +1,28 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { EditorContent as TiptapEditorContent } from '@tiptap/vue-3'
+import { useResizeObserver } from '@vueuse/core'
 import { useSenderContext } from '../../context'
 
 // editorRef 在模板中通过 ref="editorRef" 使用
 const { editor, editorRef } = useSenderContext()
+const editorScrollRef = ref<HTMLElement | null>(null)
+const inputPrefixRef = ref<HTMLElement | null>(null)
+
+useResizeObserver(inputPrefixRef, ([entry]) => {
+  if (!entry) return
+
+  editorScrollRef.value?.style.setProperty('--tr-sender-input-prefix-width', `${entry.contentRect.width}px`)
+})
 </script>
 
 <template>
   <div ref="editorRef" class="tr-sender-editor-wrapper">
     <!-- 新增：滚动容器，用于控制高度和滚动 -->
-    <div class="tr-sender-editor-scroll">
+    <div ref="editorScrollRef" :class="['tr-sender-editor-scroll', { 'has-input-prefix': $slots['input-prefix'] }]">
+      <div v-if="$slots['input-prefix']" ref="inputPrefixRef" class="tr-sender-input-prefix">
+        <slot name="input-prefix" />
+      </div>
       <TiptapEditorContent v-if="editor" :editor="editor" class="tr-sender-editor-content" />
     </div>
   </div>
@@ -24,6 +37,7 @@ const { editor, editorRef } = useSenderContext()
 
 // 滚动容器：高度和滚动由 useAutoSize 控制
 .tr-sender-editor-scroll {
+  position: relative;
   flex: 1;
   min-width: 0;
   overflow-y: hidden; // 默认隐藏，由 JS 控制
@@ -45,6 +59,25 @@ const { editor, editorRef } = useSenderContext()
       background: rgba(0, 0, 0, 0.25);
     }
   }
+
+  &.has-input-prefix {
+    :deep(.ProseMirror > p:first-child) {
+      text-indent: calc(var(--tr-sender-input-prefix-width, 0px) + var(--tr-sender-gap, 8px));
+    }
+  }
+}
+
+.tr-sender-input-prefix {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  width: max-content;
+  min-height: var(--tr-sender-line-height, 26px);
+  line-height: var(--tr-sender-line-height, 26px);
+  white-space: nowrap;
 }
 
 .tr-sender-editor-content {

--- a/packages/components/src/sender/components/layouts/MultiLineLayout.vue
+++ b/packages/components/src/sender/components/layouts/MultiLineLayout.vue
@@ -25,7 +25,11 @@ const slotScope = useSlotScope()
       <!-- 编辑器内容 -->
       <div class="tr-sender-content">
         <slot name="content" :editor="context.editor">
-          <EditorContent />
+          <EditorContent>
+            <template v-if="$slots['input-prefix']" #input-prefix>
+              <slot name="input-prefix" />
+            </template>
+          </EditorContent>
         </slot>
       </div>
     </div>

--- a/packages/components/src/sender/index.type.ts
+++ b/packages/components/src/sender/index.type.ts
@@ -352,6 +352,11 @@ export interface SenderSlots {
   prefix?: () => unknown
 
   /**
+   * 多行模式首行前置插槽
+   */
+  'input-prefix'?: () => unknown
+
+  /**
    * 内容插槽
    *
    * @param props - 插槽属性

--- a/packages/components/src/sender/index.vue
+++ b/packages/components/src/sender/index.vue
@@ -61,6 +61,9 @@ defineExpose(expose)
       <template v-if="$slots.prefix" #prefix>
         <slot name="prefix" />
       </template>
+      <template v-if="$slots['input-prefix']" #input-prefix>
+        <slot name="input-prefix" />
+      </template>
       <template v-if="$slots.content" #content="slotProps">
         <slot name="content" v-bind="slotProps" />
       </template>

--- a/packages/test/src/sender/index.vue
+++ b/packages/test/src/sender/index.vue
@@ -90,6 +90,10 @@ const handleCustomAction = () => {
   result.value = '自定义按钮被点击'
 }
 
+const handleInputPrefixAction = () => {
+  result.value = 'input-prefix 被点击'
+}
+
 const handleClearSenderAttachmentItems = () => {
   senderAttachmentItems.value = []
 }
@@ -423,6 +427,10 @@ onBeforeUnmount(() => {
     >
       <template v-if="attachmentsSourceMounted" #header>
         <TrAttachments v-model:items="senderAttachmentItems" variant="card" />
+      </template>
+
+      <template #input-prefix>
+        <button data-testid="input-prefix-btn" type="button" @click="handleInputPrefixAction">需求</button>
       </template>
 
       <template #footer>

--- a/packages/test/src/sender/selectors.ts
+++ b/packages/test/src/sender/selectors.ts
@@ -40,6 +40,8 @@ export const SENDER_SELECTORS = {
 
   footer: '.tr-sender-footer',
   customFooterBtn: '[data-testid="custom-footer-btn"]',
+  inputPrefix: '.tr-sender-input-prefix',
+  inputPrefixBtn: '[data-testid="input-prefix-btn"]',
 
   resultDisplay: '[data-testid="result-display"]',
   submitDetailDisplay: '[data-testid="submit-detail-display"]',

--- a/packages/test/src/sender/specs/basic.spec.ts
+++ b/packages/test/src/sender/specs/basic.spec.ts
@@ -211,6 +211,61 @@ test.describe('Sender 组件测试', () => {
     await helper.expectResult('自定义按钮被点击')
   })
 
+  test('Slots: input-prefix - 应该只作用于多行首行并支持交互', async () => {
+    await expect(page.locator(helper.selectors.inputPrefix)).toHaveCount(0)
+
+    await helper.toggleMode()
+    await expect(page.locator(helper.selectors.inputPrefix)).toBeVisible()
+
+    await helper.typeContent('第一行')
+    await page.keyboard.press('Control+Enter')
+    await page.keyboard.type('第二行')
+
+    const paragraphIndents = await helper
+      .getEditor()
+      .locator('p')
+      .evaluateAll((paragraphs) => paragraphs.map((paragraph) => getComputedStyle(paragraph).textIndent))
+
+    expect(parseFloat(paragraphIndents[0])).toBeGreaterThan(0)
+    expect(paragraphIndents[1]).toBe('0px')
+
+    await page.locator(helper.selectors.inputPrefixBtn).click()
+    await helper.expectResult('input-prefix 被点击')
+
+    await helper.clearContent()
+    await helper.getEditor().click()
+    for (let index = 0; index < 8; index += 1) {
+      await page.keyboard.type(`第${index + 1}行`)
+      if (index < 7) {
+        await page.keyboard.press('Control+Enter')
+      }
+    }
+
+    await helper.getEditor().evaluate((element) => {
+      const scrollContainer = element.closest('.tr-sender-editor-scroll')
+      element.scrollTop = 0
+      if (scrollContainer) {
+        scrollContainer.scrollTop = 0
+      }
+    })
+
+    const prefixTopBeforeScroll = await page.locator(helper.selectors.inputPrefix).evaluate((element) => {
+      return element.getBoundingClientRect().top
+    })
+
+    await helper.getEditor().evaluate((element) => {
+      const scrollContainer = element.closest('.tr-sender-editor-scroll')
+      element.scrollTop = element.scrollHeight
+      if (scrollContainer) {
+        scrollContainer.scrollTop = scrollContainer.scrollHeight
+      }
+    })
+
+    await expect
+      .poll(() => page.locator(helper.selectors.inputPrefix).evaluate((element) => element.getBoundingClientRect().top))
+      .toBeLessThan(prefixTopBeforeScroll)
+  })
+
   test('Emits: submit - 应该正确触发提交事件', async () => {
     await helper.typeContent('提交测试')
     await helper.clickSubmit()


### PR DESCRIPTION
## 背景

Sender 多行模式需要支持在编辑器首行前添加自定义内容，例如标签、按钮或下拉框。

## 变更内容

- 新增 `input-prefix` 插槽，仅在多行模式生效。
- 支持从 `Sender` 透传至 `MultiLineLayout` 和编辑器内容区域。
- 通过 `ResizeObserver` 动态获取插槽宽度。
- 首行内容根据插槽宽度自动缩进，后续行保持正常布局。
- 插槽内容与编辑器共用滚动区域，支持点击及自定义交互。
- 补充类型声明、文档示例和 E2E 测试。

## 使用示例

```vue
<template #input-prefix>
  <span>需求</span>
</template>
```

## 测试覆盖

- 单行模式不显示 `input-prefix`。
- 多行模式正确显示插槽。
- 仅首行内容产生缩进。
- 插槽内容支持点击交互。
- 编辑器滚动时插槽同步滚动。
- Sender E2E 测试通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `input-prefix` slot to the Sender component for displaying custom content before the first line in multi-line mode.
  * Added support for interactive prefix content that remains aligned while editing and scrolling.
  * Added a demo showcasing a styled prefix label.

* **Documentation**
  * Documented the new `input-prefix` slot and its multi-line usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->