### PR TITLE
style(anchor): stabilize marker positioning during panel expansion

### DIFF
--- a/packages/components/src/anchor/components/AnchorItem.vue
+++ b/packages/components/src/anchor/components/AnchorItem.vue
@@ -141,6 +141,7 @@ watch(
 .tr-anchor {
   &__list-item {
     position: relative;
+    padding-inline: var(--tr-anchor-surface-padding-inline);
 
     &::after {
       content: attr(data-tooltip);
@@ -169,11 +170,11 @@ watch(
     }
 
     &.is-right::after {
-      right: calc(100% + 8px);
+      right: calc(100% + var(--tr-anchor-tooltip-gap));
     }
 
     &.is-left::after {
-      left: calc(100% + 8px);
+      left: calc(100% + var(--tr-anchor-tooltip-gap));
     }
 
     &.is-tooltip-visible::after {
@@ -197,7 +198,7 @@ watch(
     display: grid;
     align-items: center;
     column-gap: 0;
-    padding: 6px 11px;
+    padding: 4px var(--tr-anchor-item-padding-inline);
     border: 0;
     border-radius: var(--tr-anchor-item-radius);
     background: transparent;
@@ -215,14 +216,18 @@ watch(
     }
   }
 
+  &__list-item:not(.is-expanded) &__item {
+    padding-inline: 0;
+  }
+
   &__list-item.is-right &__item {
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) var(--tr-anchor-marker-track-size);
     grid-template-areas: 'content marker';
     text-align: left;
   }
 
   &__list-item.is-left &__item {
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: var(--tr-anchor-marker-track-size) minmax(0, 1fr);
     grid-template-areas: 'marker content';
     text-align: left;
   }
@@ -236,7 +241,9 @@ watch(
   }
 
   &__marker-slot {
-    grid-area: marker;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -246,11 +253,11 @@ watch(
   }
 
   &__list-item.is-right &__marker-slot {
-    justify-self: end;
+    right: calc(var(--tr-anchor-surface-padding-inline) + var(--tr-anchor-item-padding-inline));
   }
 
   &__list-item.is-left &__marker-slot {
-    justify-self: start;
+    left: calc(var(--tr-anchor-surface-padding-inline) + var(--tr-anchor-item-padding-inline));
   }
 
   &__marker {

--- a/packages/components/src/anchor/components/AnchorItem.vue
+++ b/packages/components/src/anchor/components/AnchorItem.vue
@@ -141,7 +141,10 @@ watch(
 .tr-anchor {
   &__list-item {
     position: relative;
-    padding-inline: var(--tr-anchor-surface-padding-inline);
+
+    &.is-expanded {
+      padding-inline: var(--tr-anchor-surface-padding-inline);
+    }
 
     &::after {
       content: attr(data-tooltip);

--- a/packages/components/src/anchor/components/AnchorList.vue
+++ b/packages/components/src/anchor/components/AnchorList.vue
@@ -45,8 +45,8 @@ defineSlots<AnchorListSlots>()
     list-style: none;
     display: flex;
     flex-direction: column;
-    margin: 0;
-    padding: 6px 0;
+    margin: 0 calc(-1 * var(--tr-anchor-surface-padding-inline));
+    padding: 0;
   }
 
   &__empty {

--- a/packages/components/src/anchor/components/AnchorOverlay.vue
+++ b/packages/components/src/anchor/components/AnchorOverlay.vue
@@ -51,6 +51,10 @@ defineExpose({
 
 <style lang="less" scoped>
 .tr-anchor {
+  --tr-anchor-surface-padding-inline: 8px;
+  --tr-anchor-item-padding-inline: 11px;
+  --tr-anchor-tooltip-gap: 10px;
+
   pointer-events: none;
   z-index: var(--tr-z-index-fixed);
   inline-size: var(--tr-anchor-width-collapsed);
@@ -98,9 +102,9 @@ defineExpose({
   &__surface {
     width: 100%;
     overflow: visible;
-    border: 1px solid transparent;
     border-radius: var(--tr-anchor-surface-radius);
     box-sizing: border-box;
+    padding: 16px var(--tr-anchor-surface-padding-inline);
     transition:
       background-color 0.22s ease,
       border-color 0.22s ease,
@@ -109,7 +113,6 @@ defineExpose({
 
   &.is-expanded &__surface {
     background: var(--tr-anchor-bg);
-    border: 1px solid var(--tr-anchor-border);
     box-shadow: var(--tr-anchor-shadow);
   }
 


### PR DESCRIPTION
## 变更说明

- 优化 Anchor 面板、列表项与 tooltip 的间距定位。
- 使用 CSS 变量统一管理面板和目录项间距。
- 将 marker 改为相对列表项绝对定位。
- 修复右侧 Anchor 在收起态展开时 marker 向左移动的问题。
- 调整收起态目录项内边距，避免窄宽度下发生横向溢出。

## 验证

- Prettier 格式检查通过
- ESLint 检查通过
- `vue-tsc` 类型检查通过

## 截图对比

### 修改前

<img width="1169" height="567" alt="anchor-before" src="https://github.com/user-attachments/assets/628e8866-bc79-4013-a34f-bcbfc210b6d8" />


### 修改后

<img width="1169" height="567" alt="anchor-after" src="https://github.com/user-attachments/assets/fc283bcb-90e2-40f2-b56c-23e591ea1c08" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style

* Refined anchor navigation layout and spacing for improved alignment.
* Standardized surface, item, and tooltip spacing with configurable styling values.
* Improved marker positioning and expanded-state presentation.
* Adjusted list padding, inline margins, and surface borders for a cleaner appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->