### PR TITLE
refactor(model-selector): use shared useStableId for DOM ids

### DIFF
--- a/packages/components/src/model-selector/index.vue
+++ b/packages/components/src/model-selector/index.vue
@@ -14,7 +14,7 @@ import type {
 } from './index.type'
 import { getDuplicateModelEffortValues, normalizeModelEfforts } from './normalizeModelEfforts'
 import { getDuplicateModelValues, normalizeModelOptions } from './normalizeModelOptions'
-import { useTeleportTarget } from '../shared/composables/useTeleportTarget'
+import { useStableId, useTeleportTarget } from '../shared/composables'
 
 defineOptions({ name: 'TrModelSelector' })
 
@@ -42,12 +42,11 @@ const emit = defineEmits<ModelSelectorEmits>()
 defineSlots<ModelSelectorSlots>()
 
 const instance = getCurrentInstance()
-const instanceUid = instance?.uid ?? 0
 const initialVNodeProps = instance?.vnode.props ?? {}
 const hasInitialVNodeProp = (...names: string[]) => {
   return names.some((name) => Object.prototype.hasOwnProperty.call(initialVNodeProps, name))
 }
-const idPrefix = `tr-model-selector-${instanceUid}`
+const idPrefix = `tr-model-selector-${useStableId()}`
 const listboxId = `${idPrefix}-listbox`
 const referenceEl = shallowRef<HTMLElement | null>(null)
 const floatingEl = shallowRef<HTMLElement | null>(null)


### PR DESCRIPTION
## 变更说明

统一 `ModelSelector` 的 DOM ID 生成方式，改用共享的 `useStableId` composable。

## 修改内容

- 在 `ModelSelector` 中引入 `useStableId`。
- 使用 `useStableId()` 生成组件级 `idPrefix`。
- 保留现有的 listbox、option、group 和 description ID 派生逻辑。
- 保留 `getCurrentInstance()`，继续用于判断受控属性。
- 不修改模型值、选项值及其他业务 ID。

## 修改原因

此前 `ModelSelector` 直接使用 Vue 组件实例的 `uid` 生成 DOM ID。统一使用 `useStableId` 后，可以复用项目已有的稳定 ID 生成策略，避免组件自行维护 ID 生成逻辑，并保持多实例场景下 ARIA 关联 ID 的唯一性。

## 影响范围

仅影响 `ModelSelector` 内部生成的 DOM ID，不影响：

- 组件公共 API
- 模型选项数据
- `v-model` 行为
- 受控和非受控状态
- 键盘导航
- Teleport 浮层逻辑
- ARIA 属性关联关系

## 验证计划

- [x] `pnpm exec prettier --check packages/components/src/model-selector/index.vue`
- [x] `pnpm -F @opentiny/tiny-robot type-check`
- [x] `pnpm -F tiny-robot-test test:e2e -- src/model-selector/index.spec.ts`

Closes #399