### PR TITLE
ci(publish): validate release versions and publish chat artifacts

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -65,12 +65,10 @@ jobs:
         id: parse_tag
         run: |
           tag_name="${GITHUB_REF#refs/tags/}"
-          if [[ "$tag_name" == *alpha* ]]; then
-            echo "dist_tag=alpha" >> "$GITHUB_OUTPUT"
-          elif [[ "$tag_name" == *beta* ]]; then
-            echo "dist_tag=beta" >> "$GITHUB_OUTPUT"
-          elif [[ "$tag_name" == *rc* ]]; then
-            echo "dist_tag=rc" >> "$GITHUB_OUTPUT"
+          version="${tag_name#v}"
+          if [[ "$version" == *-* ]]; then
+            prerelease="${version#*-}"
+            echo "dist_tag=${prerelease%%.*}" >> "$GITHUB_OUTPUT"
           else
             echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
           fi
@@ -82,14 +80,12 @@ jobs:
             exit 1
           fi
 
-      - name: Verify package version match tag
+      - name: Verify publish package versions
         run: |
           tag_name="${GITHUB_REF#refs/tags/}"
-          package_version=$(pnpm lerna list --scope=@opentiny/tiny-robot --json | jq -r '.[0].version')
-          if [[ "$tag_name" != "v$package_version" ]]; then
-            echo "Tag name $tag_name does not match package version $package_version"
-            exit 1
-          fi
+          node scripts/verify-publish-versions.js \
+            --expected-version "${tag_name#v}" \
+            --dist-tag "${{ steps.parse_tag.outputs.dist_tag }}"
 
       # 步骤8: 构建文档
       - name: Build VitePress
@@ -107,6 +103,7 @@ jobs:
           name: package-dist
           path: |
             packages/components/dist
+            packages/chat/dist
             packages/kit/dist
             packages/svgs/dist
           if-no-files-found: error

--- a/.github/workflows/dispatch-publish.yml
+++ b/.github/workflows/dispatch-publish.yml
@@ -53,6 +53,10 @@ jobs:
           package-manager-cache: false
           registry-url: 'https://registry.npmjs.org' # 设置npm registry地址
 
+      - name: Verify publish package versions
+        if: ${{ inputs.publish_npm }}
+        run: node scripts/verify-publish-versions.js --dist-tag "${{ inputs.tag }}"
+
       # 步骤4: 获取pnpm缓存目录路径
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -94,6 +98,7 @@ jobs:
           name: dispatch-package-dist
           path: |
             packages/components/dist
+            packages/chat/dist
             packages/kit/dist
             packages/svgs/dist
           if-no-files-found: error

--- a/scripts/verify-publish-versions.js
+++ b/scripts/verify-publish-versions.js
@@ -1,0 +1,89 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const PUBLISH_PACKAGES = [
+  ['@opentiny/tiny-robot-cli', 'packages/cli/package.json'],
+  ['@opentiny/tiny-robot', 'packages/components/package.json'],
+  ['@opentiny/tiny-robot-chat', 'packages/chat/package.json'],
+  ['@opentiny/tiny-robot-kit', 'packages/kit/package.json'],
+  ['@opentiny/tiny-robot-svgs', 'packages/svgs/package.json'],
+]
+
+function readPackage(rootDir, expectedName, relativePath) {
+  const packageFile = path.join(rootDir, relativePath)
+  const packageJson = JSON.parse(fs.readFileSync(packageFile, 'utf8'))
+
+  if (packageJson.name !== expectedName) {
+    throw new Error(`${relativePath} must describe ${expectedName}; found ${String(packageJson.name)}`)
+  }
+
+  return packageJson
+}
+
+function publishChannel(version) {
+  const match =
+    /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(
+      version,
+    )
+  if (!match) throw new Error(`Package version must be a valid semantic version: ${version}`)
+  return match[1]?.split('.')[0] ?? 'latest'
+}
+
+export function verifyPublishVersions({ rootDir = process.cwd(), expectedVersion, distTag } = {}) {
+  const packages = PUBLISH_PACKAGES.map(([name, relativePath]) => ({
+    name,
+    version: readPackage(rootDir, name, relativePath).version,
+  }))
+  const version = packages[0].version
+
+  for (const pkg of packages.slice(1)) {
+    if (pkg.version !== version) {
+      throw new Error(`${pkg.name} has version ${pkg.version}; expected ${version} to match @opentiny/tiny-robot-cli`)
+    }
+  }
+
+  if (expectedVersion && version !== expectedVersion) {
+    throw new Error(`Expected version ${expectedVersion} from Git tag, but packages use ${version}`)
+  }
+
+  const requiredDistTag = publishChannel(version)
+  if (distTag && distTag !== requiredDistTag) {
+    throw new Error(
+      `Publish dist-tag ${distTag} does not match version ${version}; version requires ${requiredDistTag}`,
+    )
+  }
+
+  return { version, distTag: requiredDistTag }
+}
+
+function parseArgs(argv) {
+  const options = {}
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === '--expected-version' || argument === '--dist-tag') {
+      const value = argv[index + 1]
+      if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`)
+      if (argument === '--expected-version') options.expectedVersion = value
+      else options.distTag = value
+      index += 1
+      continue
+    }
+    throw new Error(`Unknown argument: ${argument}`)
+  }
+
+  return options
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) {
+  try {
+    const result = verifyPublishVersions(parseArgs(process.argv.slice(2)))
+    console.log(`Verified synchronized publish version ${result.version} for dist-tag ${result.distTag}`)
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/verify-publish-versions.js
+++ b/scripts/verify-publish-versions.js
@@ -24,11 +24,15 @@ function readPackage(rootDir, expectedName, relativePath) {
 
 function publishChannel(version) {
   const match =
-    /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(
+    /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(
       version,
     )
   if (!match) throw new Error(`Package version must be a valid semantic version: ${version}`)
-  return match[1]?.split('.')[0] ?? 'latest'
+  const channel = match[1]?.split('.')[0] ?? 'latest'
+  if (/^(?:v)?\d+$|^[xX]$/.test(channel)) {
+    throw new Error(`Package version derives an unusable npm dist-tag: ${channel}`)
+  }
+  return channel
 }
 
 export function verifyPublishVersions({ rootDir = process.cwd(), expectedVersion, distTag } = {}) {

--- a/scripts/verify-publish-versions.test.js
+++ b/scripts/verify-publish-versions.test.js
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { verifyPublishVersions } from './verify-publish-versions.js'
+
+const verifierFile = fileURLToPath(new URL('./verify-publish-versions.js', import.meta.url))
+const packagePaths = {
+  '@opentiny/tiny-robot-cli': 'packages/cli/package.json',
+  '@opentiny/tiny-robot': 'packages/components/package.json',
+  '@opentiny/tiny-robot-chat': 'packages/chat/package.json',
+  '@opentiny/tiny-robot-kit': 'packages/kit/package.json',
+  '@opentiny/tiny-robot-svgs': 'packages/svgs/package.json',
+}
+
+function createFixture(versions) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tiny-robot-publish-versions-'))
+
+  for (const [name, relativePath] of Object.entries(packagePaths)) {
+    const packageFile = path.join(root, relativePath)
+    fs.mkdirSync(path.dirname(packageFile), { recursive: true })
+    fs.writeFileSync(packageFile, `${JSON.stringify({ name, version: versions[name] }, null, 2)}\n`)
+  }
+
+  return root
+}
+
+function synchronizedVersions(version) {
+  return Object.fromEntries(Object.keys(packagePaths).map((name) => [name, version]))
+}
+
+test('publish verification accepts synchronized prerelease packages on their channel', () => {
+  const root = createFixture(synchronizedVersions('0.5.2-alpha.15'))
+
+  try {
+    assert.deepEqual(verifyPublishVersions({ rootDir: root, expectedVersion: '0.5.2-alpha.15', distTag: 'alpha' }), {
+      version: '0.5.2-alpha.15',
+      distTag: 'alpha',
+    })
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publish verification accepts synchronized stable packages on latest', () => {
+  const root = createFixture(synchronizedVersions('0.5.3'))
+
+  try {
+    assert.deepEqual(verifyPublishVersions({ rootDir: root, distTag: 'latest' }), {
+      version: '0.5.3',
+      distTag: 'latest',
+    })
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publish verification rejects a mismatched runtime package', () => {
+  const versions = synchronizedVersions('0.5.2-alpha.15')
+  versions['@opentiny/tiny-robot-svgs'] = '0.5.2-alpha.14'
+  const root = createFixture(versions)
+
+  try {
+    assert.throws(
+      () => verifyPublishVersions({ rootDir: root, distTag: 'alpha' }),
+      /@opentiny\/tiny-robot-svgs.*0\.5\.2-alpha\.14.*0\.5\.2-alpha\.15/i,
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publish verification rejects a version that does not match the Git tag', () => {
+  const root = createFixture(synchronizedVersions('0.5.2-alpha.15'))
+
+  try {
+    assert.throws(
+      () => verifyPublishVersions({ rootDir: root, expectedVersion: '0.5.2-alpha.16', distTag: 'alpha' }),
+      /expected.*0\.5\.2-alpha\.16.*0\.5\.2-alpha\.15/i,
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publish verification rejects a dist-tag that does not match the package version', () => {
+  const root = createFixture(synchronizedVersions('0.5.2-beta.3'))
+
+  try {
+    assert.throws(() => verifyPublishVersions({ rootDir: root, distTag: 'alpha' }), /dist-tag alpha.*requires beta/i)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publish verifier CLI fails before publication when package versions diverge', () => {
+  const versions = synchronizedVersions('0.5.3')
+  versions['@opentiny/tiny-robot-chat'] = '0.5.2'
+  const root = createFixture(versions)
+
+  try {
+    const result = spawnSync(process.execPath, [verifierFile, '--dist-tag', 'latest'], {
+      cwd: root,
+      encoding: 'utf8',
+    })
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /@opentiny\/tiny-robot-chat/i)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/scripts/verify-publish-versions.test.js
+++ b/scripts/verify-publish-versions.test.js
@@ -59,6 +59,32 @@ test('publish verification accepts synchronized stable packages on latest', () =
   }
 })
 
+test('publish verification rejects prerelease numeric identifiers with leading zeroes', () => {
+  const root = createFixture(synchronizedVersions('1.2.3-alpha.01'))
+
+  try {
+    assert.throws(
+      () => verifyPublishVersions({ rootDir: root, distTag: 'alpha' }),
+      /valid semantic version.*1\.2\.3-alpha\.01/i,
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('publish verification rejects a numeric prerelease channel unusable by npm', () => {
+  const root = createFixture(synchronizedVersions('1.2.3-0'))
+
+  try {
+    assert.throws(
+      () => verifyPublishVersions({ rootDir: root, distTag: '0' }),
+      /unusable npm dist-tag.*0/i,
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
 test('publish verification rejects a mismatched runtime package', () => {
   const versions = synchronizedVersions('0.5.2-alpha.15')
   versions['@opentiny/tiny-robot-svgs'] = '0.5.2-alpha.14'


### PR DESCRIPTION
## 背景

随着 `@opentiny/tiny-robot-chat` 纳入项目发布体系，现有发布流程需要同步支持 Chat 包，并统一校验所有可发布包的版本信息。

本 PR 仅调整发布工作流和发布版本校验逻辑，依赖前置 #411，先合入基础包，再合入相关的工作流

## 变更内容

### 1. 新增发布版本校验脚本

新增：

```text
scripts/verify-publish-versions.js
```

统一校验以下发布包：

- `@opentiny/tiny-robot-cli`
- `@opentiny/tiny-robot`
- `@opentiny/tiny-robot-chat`
- `@opentiny/tiny-robot-kit`
- `@opentiny/tiny-robot-svgs`

校验内容：

- 包路径与包名是否匹配。
- 所有发布包的版本是否一致。
- 包版本是否与 Git Tag 一致。
- 包版本是否符合 SemVer。
- npm dist-tag 是否与版本类型匹配。

版本与 dist-tag 的对应关系：

```text
0.5.0-alpha.1  -> alpha
0.5.0-beta.1   -> beta
0.5.0-rc.1     -> rc
0.5.0           -> latest
```

脚本支持：

```bash
node scripts/verify-publish-versions.js \
  --expected-version 0.5.0-alpha.1 \
  --dist-tag alpha
```

### 2. 更新自动发布工作流

调整：

```text
.github/workflows/auto-publish.yml
```

变更内容：

- 使用 SemVer 规则解析 Git Tag。
- 替换原有仅校验主组件包版本的逻辑。
- 发布前校验所有发布包版本。
- 校验 Git Tag、包版本和 dist-tag 的一致性。
- 将 `packages/chat/dist` 加入发布产物。
- 保持现有文档构建、npm 发布和 GitHub Release 流程不变。

### 3. 更新手动发布工作流

调整：

```text
.github/workflows/dispatch-publish.yml
```

变更内容：

- npm 发布模式下增加统一版本校验。
- 文档部署模式下跳过 npm 包版本校验。
- 将 `packages/chat/dist` 加入 npm 发布产物。
- 保持现有手动发布和文档部署流程不变。

### 4. 新增版本校验测试

新增：

```text
scripts/verify-publish-versions.test.js
```

覆盖：

- 同步 alpha 版本校验。
- 同步稳定版本校验。
- 发布包版本不一致。
- 包版本与 Git Tag 不一致。
- dist-tag 与版本类型不匹配。
- Chat 包版本不一致时 CLI 校验失败。

## 验证方式

```bash
node --test scripts/verify-publish-versions.test.js
git diff --check
```

## 风险控制

版本校验失败会在 npm 发布前终止流程，避免以下情况：

- 发布包版本不一致。
- Git Tag 与包版本不一致。
- 使用错误的 npm dist-tag。
- Chat 构建产物缺失。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package publishing checks to ensure package versions, release tags, and release channels match before publication.
  - Improved handling of stable and prerelease publishing tags, including validation of invalid or incompatible tag formats.

- **New Features**
  - Chat distribution files are now included in published build artifacts.

- **Tests**
  - Added coverage for synchronized package versions, release-tag mismatches, release-channel mismatches, and publication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->