### PR TITLE
fix(history): preserve item state across immutable updates

### DIFF
--- a/packages/components/src/history/composables/useRenameEditor.ts
+++ b/packages/components/src/history/composables/useRenameEditor.ts
@@ -1,9 +1,10 @@
 import { onClickOutside } from '@vueuse/core'
-import { computed, nextTick, ref, shallowRef, type Ref } from 'vue'
+import { computed, nextTick, ref, shallowRef, watch, type Ref } from 'vue'
 
 export interface UseRenameEditorProps<T extends { title: string }> {
   renameControlOnClickOutside?: 'confirm' | 'cancel' | 'none'
   onItemTitleChange: (newTitle: string, item: T) => void
+  resolveItem?: (item: T) => T | undefined
 }
 
 export interface UseRenameEditorReturn<T extends { title: string }> {
@@ -20,8 +21,15 @@ export interface UseRenameEditorReturn<T extends { title: string }> {
 export const useRenameEditor = <T extends { title: string }>({
   renameControlOnClickOutside,
   onItemTitleChange,
+  resolveItem,
 }: UseRenameEditorProps<T>): UseRenameEditorReturn<T> => {
-  const editingItem = shallowRef<T | undefined>(undefined) as Ref<T | undefined>
+  const editingTarget = shallowRef<T | undefined>(undefined)
+  const editingItem = computed(() => {
+    const target = editingTarget.value
+    if (!target) return undefined
+
+    return resolveItem ? resolveItem(target) : target
+  })
   const editorRefList = ref<HTMLInputElement[] | null>(null)
   const editorRef = computed(() => editorRefList.value?.at(0))
   const editorConfirmRefList = ref<HTMLButtonElement[] | null>(null)
@@ -31,7 +39,7 @@ export const useRenameEditor = <T extends { title: string }>({
   const editorValue = ref<string>('')
 
   const handleEdit = (item: T) => {
-    editingItem.value = item
+    editingTarget.value = item
     editorValue.value = item.title
     nextTick(() => {
       const input = editorRef.value
@@ -43,17 +51,27 @@ export const useRenameEditor = <T extends { title: string }>({
   }
 
   const handleEditCancel = () => {
-    editingItem.value = undefined
+    editingTarget.value = undefined
     editorValue.value = ''
   }
 
   const handleEditConfirm = () => {
-    if (editingItem.value) {
-      onItemTitleChange(editorValue.value, editingItem.value)
+    const item = editingItem.value
+    if (item) {
+      onItemTitleChange(editorValue.value, item)
     }
-    editingItem.value = undefined
-    editorValue.value = ''
+    handleEditCancel()
   }
+
+  watch(
+    editingItem,
+    (item, previousItem) => {
+      if (previousItem && !item) {
+        handleEditCancel()
+      }
+    },
+    { flush: 'sync' },
+  )
 
   if (renameControlOnClickOutside === 'confirm' || renameControlOnClickOutside === 'cancel') {
     onClickOutside(

--- a/packages/components/src/history/index.vue
+++ b/packages/components/src/history/index.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup generic="T extends HistoryItem">
 import { IconCheck, IconClose, IconDelete, IconEditPen, IconMore } from '@opentiny/tiny-robot-svgs'
-import { computed, nextTick, ref, shallowRef } from 'vue'
+import { computed, nextTick, ref, shallowRef, watch } from 'vue'
 import { useTouchDevice } from '../shared/composables'
 import Empty from './components/Empty.vue'
 import MenuList from './components/MenuList.vue'
@@ -43,6 +43,16 @@ const isEmpty = computed(() => {
   return groups.value.length === 0 || groups.value.every((group) => group.items.length === 0)
 })
 
+const currentItems = computed(() => groups.value.flatMap((group) => group.items))
+
+const resolveCurrentItem = (target: T): T | undefined => {
+  if (target.id) {
+    return currentItems.value.find((item) => item.id === target.id)
+  }
+
+  return currentItems.value.find((item) => item === target)
+}
+
 const {
   editingItem,
   editorRefList,
@@ -57,12 +67,22 @@ const {
   onItemTitleChange: (newTitle, item) => {
     emit('item-title-change', newTitle, item)
   },
+  resolveItem: resolveCurrentItem,
 })
 
 const { isTouchDevice } = useTouchDevice()
 
 const menuTriggerEl = ref<HTMLButtonElement | null>(null)
-const menuTriggerItem = shallowRef<T | null>(null)
+const menuTriggerTarget = shallowRef<T | null>(null)
+const menuTriggerItem = computed<T | null>({
+  get: () => {
+    const target = menuTriggerTarget.value
+    return target ? (resolveCurrentItem(target) ?? null) : null
+  },
+  set: (item) => {
+    menuTriggerTarget.value = item
+  },
+})
 const menuListRef = ref<{ focusFirstItem: () => void; focusLastItem: () => void } | null>(null)
 
 const focusMenuItem = (position: 'first' | 'last') => {
@@ -107,6 +127,16 @@ const closeMenu = () => {
   menuTriggerEl.value = null
   menuTriggerItem.value = null
 }
+
+watch(
+  menuTriggerItem,
+  (item) => {
+    if (!item && menuTriggerTarget.value) {
+      closeMenu()
+    }
+  },
+  { flush: 'sync' },
+)
 
 const handleMenuTriggerEscape = (event: KeyboardEvent) => {
   if (!menuTriggerEl.value) return

--- a/packages/test/component/history/History.fixture.vue
+++ b/packages/test/component/history/History.fixture.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import History from '../../../components/src/history/index.vue'
 import type { HistoryItem, HistoryMenuItem } from '../../../components/src/history/index.type'
 
 type FixtureItem = HistoryItem & { kind: string }
+type MappedConversationItem = HistoryItem & { revision: number }
 
 const flatItems: FixtureItem[] = [
   { id: 'chat-1', title: 'First chat', kind: 'work' },
@@ -27,6 +28,49 @@ const confirmedRename = ref('')
 const confirmedRenameIdentity = ref('')
 const cancelledRename = ref('')
 const untouchedRename = ref('')
+const mappedConversationSource = ref<Array<{ id: string; title?: string; revision: number }>>([
+  { id: 'conversation-1', revision: 1 },
+  { id: 'conversation-2', title: 'Existing title', revision: 1 },
+])
+const mappedConversationData = computed(() =>
+  mappedConversationSource.value.map((conversation) => ({
+    ...conversation,
+    title: conversation.title || '新标题',
+  })),
+)
+const mappedRenameOutput = ref('')
+const mappedRenameIdentity = ref('')
+const mappedActionOutput = ref('')
+const mappedActionIdentity = ref('')
+
+const replaceMappedConversations = () => {
+  mappedConversationSource.value = mappedConversationSource.value.map((conversation) => ({
+    ...conversation,
+    revision: conversation.revision + 1,
+  }))
+}
+
+const removeMappedConversation = () => {
+  mappedConversationSource.value = mappedConversationSource.value.filter(
+    (conversation) => conversation.id !== 'conversation-1',
+  )
+}
+
+const restoreMappedConversation = () => {
+  mappedConversationSource.value = [{ id: 'conversation-1', revision: 3 }, ...mappedConversationSource.value]
+}
+
+const recordMappedRename = (newTitle: string, item: MappedConversationItem) => {
+  mappedRenameOutput.value = JSON.stringify({ newTitle, item })
+  mappedRenameIdentity.value =
+    item === mappedConversationData.value.find((conversation) => conversation.id === item.id) ? 'current' : 'stale'
+}
+
+const recordMappedAction = (action: HistoryMenuItem, item: MappedConversationItem) => {
+  mappedActionOutput.value = JSON.stringify({ action, item })
+  mappedActionIdentity.value =
+    item === mappedConversationData.value.find((conversation) => conversation.id === item.id) ? 'current' : 'stale'
+}
 
 const recordClick = (item: FixtureItem) => {
   lastItemClick.value = JSON.stringify(item)
@@ -106,6 +150,30 @@ const recordUntouchedRename = (newTitle: string, item: FixtureItem) => {
     <section data-testid="none-history">
       <History :data="flatItems" rename-control-on-click-outside="none" @item-title-change="recordUntouchedRename" />
       <output data-testid="none-output">{{ untouchedRename }}</output>
+    </section>
+
+    <button data-testid="replace-mapped-conversations" type="button" @click="replaceMappedConversations">
+      Replace mapped conversations
+    </button>
+    <button data-testid="remove-mapped-conversation" type="button" @click="removeMappedConversation">
+      Remove mapped conversation
+    </button>
+    <button data-testid="restore-mapped-conversation" type="button" @click="restoreMappedConversation">
+      Restore mapped conversation
+    </button>
+    <section data-testid="mapped-conversation-history" @replace-conversations="replaceMappedConversations">
+      <History
+        :data="mappedConversationData"
+        :menu-items="menuItems"
+        :show-rename-controls="true"
+        rename-control-on-click-outside="none"
+        @item-title-change="recordMappedRename"
+        @item-action="recordMappedAction"
+      />
+      <output data-testid="mapped-rename-output">{{ mappedRenameOutput }}</output>
+      <output data-testid="mapped-rename-identity">{{ mappedRenameIdentity }}</output>
+      <output data-testid="mapped-action-output">{{ mappedActionOutput }}</output>
+      <output data-testid="mapped-action-identity">{{ mappedActionIdentity }}</output>
     </section>
   </main>
 </template>

--- a/packages/test/component/history/History.spec.ts
+++ b/packages/test/component/history/History.spec.ts
@@ -208,4 +208,59 @@ test.describe('History', () => {
     await expect(noneEditor).toHaveValue('Still editing')
     await expect(noneHistory.getByTestId('none-output')).toBeEmpty()
   })
+
+  test('preserves mapped conversation rename state by id and emits the current item', async ({ mount }) => {
+    const component = await mount(HistoryFixture)
+    const history = component.getByTestId('mapped-conversation-history')
+    const editor = await openRenameEditor(history, '新标题')
+
+    await editor.fill('Draft title')
+    await component.getByTestId('replace-mapped-conversations').click()
+
+    await expect(editor).toBeVisible()
+    await expect(editor).toHaveValue('Draft title')
+    await editor.press('Enter')
+    await expect(history.getByTestId('mapped-rename-output')).toHaveText(
+      JSON.stringify({
+        newTitle: 'Draft title',
+        item: { id: 'conversation-1', revision: 2, title: '新标题' },
+      }),
+    )
+    await expect(history.getByTestId('mapped-rename-identity')).toHaveText('current')
+  })
+
+  test('preserves mapped conversation menu state by id and emits the current item', async ({ mount }) => {
+    const component = await mount(HistoryFixture)
+    const history = component.getByTestId('mapped-conversation-history')
+    const trigger = history.getByRole('button', { name: '新标题 更多操作' })
+
+    await trigger.focus()
+    await trigger.press('ArrowDown')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+
+    await history.evaluate((element) => element.dispatchEvent(new Event('replace-conversations')))
+
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    await history.getByRole('menuitem', { name: '归档' }).click()
+    await expect(history.getByTestId('mapped-action-output')).toHaveText(
+      JSON.stringify({
+        action: { id: 'archive', text: '归档' },
+        item: { id: 'conversation-1', revision: 2, title: '新标题' },
+      }),
+    )
+    await expect(history.getByTestId('mapped-action-identity')).toHaveText('current')
+  })
+
+  test('does not restore stale rename state when a removed id is added again', async ({ mount }) => {
+    const component = await mount(HistoryFixture)
+    const history = component.getByTestId('mapped-conversation-history')
+    const editor = await openRenameEditor(history, '新标题')
+
+    await editor.fill('Stale draft')
+    await component.getByTestId('remove-mapped-conversation').click()
+    await component.getByTestId('restore-mapped-conversation').click()
+
+    await expect(history.getByRole('textbox')).toHaveCount(0)
+    await expect(history).toContainText('新标题')
+  })
 })


### PR DESCRIPTION
## 背景

`History` 通常会与 `useConversation()` 返回的 `conversations` 搭配使用。由于 `ConversationInfo.title` 是可选字段，业务侧常通过 `computed(map)` 补充标题兜底值，例如“新标题”。

PR #405 将相关状态改为 `shallowRef`，解决了初次点击重命名时代理对象引用不一致的问题；但当 `conversations` 发生不可变更新、`map` 重新创建同 ID 对象时，编辑状态和菜单状态仍会因为对象引用变化而丢失。

## 最小复现

```vue
<script setup lang="ts">
import { computed } from 'vue'
import { TrHistory } from '@opentiny/tiny-robot'
import { useConversation } from '@opentiny/tiny-robot-kit'

const { conversations, updateConversationTitle } = useConversation(options)

const historyData = computed(() =>
  conversations.value.map((conversation) => ({
    ...conversation,
    title: conversation.title || '新标题',
  })),
)

// 模拟接口刷新、状态同步等不可变更新
const replaceItems = () => {
  conversations.value = conversations.value.map((conversation) => ({ ...conversation }))
}

const handleRename = (title: string, item: { id: string }) => {
  updateConversationTitle(item.id, title)
}
</script>

<template>
  <TrHistory
    :data="historyData"
    :show-rename-controls="true"
    rename-control-on-click-outside="none"
    @item-title-change="handleRename"
  />
  <button @click="replaceItems">以相同 ID 重建对象</button>
</template>
```

## 复现步骤

1. 点击标题为“新标题”的会话行末菜单，选择“重命名”。
2. 在输入框中输入任意草稿，暂不确认。
3. 触发 `replaceItems`，以相同 `id` 创建全新的会话对象。
4. 修复前：编辑框和草稿消失；已打开的操作菜单也会关闭，后续事件可能携带旧对象。
5. 修复后：编辑框、草稿和菜单状态保留；确认重命名或执行菜单动作时携带当前最新对象。

## 修改说明

- 使用稳定的 `id` 从最新 History 数据中解析当前交互目标。
- 重命名和菜单状态在同 ID 对象替换后继续保留。
- 重命名及菜单事件返回最新的 item 对象。
- 目标条目被删除时清理交互状态，避免条目重新加入后恢复旧草稿。

## 兼容性

不修改 `History` 的公开 Props、Events、Slots 或导出类型，仅调整组件内部状态解析逻辑。

## 验证

- 完整组件测试：111/111 通过。
- History 新增回归场景：重命名状态保留、菜单状态保留、目标删除后不恢复陈旧状态。
- 组件类型检查、生产构建、ESLint、Prettier 均通过。
- GitHub Actions：4/4 checks passed。

Related to #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved in-progress rename text when history items are refreshed.
  - Kept open action menus active when item data updates.
  - Ensured rename and action events use the latest item information.
  - Cleared rename and menu state when an item is removed, preventing stale state from returning if it is later restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->